### PR TITLE
Docs (tutorial): correct PP header items table entries

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -5897,8 +5897,8 @@ construct properties:
 Header item  Description          Field construct property
 ===========  ===================  ========================
 LBEXP        Experiment identity  runid
-LBTIM        Time indicator       lbproc
-LPPROC       Processing code      lbtim
+LBTIM        Time indicator       lbtim
+LBPROC       Processing code      lbproc
 LBUSER(4)    STASH code           stash_code
 LBUSER(7)    Internal submodel    submodel
 ===========  ===================  ========================


### PR DESCRIPTION
Hi again. I am about to raise several PRs to suggest some minor self-contained changes.

I have tried to group them to minimise the number of PRs to open whilst keeping suggested changes within each related. I'm happy to amend or close any of them if they aren't suitable for whatever reason. In each case I will add a changelog entry commit once the PR is opened so I know the hyperlink with the ID number to reference.

One question: for suggestions to changes to the documentation, I imagine you would like a PR to include the changes built via Sphinx & the Makefile to tupdated HTML files under ``docs/``? I've tried to do that in these cases, but I am having a problem building the docs whereby the ``make html ./`` command is not picking up on relevant modules despite them being present in my local environment, e.g:

```python
Running Sphinx v1.3.6

Exception occurred:
  File "conf.py", line 21, in <module>
    import cf
ImportError: No module named cf
```

I'll put these PRs in for consideration whilst I try to debug the building issue shortly. It's possibly just my environment rather than a facet of the codebase.

**********************

(Firstly,) I noticed there are some entries in a table in the documentation, namely [that entitled 'Mapping of PP header items to field constructs'](https://ncas-cms.github.io/cf-python/tutorial.html#mapping-of-pp-header-items-to-field-constructs) which at present appear incorrect:

* ``lbproc`` & ``lbtim`` surely refer to the header items of the same name but in upper case, so their positions have been swapped by mistake?
* ``LPPROC`` is listed, but a ``grep`` on the ``cf/`` directory returns no results for that phase/pattern, whereas ``LBPROC`` appears multiple times, so it seems there is a typo there too?