### PR TITLE
Documentation: notes on verbosity & versioning

### DIFF
--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -57,8 +57,6 @@ jobs:
         activate-environment: cf-latest
         python-version: ${{ matrix.python-version }}
         channels: ncas, conda-forge
-        allow-softlinks: true
-        channel-priority: true
 
     # Ensure shell is configured with conda activated:
     - name: Check conda config
@@ -80,6 +78,14 @@ jobs:
         pip install pycodestyle
         # Important! Must install our development version of cf-python to test:
         pip install -e .
+
+    # Make UMRead library
+    - name: Make UMRead
+      shell: bash -l {0}
+      run: |
+        cd cf/umread_lib/c-lib
+        make
+        cd -
 
     # Provide another notification message
     - name: Notify about starting testing

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -14,6 +14,10 @@ Version |release| for version |version| of the CF conventions.
    :local:
    :backlinks: entry
 
+.. note:: The latest versions of cf available from the Python package index
+          (PyPI) and conda are confirmed at `the top of the README document
+          <https://github.com/NCAS-CMS/cf-python#cf-python>`_.
+
 .. _Operating-systems:
 
 **Operating systems**

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -50,6 +50,21 @@ The cf package is imported as follows:
 
    >>> import cf
 
+.. tip:: It is possible to change the extent to which cf outputs
+         feedback messages and it may be instructive to increase the
+         verbosity whilst working through this tutorial to see and
+         learn more about what cf is doing under the hood and about
+         the nature of the dataset being operated on. This can be done
+         for example by running:
+
+         .. code-block:: python
+            :caption: *Increase the verbosity of cf from the default.*
+
+            >>> cf.LOG_LEVEL('INFO')
+
+         See :ref:`the section on 'Logging' <Logging>` for
+         more information.
+
 .. _CF-version:
 
 CF version


### PR DESCRIPTION
Some documentation commits. Putting these in via PR because I want to do some work on the GH Actions workflow (specifically, get the environment set up so the ``test_PP_*`` tests can pass) & want to stick to having triggering with PRs only.