### PR TITLE
Docs (tutorial): add context for referenced functions

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -251,7 +251,8 @@ levels of detail.
 Minimal detail
 ^^^^^^^^^^^^^^
 
-The built-in `repr` function returns a short, one-line description:
+The built-in `repr` function, invoked on a variable by calling that variable
+alone at the interpreter prompt, returns a short, one-line description:
 
 .. code-block:: python
    :caption: *Inspect the contents of the two field constructs from
@@ -277,10 +278,10 @@ spanned by the data array ("latitude" and "longitude" with sizes 5 and
 Medium detail
 ^^^^^^^^^^^^^
 
-The built-in `str` function returns similar information as the
-one-line output, along with short descriptions of the metadata
-constructs, which include the first and last values of their data
-arrays:
+The built-in `str` function, invoked by a `print` call on a field construct,
+returns similar information as the one-line output, along with short
+descriptions of the metadata constructs, which include the first and last
+values of their data arrays:
 
 .. code-block:: python
   :caption: *Inspect the contents of the two field constructs with


### PR DESCRIPTION
(As per #17, I will add a commit to build changes into the HTML files, once I can work out why I am getting errors trying to build the documentation.)

In the ['Inspection' section of the documentation tutorial](https://ncas-cms.github.io/cf-python/tutorial.html?highlight=lbproc#inspection) there is reference to the built-ins ``repr()`` & ``str()``, but in the subsequent code examples those built-ins are not called directly, rather called under the hood by calling, & by calling ``print()`` on, respectively, the field construct (or dataset, etc.).

To someone without relevant knowledge of Python to know that ``print()`` show the ``str()`` etc. I think it could be unclear as to how the code snippets & the functions referred to relate, so I suggest adding something similar to that proposed here to put that into context.