### PR TITLE
Simplify comparisons

### DIFF
--- a/cf/bounds.py
+++ b/cf/bounds.py
@@ -60,7 +60,7 @@ the `nc_set_dimension`, `nc_get_dimension`, `nc_del_dimension` and
             return True
 
         if nbounds == 4 and data.ndim == 3:
-            if overlap == True:
+            if overlap:
                 raise ValueError(
                     "overlap=True and can't tell if 2-d bounds are contiguous")
             

--- a/cf/functions.py
+++ b/cf/functions.py
@@ -2174,7 +2174,7 @@ def _section(o, axes=None, data=False, stop=None, chunks=False,
     '''
     # retrieve the index of each axis defining the sections
     if data:
-        if axes == None:
+        if axes is None:
             axis_indices = range(o.ndim)
         else:
             axis_indices = axes

--- a/cf/test/test_CellMethod.py
+++ b/cf/test/test_CellMethod.py
@@ -127,9 +127,9 @@ class CellMethodTest(unittest.TestCase):
         cm0, cm1 = cf.CellMethod.create('time: minimum within days time: sum over years')
 
         self.assertTrue(cm0.within == 'days')
-        self.assertTrue(cm1.get_qualifier('within', None) == None)
-        self.assertTrue(cm0.get_qualifier('where', None) == None)
-        self.assertTrue(cm0.get_qualifier('over', None) == None)
+        self.assertTrue(cm1.get_qualifier('within', None) is None)
+        self.assertTrue(cm0.get_qualifier('where', None) is None)
+        self.assertTrue(cm0.get_qualifier('over', None) is None)
         self.assertTrue(cm1.over == 'years')
         self.assertTrue(cm0.method == 'minimum')
         self.assertTrue(cm1.method == 'sum')

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -735,15 +735,15 @@ class FieldTest(unittest.TestCase):
         f = self.f.copy()
         _ = f.del_data_axes()
         self.assertFalse(f.has_data_axes())
-        self.assertTrue(f.del_data_axes(default=None) == None)
+        self.assertTrue(f.del_data_axes(default=None) is None)
 
         f = self.f.copy()
         for key in f.constructs.filter_by_data():
             self.assertTrue(f.has_data_axes(key))
             _ = f.get_data_axes(key)
             _ = f.del_data_axes(key)
-            self.assertTrue(f.del_data_axes(key, default=None) == None)
-            self.assertTrue(f.get_data_axes(key, default=None) == None)
+            self.assertTrue(f.del_data_axes(key, default=None) is None)
+            self.assertTrue(f.get_data_axes(key, default=None) is None)
             self.assertFalse(f.has_data_axes(key))
 
         g = cf.Field()            
@@ -1492,7 +1492,7 @@ class FieldTest(unittest.TestCase):
         self.assertTrue(f.coordinate_reference('rotated_latitude_longitude', key=True) == key)
 
         # Delete        
-        self.assertTrue(f.del_coordinate_reference('qwerty', default=None) == None)
+        self.assertTrue(f.del_coordinate_reference('qwerty', default=None) is None)
         
         self.assertTrue(len(f.coordinate_references) == 2)
         self.assertTrue(len(f.domain_ancillaries) == 3)
@@ -1750,7 +1750,7 @@ class FieldTest(unittest.TestCase):
 
         f = self.f.copy()
         g = f.mask_invalid()        
-        self.assertTrue(f.mask_invalid(inplace=True) == None)
+        self.assertTrue(f.mask_invalid(inplace=True) is None)
 
 
 #--- End: class

--- a/cf/umread_lib/extraData.py
+++ b/cf/umread_lib/extraData.py
@@ -61,7 +61,7 @@ class ExtraData(dict):
         """
         Compare two extra data dictionaries returned by unpacker
         """
-        if other == None:
+        if other is None:
             return 1
         ka = self.sorted_keys()
         kb = other.sorted_keys()

--- a/cf/umread_lib/umfile.py
+++ b/cf/umread_lib/umfile.py
@@ -237,7 +237,7 @@ class Rec:
 using cached read
 
         '''
-        if self._extra_data == None:
+        if self._extra_data is None:
             self._extra_data = self.read_extra_data()
 
         return self._extra_data


### PR DESCRIPTION
This PR replaces `var == True` by a simple `var` test, and also uses `is None` instead of `== None` (see [ref](http://jaredgrubb.blogspot.com/2009/04/python-is-none-vs-none.html))