### PR TITLE
cfa: remove specific user shebang

### DIFF
--- a/scripts/cfa
+++ b/scripts/cfa
@@ -1,4 +1,3 @@
-#!/home/david/anaconda3/bin/python3
 #!/usr/bin/python3
 #-*-python-*-
 


### PR DESCRIPTION
HI, I was just getting a feel for the codebase & noticed the ``cfa`` script has a specific user/path Python shebang at the very top, before the standard generic user one.

I suspect this is left in from a Python 3 porting development stage, as I can't see a purpose it would serve generally, & there is no equivalent Python 2 line in the earlier version of the same script up on Bitbucket.

I thought it would be easier to put in a PR to suggest to remove it than to write up an Issue. Thanks.
