### PR TITLE
New function cf.configuration with unit test

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -20,6 +20,13 @@ version 3.6.0
 * New method: `cf.DomainAxis.nc_set_dimension_groups`
 * New method: `cf.DomainAxis.nc_clear_dimension_groups`
 * New keyword parameter to `cf.write`: ``group``
+* New function: `cf.configuration`
+* Renamed to lower-case (but otherwise identical) names all functions which
+  get and/or set global constants: `cf.atol`, `cf.rtol`, `cf.log_level`,
+  `cf.chunksize`, `cf.collapse_parallel_mode`, `cf.free_memory`,
+  `cf.free_memory_factor`, `cf.fm_threshold`, `cf.of_fraction`,
+  `cf.regrid_logging`, `cf.set_performance`, `cf.tempdir`, `cf.total_memory`,
+  `cf.relaxed_identities`. The upper-case names remain functional as aliases.
 * Changed dependency: ``1.8.6<=cfdm<1.9.0``
 * Changed dependency: ``cfunits>=3.2.8``
 

--- a/cf/cfdatetime.py
+++ b/cf/cfdatetime.py
@@ -265,10 +265,10 @@ def dt_vector(arg, month=1, day=1, hour=0, minute=0, second=0,
             _[:, 5] = second
             _[:, 6] = microsecond
             arg = _
-            
+
             out = [dt(*args, calendar=calendar) for args in arg]
     else:
-         out = [dt(*args, calendar=calendar) for args in arg]
+        out = [dt(*args, calendar=calendar) for args in arg]
 
     out = numpy.array(out)
 

--- a/cf/constants.py
+++ b/cf/constants.py
@@ -10,6 +10,8 @@ from tempfile import gettempdir
 from numpy.ma import masked as numpy_ma_masked
 from numpy.ma import nomask as numpy_ma_nomask
 
+import cfdm
+
 from . import mpi_on
 from . import mpi_size
 if mpi_on:
@@ -48,11 +50,13 @@ Whilst the dictionary may be modified directly, it is safer to
 retrieve and set the values with a function where one is
 provided. This is due to interdependencies between some values.
 
-:Keys:
+Note ATOL and RTOL are constants that in essence belong in this
+dict, but since they can be read and manipulated directly from cfdm,
+it is safest to work with cfdm.constants.CONSTANTS['ATOL'] (and
+'RTOL' equivalent) instead of storing separately and synchronising
+them here in cf.
 
-    ATOL : float
-      The value of absolute tolerance for testing numerically
-      tolerant equality.
+:Keys:
 
     TOTAL_MEMORY : float
       Find the total amount of physical memory (in bytes).
@@ -74,10 +78,6 @@ provided. This is due to interdependencies between some values.
       The fraction of the maximum number of concurrently open
       files which may be used for files containing data
       arrays.
-
-    RTOL : float
-      The value of relative tolerance for testing numerically
-      tolerant equality.
 
     TEMPDIR : str
       The location to store temporary files. By default it is
@@ -103,8 +103,7 @@ provided. This is due to interdependencies between some values.
       See cf.log_level().
 """
 CONSTANTS = {
-    'RTOL': sys.float_info.epsilon,
-    'ATOL': sys.float_info.epsilon,
+    # See cfdm.constants.CONSTANTS for effective 'ATOL' and 'RTOL' values
     'TEMPDIR': gettempdir(),
     'OF_FRACTION': 0.5,
     'TOTAL_MEMORY': _TOTAL_MEMORY,

--- a/cf/constants.py
+++ b/cf/constants.py
@@ -50,7 +50,7 @@ provided. This is due to interdependencies between some values.
 
 :Keys:
 
-    atol : float
+    ATOL : float
       The value of absolute tolerance for testing numerically
       tolerant equality.
 
@@ -75,7 +75,7 @@ provided. This is due to interdependencies between some values.
       files which may be used for files containing data
       arrays.
 
-    rtol : float
+    RTOL : float
       The value of relative tolerance for testing numerically
       tolerant equality.
 
@@ -98,9 +98,9 @@ provided. This is due to interdependencies between some values.
       this is 0 to try and automatically determine which mode to
       use.
 
-    log_level : str
+    LOG_LEVEL : str
       The minimal level of seriousness for which log messages are shown.
-      See functions.log_level().
+      See cf.log_level().
 """
 CONSTANTS = {
     'RTOL': sys.float_info.epsilon,

--- a/cf/field.py
+++ b/cf/field.py
@@ -282,16 +282,16 @@ class Field(mixin.PropertiesData,
     The netCDF variable group structure may be accessed with the
     `nc_set_variable`, `nc_get_variable`, `nc_variable_groups`,
     `nc_clear_variable_groups` and `nc_set_variable_groups` methods.
-   
+
     The netCDF group attributes may be accessed with the
     `nc_group_attributes`, `nc_clear_group_attributes`,
     `nc_set_group_attribute` and `nc_set_group_attributes` methods.
-   
+
     The netCDF geometry variable group structure may be accessed with
     the `nc_set_geometry_variable`, `nc_get_geometry_variable`,
     `nc_geometry_variable_groups`, `nc_clear_variable_groups` and
     `nc_set_geometry_variable_groups` methods.
-   
+
     Some components exist within multiple constructs, but when written
     to a netCDF dataset the netCDF names associated with such
     components will be arbitrarily taken from one of them. The netCDF
@@ -310,7 +310,7 @@ class Field(mixin.PropertiesData,
 
     CF-compliance issues for field constructs read from a netCDF
     dataset may be accessed with the `dataset_compliance` method.
-   
+
     '''
     def __new__(cls, *args, **kwargs):
         instance = super().__new__(cls)
@@ -2372,12 +2372,12 @@ class Field(mixin.PropertiesData,
     **Examples:**
 
     >>> f._conform_coordinate_references('auxiliarycoordinate1')
-    >>> f._conform_coordinate_references('auxiliarycoordinate1', 
+    >>> f._conform_coordinate_references('auxiliarycoordinate1',
     ...                                  coordref=cr)
 
         '''
-        identity = self.constructs[key].identity(strict=True)        
-        
+        identity = self.constructs[key].identity(strict=True)
+
         if coordref is None:
             refs = self.coordinate_references.values()
         else:
@@ -2388,7 +2388,7 @@ class Field(mixin.PropertiesData,
             if identity in coordinates:
                 ref.del_coordinate(identity, None)
                 ref.set_coordinate(key)
-        #--- End: for
+        # --- End: for
 
     def _coordinate_reference_axes(self, key):
         '''TODO

--- a/cf/functions.py
+++ b/cf/functions.py
@@ -177,6 +177,235 @@ else:
 
 # --- End: if
 
+
+def configuration(
+    atol=None,
+    rtol=None,
+    tempdir=None,
+    of_fraction=None,
+    chunksize=None,
+    collapse_parallel_mode=None,
+    free_memory_factor=None,
+    log_level=None,
+    regrid_logging=None,
+    relaxed_identities=None,
+):
+    '''View or set any number of constants in the project-wide configuration.
+
+    The full list of global constants that can be set in any combination
+    are:
+
+    * `atol`
+    * `rtol`
+    * `tempdir`
+    * `of_fraction`
+    * `chunksize`
+    * `collapse_parallel_mode`
+    * `free_memory_factor`
+    * `log_level`
+    * `regrid_logging`
+    * `relaxed_identities`
+
+    The following settings are also included in the dictionary that is
+    returned to view, but they are fixed by external factors so cannot
+    be set, hence there are no corresponding parameters:
+
+    * `total_memory`
+    * `fm_threshold`
+    * `min_total_memory`
+
+    These are all constants that apply throughout `cf`, except for in
+    specific functions only if overriden by the corresponding keyword
+    argument to that function.
+
+    The value of `None`, either taken by default or supplied as a value,
+    will result in the constant in question not being changed from the
+    current value. That is, it will have no effect.
+
+    Note that setting a constant using this function is equivalent to setting
+    it by means of a specific function of the same name, e.g. via `cf.atol`,
+    but in this case multiple constants can be set at once.
+
+    .. versionadded:: 3.5.2
+
+    .. seealso:: `atol`, `rtol`, `tempdir`, `of_fraction`, `chunksize`,
+                 `collapse_parallel_mode`, `total_memory`,
+                 `free_memory_factor`, `fm_threshold`, `min_total_memory`,
+                 `log_level`, `regrid_logging`, `relaxed_identities`
+
+    :Parameters:
+
+        atol: `float`, optional
+            The new value of absolute tolerance. The default is to not
+            change the current value.
+
+        rtol: `float`, optional
+            The new value of relative tolerance. The default is to not
+            change the current value.
+
+        tempdir: `str`, optional
+            The new directory for temporary files. Tilde expansion (an
+            initial component of ``~`` or ``~user`` is replaced by
+            that *user*'s home directory) and environment variable
+            expansion (substrings of the form ``$name`` or ``${name}``
+            are replaced by the value of environment variable *name*)
+            are applied to the new directory name.
+
+            The default is to not change the directory.
+
+        of_fraction: `float`, optional
+            The new fraction (between 0.0 and 1.0). The default is to
+            not change the current behaviour.
+
+        chunksize: `float`, optional
+            The new chunksize in bytes. The default is to not change
+            the current behaviour.
+
+        collapse_parallel_mode: `int`, optional
+            The new value (0, 1 or 2).
+
+        free_memory_factor: `float`
+            The new value of the fraction of memory kept free as a
+            temporary workspace. The default is to not change the
+            current behaviour.
+
+        log_level: `str` or `int`, optional
+            The new value of the minimal log severity level. This can
+            be specified either as a string equal (ignoring case) to
+            the named set of log levels or identifier 'DISABLE', or an
+            integer code corresponding to each of these, namely:
+
+            * ``'DISABLE'`` (``0``);
+            * ``'WARNING'`` (``1``);
+            * ``'INFO'`` (``2``);
+            * ``'DETAIL'`` (``3``);
+            * ``'DEBUG'`` (``-1``).
+
+        regrid_logging: `bool`, optional
+            The new value (either `True` to enable logging or `False`
+            to disable it). The default is to not change the current
+            behaviour.
+
+        `relaxed_identities`: `bool`, optional
+            The new value; if `True`, use 'relaxed' mode when getting a
+            construct identity. The default is to not change the current
+            value.
+
+    :Returns:
+
+        `dict`
+            The names and values of the project-wide constants prior to the
+            change, or the current names and values if no new values are
+            specified.
+
+    **Examples:**
+
+    >>> cf.configuration()  # view full global configuration of constants
+    {'rtol': 2.220446049250313e-16,
+     'atol': 2.220446049250313e-16,
+     'tempdir': '/tmp',
+     'of_fraction': 0.5,
+     'total_memory': 8287346688.0,
+     'free_memory_factor': 0.1,
+     'regrid_logging': False,
+     'collapse_parallel_mode': 0,
+     'relaxed_identities': False,
+     'log_level': 'WARNING',
+     'fm_threshold': 828734668.8000001,
+     'min_total_memory': 8287346688.0,
+     'chunksize': 82873466.88000001}
+    >>> cf.chunksize(7.5e7)  # any change to one constant...
+    82873466.88000001
+    >>> cf.configuration()['chunksize']  # ...is reflected in the configuration
+    75000000.0
+
+    >>> cf.configuration(
+    ...     of_fraction=0.7, tempdir='/usr/tmp', log_level='INFO')  # set items
+    {'rtol': 2.220446049250313e-16,
+     'atol': 2.220446049250313e-16,
+     'tempdir': '/tmp',
+     'of_fraction': 0.5,
+     'total_memory': 8287346688.0,
+     'free_memory_factor': 0.1,
+     'regrid_logging': False,
+     'collapse_parallel_mode': 0,
+     'relaxed_identities': False,
+     'log_level': 'WARNING',
+     'fm_threshold': 828734668.8000001,
+     'min_total_memory': 8287346688.0,
+     'chunksize': 75000000.0}
+    >>> cf.configuration()  # the items set have been updated accordingly
+    {'rtol': 2.220446049250313e-16,
+     'atol': 2.220446049250313e-16,
+     'tempdir': '/usr/tmp',
+     'of_fraction': 0.7,
+     'total_memory': 8287346688.0,
+     'free_memory_factor': 0.1,
+     'regrid_logging': False,
+     'collapse_parallel_mode': 0,
+     'relaxed_identities': False,
+     'log_level': 'INFO',
+     'fm_threshold': 828734668.8000001,
+     'min_total_memory': 8287346688.0,
+     'chunksize': 75000000.0}
+
+    '''
+    return _configuration(
+        new_atol=atol,
+        new_rtol=rtol,
+        new_tempdir=tempdir,
+        new_of_fraction=of_fraction,
+        new_chunksize=chunksize,
+        new_collapse_parallel_mode=collapse_parallel_mode,
+        new_free_memory_factor=free_memory_factor,
+        new_log_level=log_level,
+        new_regrid_logging=regrid_logging,
+        new_relaxed_identities=relaxed_identities,
+    )
+
+
+def _configuration(**kwargs):
+    '''Internal helper function to provide the logic for `cf.configuration`.
+
+    We delegate from the user-facing `cf.configuration` for two main reasons:
+
+    1) to avoid a name clash there between the keyword arguments and the
+    functions which they each call (e.g. `atol` and `cf.atol`) which
+    would otherwise necessitate aliasing every such function name; and
+
+    2) because the user-facing function must have the appropriate keywords
+    explicitly listed, but the very similar logic applied for each keyword
+    can be consolidated by iterating over the full dictionary of input kwargs.
+
+    '''
+    # Filter out WORKSPACE_FACTOR_{1,2} constants which are only used
+    # externally and not exposed to the user:
+    old = {name.lower(): val for name, val in CONSTANTS.items() if
+           not name.startswith('WORKSPACE_FACTOR_')}
+    # Filter out 'None' kwargs from configuration() defaults. Note that this
+    # does not filter out '0' or 'True' values, which is important as the user
+    # might be trying to set those, as opposed to None emerging as default.
+    kwargs = {name: val for name, val in kwargs.items() if val is not None}
+
+    # Note values are the functions not the keyword arguments of same name:
+    reset_mapping = {
+        'new_atol': atol,
+        'new_rtol': rtol,
+        'new_tempdir': tempdir,
+        'new_of_fraction': of_fraction,
+        'new_chunksize': chunksize,
+        'new_collapse_parallel_mode': collapse_parallel_mode,
+        'new_free_memory_factor': free_memory_factor,
+        'new_log_level': log_level,
+        'new_regrid_logging': regrid_logging,
+        'new_relaxed_identities': relaxed_identities,
+    }
+    for setting_alias, new_value in kwargs.items():  # for all input kwargs...
+        reset_mapping[setting_alias](new_value)  # ...run corresponding func
+
+    return old
+
+
 def free_memory():
     '''The available physical memory.
 
@@ -673,8 +902,8 @@ def regrid_logging(*arg):
     :Parameters:
 
         arg: `bool`, optional
-            The new value (either True to enable logging or False to
-            disable it).  The default is to not change the current
+            The new value (either `True` to enable logging or `False`
+            to disable it). The default is to not change the current
             behaviour.
 
     :Returns:

--- a/cf/functions.py
+++ b/cf/functions.py
@@ -382,6 +382,10 @@ def _configuration(**kwargs):
     # externally and not exposed to the user:
     old = {name.lower(): val for name, val in CONSTANTS.items() if
            not name.startswith('WORKSPACE_FACTOR_')}
+    # Also add rtol and atol from cfdm as they are effective constants in cf:
+    for tolerance in ('ATOL', 'RTOL'):
+        old[tolerance.lower()] = cfdm.constants.CONSTANTS[tolerance]
+
     # Filter out 'None' kwargs from configuration() defaults. Note that this
     # does not filter out '0' or 'True' values, which is important as the user
     # might be trying to set those, as opposed to None emerging as default.

--- a/cf/functions.py
+++ b/cf/functions.py
@@ -487,7 +487,10 @@ def free_memory_factor(*args):
     '''
     old = CONSTANTS['FREE_MEMORY_FACTOR']
     if args:
-        free_memory_factor = float(args[0])
+        try:
+            free_memory_factor = float(args[0])
+        except (ValueError, TypeError):
+            raise ValueError('Free memory factor must be a float')
         if free_memory_factor <= 0.0 or free_memory_factor >= 1.0:
             raise ValueError(
                 'Free memory factor must be between 0.0 and 1.0 not inclusive')
@@ -839,7 +842,7 @@ def TEMPDIR(*new_tempdir):
     return tempdir(*new_tempdir)
 
 
-def of_fraction(*arg):
+def of_fraction(*args):
     '''The amount of concurrently open files above which files containing
     data arrays may be automatically closed.
 
@@ -886,8 +889,16 @@ def of_fraction(*arg):
 
     '''
     old = CONSTANTS['OF_FRACTION']
-    if arg:
-        CONSTANTS['OF_FRACTION'] = arg[0]
+    if args:
+        try:
+            fraction = float(args[0])
+        except (ValueError, TypeError):
+            raise ValueError('Fraction must be a float')
+        fraction = float(args[0])
+        if fraction <= 0.0 or fraction >= 1.0:
+            raise ValueError(
+                'Fraction must be between 0.0 and 1.0 not inclusive')
+        CONSTANTS['OF_FRACTION'] = fraction
 
     return old
 
@@ -981,8 +992,12 @@ def collapse_parallel_mode(*arg):
     '''
     old = CONSTANTS['COLLAPSE_PARALLEL_MODE']
     if arg:
-        if arg[0] not in (0, 1, 2):
-            raise ValueError('Invalid collapse parallel mode')
+        allowed_values = (0, 1, 2)
+        if arg[0] not in allowed_values:
+            raise ValueError(
+                'Invalid collapse parallel mode. Valid values are '
+                '{}'.format(allowed_values)
+            )
 
         CONSTANTS['COLLAPSE_PARALLEL_MODE'] = arg[0]
 

--- a/cf/mixin/propertiesdata.py
+++ b/cf/mixin/propertiesdata.py
@@ -2873,7 +2873,7 @@ class PropertiesData(Properties):
         if properties:
             for prop in self.inherited_properties():
                 properties.pop(prop, None)
-                
+
             out.append("{}.set_properties({})".format(name,
                                                       properties))
 

--- a/cf/read_write/netcdf/netcdfwrite.py
+++ b/cf/read_write/netcdf/netcdfwrite.py
@@ -184,21 +184,21 @@ class NetCDFWrite(cfdm.read_write.netcdf.NetCDFWrite):
     .. versionadded:: 3.0.0
 
     :Parameters:
-    
+
         f: Field construct
-    
+
         key: `str`
             The coordinate construct key
-    
+
         coord_1d: Coordinate construct
-    
+
         axis: `str`
             The field's axis identifier for the scalar coordinate.
-    
+
         coordinates: `list`
-    
+
     :Returns:
-    
+
         coordinates: `list`
             The updated list of netCDF auxiliary coordinate names.
 
@@ -206,7 +206,7 @@ class NetCDFWrite(cfdm.read_write.netcdf.NetCDFWrite):
         # Unsafe to set mutable '{}' as default in the func signature.
         if extra is None:  # distinguish from falsy '{}'
             extra = {}
-            
+
         coord_1d = self._change_reference_datetime(coord_1d)
 
         return super()._write_scalar_coordinate(f, key, coord_1d,

--- a/cf/read_write/read.py
+++ b/cf/read_write/read.py
@@ -55,7 +55,7 @@ def read(files, external=None, verbose=None, warnings=False,
 
 
     **NetCDF hierarchical groups**
-    
+
     Hierarchical groups in CF provide a mechanism to structure
     variables within netCDF4 datasets. Field constructs are
     constructed from grouped datasets by applying the well defined

--- a/cf/read_write/write.py
+++ b/cf/read_write/write.py
@@ -88,7 +88,7 @@ def write(fields, filename, fmt='NETCDF4', overwrite=True,
 
 
     **NetCDF hierarchical groups**
-    
+
     Hierarchical groups in CF provide a mechanism to structure
     variables within netCDF4 datasets with well defined rules for
     resolving references to out-of-group netCDF variables and

--- a/cf/test/test_Maths.py
+++ b/cf/test/test_Maths.py
@@ -11,7 +11,7 @@ import cf
 class MathTest(unittest.TestCase):
     filename1 = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                              'regrid_file1.nc')
-    
+
     test_only = []
 #    test_only = ('NOTHING!!!!!',)
 #    test_only = ('test_relative_vorticity_distance')
@@ -49,7 +49,6 @@ class MathTest(unittest.TestCase):
         v.set_construct(dim_x, axes=[X])
         v.set_construct(dim_y, axes=[Y])
         v.set_data(cf.Data(data_2d, 'm/s'), axes=('X', 'Y'))
-
 
         rv = cf.relative_vorticity(u, v, one_sided_at_boundary=True)
         self.assertTrue((rv.array == 0.0).all())

--- a/cf/test/test_function.py
+++ b/cf/test/test_function.py
@@ -117,7 +117,7 @@ class functionTest(unittest.TestCase):
         expected_post_set = dict(org)  # copy for safety with mutable dict
         for setting, value in reset_values.items():
             # These are shown in output but can't be set (no such kwarg):
-            if setting in constants_that_cannot_be_set:  
+            if setting in constants_that_cannot_be_set:
                 with self.assertRaises(TypeError):  # error from invalid kwarg
                     cf.configuration(**{setting: value})
                 continue

--- a/cf/test/test_function.py
+++ b/cf/test/test_function.py
@@ -133,12 +133,10 @@ class functionTest(unittest.TestCase):
                 expected_post_set['fm_threshold'] = (
                     value * expected_post_set['total_memory'])
 
-            print("-------------------", setting, value)
             # Can't trivially do a direct test that the actual and expected
             # return dicts are the same as there are float values which have
             # limited float precision so need assertAlmostEqual testing:
             for name, val in expected_post_set.items():
-                print("CHECK::", post_set[name], val)
                 self.assertAlmostEqual(post_set[name], val, places=8)
 
         # Reset so later test fixtures don't spam with output messages:

--- a/cf/test/test_function.py
+++ b/cf/test/test_function.py
@@ -172,9 +172,12 @@ class functionTest(unittest.TestCase):
         # Test edge cases & invalid inputs...
         # ... 1. Falsy value inputs on some representative items:
         pre_set_config = cf.configuration()
+        with self.assertRaises(ValueError):
+            cf.configuration(of_fraction=0.0)
+        with self.assertRaises(ValueError):
+            cf.configuration(free_memory_factor=0.0)
         new_values = {
             'tempdir': '',
-            'of_fraction': 0,
             'atol': 0.0,
             'regrid_logging': False,
         }

--- a/cf/test/test_groups.py
+++ b/cf/test/test_groups.py
@@ -12,13 +12,15 @@ import cf
 n_tmpfiles = 6
 tmpfiles = [tempfile.mktemp('_test_groups.nc', dir=os.getcwd())
             for i in range(n_tmpfiles)]
-(ungrouped_file1,
- ungrouped_file2,
- ungrouped_file3,
- grouped_file1,
- grouped_file2,
- grouped_file3,
+(
+    ungrouped_file1,
+    ungrouped_file2,
+    ungrouped_file3,
+    grouped_file1,
+    grouped_file2,
+    grouped_file3,
 ) = tmpfiles
+
 
 def _remove_tmpfiles():
     '''Remove temporary files created during tests.
@@ -29,6 +31,7 @@ def _remove_tmpfiles():
             os.remove(f)
         except OSError:
             pass
+
 
 atexit.register(_remove_tmpfiles)
 
@@ -51,12 +54,12 @@ class GroupsTest(unittest.TestCase):
 
         ungrouped_file = ungrouped_file1
         grouped_file = grouped_file1
-        
-        # Add a second grid mapping    
+
+        # Add a second grid mapping
         datum = cf.Datum(parameters={'earth_radius': 7000000})
         conversion = cf.CoordinateConversion(
             parameters={'grid_mapping_name': 'latitude_longitude'})
-        
+
         grid = cf.CoordinateReference(
             coordinate_conversion=conversion,
             datum=datum,
@@ -64,7 +67,7 @@ class GroupsTest(unittest.TestCase):
         )
 
         f.set_construct(grid)
-        
+
         grid0 = f.construct('grid_mapping_name:rotated_latitude_longitude')
         grid0.del_coordinate('auxiliarycoordinate0')
         grid0.del_coordinate('auxiliarycoordinate1')
@@ -79,29 +82,30 @@ class GroupsTest(unittest.TestCase):
         # ------------------------------------------------------------
         g.nc_set_variable_groups(['forecast', 'model'])
         cf.write(g, grouped_file)
-        
+
         nc = netCDF4.Dataset(grouped_file, 'r')
         self.assertIn(
             f.nc_get_variable(),
             nc.groups['forecast'].groups['model'].variables
         )
         nc.close()
-        
+
         h = cf.read(grouped_file, verbose=1)
         self.assertEqual(len(h), 1, repr(h))
         self.assertTrue(f.equals(h[0], verbose=2))
-        
+
         # ------------------------------------------------------------
         # Move constructs one by one to the /forecast group
         # ------------------------------------------------------------
-        for name in ('time',  # Dimension coordinate
-                     'grid_latitude',  # Dimension coordinate
-                     'longitude', # Auxiliary coordinate
-                     'measure:area',  # Cell measure
-                     'surface_altitude',  # Domain ancillary
-                     'air_temperature standard_error',  # Field ancillary
-                     'grid_mapping_name:rotated_latitude_longitude',
-    ):
+        for name in (
+                'time',  # Dimension coordinate
+                'grid_latitude',  # Dimension coordinate
+                'longitude',  # Auxiliary coordinate
+                'measure:area',  # Cell measure
+                'surface_altitude',  # Domain ancillary
+                'air_temperature standard_error',  # Field ancillary
+                'grid_mapping_name:rotated_latitude_longitude',
+        ):
             g.construct(name).nc_set_variable_groups(['forecast'])
             cf.write(g, grouped_file, verbose=1)
 
@@ -123,7 +127,7 @@ class GroupsTest(unittest.TestCase):
         name = 'grid_latitude'
         g.construct(name).bounds.nc_set_variable_groups(['forecast'])
         cf.write(g, grouped_file)
-        
+
         nc = netCDF4.Dataset(grouped_file, 'r')
         self.assertIn(
             f.construct(name).bounds.nc_get_variable(),
@@ -133,21 +137,21 @@ class GroupsTest(unittest.TestCase):
         h = cf.read(grouped_file, verbose=1)
         self.assertEqual(len(h), 1, repr(h))
         self.assertTrue(f.equals(h[0], verbose=2))
-        
+
     def test_groups_geometry(self):
         f = cf.example_field(6)
-    
+
 #        return True
-            
+
         ungrouped_file = ungrouped_file2
         grouped_file = grouped_file2
-        
+
         cf.write(f, ungrouped_file)
         g = cf.read(ungrouped_file, verbose=1)
         self.assertEqual(len(g), 1)
         g = g[0]
         self.assertTrue(f.equals(g, verbose=3))
-        
+
         # ------------------------------------------------------------
         # Move the field construct to the /forecast/model group
         # ------------------------------------------------------------
@@ -160,11 +164,11 @@ class GroupsTest(unittest.TestCase):
             nc.groups['forecast'].groups['model'].variables
         )
         nc.close()
-        
+
         h = cf.read(grouped_file)
         self.assertEqual(len(h), 1, repr(h))
         self.assertTrue(f.equals(h[0], verbose=2))
-        
+
         # ------------------------------------------------------------
         # Move the geometry container to the /forecast group
         # ------------------------------------------------------------
@@ -173,7 +177,7 @@ class GroupsTest(unittest.TestCase):
 
         # Check that the variable is in the right group
         nc = netCDF4.Dataset(grouped_file, 'r')
-        self.assertIn(            
+        self.assertIn(
             f.nc_get_geometry_variable(),
             nc.groups['forecast'].variables)
         nc.close()
@@ -182,7 +186,7 @@ class GroupsTest(unittest.TestCase):
         h = cf.read(grouped_file)
         self.assertEqual(len(h), 1, repr(h))
         self.assertTrue(f.equals(h[0], verbose=2))
-        
+
         # ------------------------------------------------------------
         # Move a node coordinate variable to the /forecast group
         # ------------------------------------------------------------
@@ -191,7 +195,7 @@ class GroupsTest(unittest.TestCase):
 
         # Check that the variable is in the right group
         nc = netCDF4.Dataset(grouped_file, 'r')
-        self.assertIn(            
+        self.assertIn(
             f.construct('longitude').bounds.nc_get_variable(),
             nc.groups['forecast'].variables)
         nc.close()
@@ -211,7 +215,7 @@ class GroupsTest(unittest.TestCase):
 
         # Check that the variable is in the right group
         nc = netCDF4.Dataset(grouped_file, 'r')
-        self.assertIn(            
+        self.assertIn(
             ncvar,
             nc.groups['forecast'].variables)
         nc.close()
@@ -233,7 +237,7 @@ class GroupsTest(unittest.TestCase):
 
         # Check that the variable is in the right group
         nc = netCDF4.Dataset(grouped_file, 'r')
-        self.assertIn(            
+        self.assertIn(
             ncvar,
             nc.groups['forecast'].variables)
         nc.close()
@@ -253,7 +257,7 @@ class GroupsTest(unittest.TestCase):
 
         # Check that the variable is in the right group
         nc = netCDF4.Dataset(grouped_file, 'r')
-        self.assertIn(            
+        self.assertIn(
             f.construct('longitude').get_interior_ring().nc_get_variable(),
             nc.groups['forecast'].variables)
         nc.close()
@@ -262,7 +266,7 @@ class GroupsTest(unittest.TestCase):
         h = cf.read(grouped_file, verbose=1)
         self.assertEqual(len(h), 1, repr(h))
         self.assertTrue(f.equals(h[0], verbose=2))
-        
+
     def test_groups_compression(self):
         f = cf.example_field(4)
 
@@ -273,8 +277,8 @@ class GroupsTest(unittest.TestCase):
         f.compress('indexed_contiguous', inplace=True)
         f.data.get_count().nc_set_variable('count')
         f.data.get_index().nc_set_variable('index')
-        
-        cf.write(f, ungrouped_file , verbose=1)
+
+        cf.write(f, ungrouped_file, verbose=1)
         g = cf.read(ungrouped_file)[0]
         self.assertTrue(f.equals(g, verbose=2))
 
@@ -282,29 +286,29 @@ class GroupsTest(unittest.TestCase):
         # Move the field construct to the /forecast/model group
         # ------------------------------------------------------------
         g.nc_set_variable_groups(['forecast', 'model'])
-        
+
         # ------------------------------------------------------------
         # Move the count variable to the /forecast group
-        # ------------------------------------------------------------        
+        # ------------------------------------------------------------
         g.data.get_count().nc_set_variable_groups(['forecast'])
-        
+
         # ------------------------------------------------------------
         # Move the index variable to the /forecast group
-        # ------------------------------------------------------------        
+        # ------------------------------------------------------------
         g.data.get_index().nc_set_variable_groups(['forecast'])
-        
+
         # ------------------------------------------------------------
         # Move the coordinates that span the element dimension to the
         # /forecast group
         # ------------------------------------------------------------
         name = 'altitude'
         g.construct(name).nc_set_variable_groups(['forecast'])
-        
+
         # ------------------------------------------------------------
         # Move the sample dimension to the /forecast group
-        # ------------------------------------------------------------        
+        # ------------------------------------------------------------
         g.data.get_count().nc_set_sample_dimension_groups(['forecast'])
-        
+
         cf.write(g, grouped_file, verbose=1)
 
         nc = netCDF4.Dataset(grouped_file, 'r')
@@ -324,16 +328,16 @@ class GroupsTest(unittest.TestCase):
             f.construct('altitude').nc_get_variable(),
             nc.groups['forecast'].variables)
         nc.close()
-        
+
         h = cf.read(grouped_file, verbose=1)
         self.assertEqual(len(h), 1, repr(h))
         self.assertTrue(f.equals(h[0], verbose=2))
 
-#--- End: class
+# --- End: class
+
 
 if __name__ == '__main__':
     print('Run date:', datetime.datetime.utcnow())
     cf.environment()
     print()
     unittest.main(verbosity=2)
-

--- a/docs/source/function.rst
+++ b/docs/source/function.rst
@@ -136,7 +136,6 @@ Version |release| for version |version| of the CF conventions.
    cf.free_memory
    cf.free_memory_factor
    cf.fm_threshold
-   cf.minncfm
    cf.of_fraction
    cf.regrid_logging
    cf.set_performance

--- a/docs/source/function.rst
+++ b/docs/source/function.rst
@@ -47,6 +47,8 @@ Version |release| for version |version| of the CF conventions.
    cf.default_netCDF_fillvals
    cf.histogram
    cf.relative_vorticity
+   cf.ATOL
+   cf.RTOL
 
 **Condition constructors**
 --------------------------
@@ -128,6 +130,22 @@ Version |release| for version |version| of the CF conventions.
    :toctree: function/
    :template: function.rst
 
+   cf.configuration
+   cf.chunksize
+   cf.collapse_parallel_mode
+   cf.free_memory
+   cf.free_memory_factor
+   cf.fm_threshold
+   cf.minncfm
+   cf.of_fraction
+   cf.regrid_logging
+   cf.set_performance
+   cf.tempdir
+   cf.total_memory
+   cf.close_files
+   cf.close_one_file
+   cf.open_files
+   cf.open_files_threshold_exceeded
    cf.CHUNKSIZE
    cf.COLLAPSE_PARALLEL_MODE
    cf.FREE_MEMORY
@@ -139,10 +157,6 @@ Version |release| for version |version| of the CF conventions.
    cf.SET_PERFORMANCE
    cf.TEMPDIR
    cf.TOTAL_MEMORY
-   cf.close_files
-   cf.close_one_file
-   cf.open_files
-   cf.open_files_threshold_exceeded
 
 **Miscellaneous**
 -----------------
@@ -153,7 +167,6 @@ Version |release| for version |version| of the CF conventions.
    :template: function.rst
 
    cf.CF
-   cf.RELAXED_IDENTITIES
    cf.abspath
    cf.dirname
    cf.dump
@@ -163,8 +176,11 @@ Version |release| for version |version| of the CF conventions.
    cf.hash_array
    cf.implementation
    cf.inspect
+   cf.log_level
    cf.pathjoin
    cf.pickle
+   cf.relaxed_identities
    cf.relpath
    cf.unpickle
-   cf.log_level
+   cf.LOG_LEVEL
+   cf.RELAXED_IDENTITIES


### PR DESCRIPTION
Final step towards & therefore closes #70, after work to convert all functions to get & set individual global constants to lower-case was completed in #93. This is equivalent to NCAS-CMS/cfdm#61 but is more complicated as there are many more global constant settings to include for `cf` (13 vs. 3 for `cfdm`).

Opening as a WIP because in implementing this, particularly the unit test, I noticed that `cf.atol` & `cf.rtol` are detached from the corresponding constants in `cf.CONSTANTS`, instead getting & setting the `cfdm` equivalent (see #85 where I will detail it further). I would like to fix this first before completing this PR as it causes the unit test to fail (for valid reason). Best wait until the underlying issue is addressed to merge with a passing unit test (without bodging it temporarily).

Once that is discussed & resolved, I still want to extend the unit test for ``cf.configuration`` added here slightly, before removing the WIP status.