### PR TITLE
Docs (all): fix spelling & formatting errors & typos

### DIFF
--- a/docs/source/class.rst
+++ b/docs/source/class.rst
@@ -93,7 +93,7 @@
    cf.TimeDuration
    cf.Units
 
-**Data compression classses**
+**Data compression classes**
 -----------------------------
 
 Classes that support the creation and storage of compressed arrays.

--- a/docs/source/field_analysis.rst
+++ b/docs/source/field_analysis.rst
@@ -929,7 +929,7 @@ Binning operations
 
 The `~Field.bin` method of the field construct groups its data into
 bins, where each group is defined by the elements that correspond to
-an :ref:`N-dimensionsal histogram bin of another set of variables
+an :ref:`N-dimensional histogram bin of another set of variables
 <Histograms>`, and collapses the elements in each group to a single
 representative value. The same :ref:`collapse methods
 <Collapse-methods>` and :ref:`weighting options <Collapse-weights>` as
@@ -1021,7 +1021,7 @@ Percentiles
 ^^^^^^^^^^^
 
 Percentiles of the data can be computed along any subset of the axes
-with the `~Field.percentile` method fof the field construct.
+with the `~Field.percentile` method of the field construct.
 
 .. code-block:: python
    :caption: *Find the 20th, 40th, 50th, 60th and 80th percentiles.*
@@ -1204,7 +1204,7 @@ Regridding from and to spherical coordinate systems using the
 `~cf.Field.regrids` method is only available for the 'X' and 'Y' axes
 simultaneously. All other axes are unchanged. The calculation of the
 regridding weights is based on areas and distances on the surface of
-the sphere, rather in :ref:`Euclidian space <Cartesian-regridding>`.
+the sphere, rather in :ref:`Euclidean space <Cartesian-regridding>`.
 
 The following combinations of spherical source and destination domain
 coordinate systems are available to the `~Field.regrids` method:
@@ -1563,7 +1563,7 @@ they have different standard names.
             instance on the right hand side (RHS).
 
 	  * If, however, the field construct is on the RHS then a
-            `numpy` array or `Data` innstance (which ever type is on
+            `numpy` array or `Data` instance (which ever type is on
             the LHS) is returned, containing the same data as in the
             first case.
     
@@ -1707,7 +1707,7 @@ If both operands of an :ref:`arithmetical <Arithmetical-operations>`
 or :ref:`relational <Relational-operations>` operation are field
 constructs with insufficient metadata to create a mapping of physically
 compatible dimensions, there are various techniques that allow the
-operation the operation procede.
+operation to proceed.
 
 * **Option 1:** The operation may applied to the field constructs'
   data instead. See below for more details.

--- a/docs/source/performance.rst
+++ b/docs/source/performance.rst
@@ -168,7 +168,7 @@ is equivalent to
 
 >>> h = f[7:2:-2, ...]
 
-and if all of the partitions of field construct``f`` are stored on
+and if all of the partitions of field construct ``f`` are stored on
 disk then in both cases so are all of the partitions of field
 construct ``h`` and no data has been read from disk.
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -679,7 +679,7 @@ A field construct's identity may be any one of the following
 
 * The value of the `~Field.standard_name` property,
   e.g. ``'air_temperature'``,
-* The value of the `~Field.id` attribute, preceeded by ``'id%='``,
+* The value of the `~Field.id` attribute, preceded by ``'id%='``,
 * The value of any property, preceded by the property name and an
   equals, e.g. ``'long_name=Air Temperature'``, ``'foo=bar'``, etc.,
 * The netCDF variable name, preceded by "ncvar%", e.g. ``'ncvar%tas'``
@@ -1757,7 +1757,7 @@ latitude name'``.
 A construct's identity may be any one of the following
 
 * The value of the `!standard_name` property, e.g. ``'air_temperature'``,
-* The value of the `!id` attribute, preceeded by ``'id%='``,
+* The value of the `!id` attribute, preceded by ``'id%='``,
 * The physical nature of the construct denoted by ``'X'``, ``'Y'``,
   ``'Z'`` or ``'T'``, denoting longitude (or x-projection), latitude
   (or y-projection), vertical and temporal constructs respectively,
@@ -3073,7 +3073,7 @@ from where the conditions are met. The tuple of indices returned by
 the `~Field.indices` may the be used in normal :ref:`assignment by
 index <Assignment-by-index>`.
 
-The `~Field.indices` method akes exactly the same arguments as the
+The `~Field.indices` method takes exactly the same arguments as the
 `~Field.subspace` method of the field construct. See
 :ref:`Subspacing-by-metadata` for details.
 
@@ -3395,8 +3395,8 @@ For convenience, many commonly used conditions can be created with
 `cf.Query` instance constructors.
 
 .. code-block:: python
-   :caption: *A example of a constructor (for a cell contaiing a
-             value) and its equivalent construction from construtor
+   :caption: *An example of a constructor (for a cell containing a
+             value) and its equivalent construction from constructor
              cf.Query instances.*
 
    >>> cf.contains(4)
@@ -3499,7 +3499,7 @@ addition, different values can be assigned to where the conditions
 are, and are not, met
 
 .. code-block:: python
-   :caption: *Set all data elements that are less then 273.15 to
+   :caption: *Set all data elements that are less than 273.15 to
              missing data.*
 
    >>> t = cf.read('file.nc')[1]
@@ -3528,7 +3528,7 @@ are, and are not, met
      [276.4    -- 276.3    -- 276.1    -- 277.0 273.4    --]]]
 
 .. code-block:: python
-   :caption: *Set all data elements that are less then 273.15 to 0,
+   :caption: *Set all data elements that are less than 273.15 to 0,
              and all other elements to 1.*
 
    >>> u = t.where(cf.lt(273.15), x=0, y=1)
@@ -3604,7 +3604,7 @@ There are various methods for creating a field construct in memory:
 ..
 
 * :ref:`Command modification <Command-modification>`: Produce the
-  commands that would create an already exising field construct, and
+  commands that would create an already existing field construct, and
   then modify them.
 
 ..
@@ -4087,7 +4087,7 @@ the desired field constuct. The commands are produced by the
 .. Code Block 3
 
 .. code-block:: python
-   :caption: *Create the commands that would create an exisiting field
+   :caption: *Create the commands that would create an existing field
              construct.*
 	
    >>> q, t = cf.read('file.nc')
@@ -5221,7 +5221,7 @@ Note that when reading :ref:`PP and UM fields files
 is `True` by default, because units are not always available to field
 constructs derived from :ref:`PP-and-UM-fields-files`.
 
-Field constructs that are logically similar but aranged differently
+Field constructs that are logically similar but arranged differently
 are also aggregatable.
 
 .. code-block:: python
@@ -5463,7 +5463,7 @@ data array elements are modified:
    >>> h.data.get_compression_type()
    ''
 
-Perhaps the easist way to create a compressed field construct is to
+Perhaps the easiest way to create a compressed field construct is to
 create the equivalent uncompressed field construct and then compress
 it with its `~Field.compress` method, which also compresses the
 metadata constructs as required.

--- a/docs/source/visualisation.rst
+++ b/docs/source/visualisation.rst
@@ -10,7 +10,7 @@ cf-plot
 -------
 
 The `cf-plot package <http://ajheaps.github.io/cf-plot/>`_ provides
-metadata-aware visualisation for `cf` fields. This is a seperate
+metadata-aware visualisation for `cf` fields. This is a separate
 library and `cf` does not depend on it.
 
 The functionality of `cfplot` includes


### PR DESCRIPTION
(As per #17, I will add a commit to build changes into the HTML files, once I can work out why I am getting errors trying to build the documentation.)

Whilst reading through the documentation I noticed a few typos, so I thought I could run over most of the core documentation content via all the ``.rst`` files under ``docs/source/`` with a pipeline command extracting the plain text & sending it to the``aspell`` spelling checker. Here are corrections from doing that. There is also one formatting error I noticed by eye.
