### PR TITLE
set_data, inplace default, data_like

### DIFF
--- a/cf/abstract/coordinate.py
+++ b/cf/abstract/coordinate.py
@@ -299,7 +299,7 @@
 #     # ----------------------------------------------------------------
 #     # Methods
 #     # ----------------------------------------------------------------
-#     @_inplace_enabled
+#     @_inplace_enabled(default=False)
 #     def autoperiod(self, inplace=False):
 #         '''TODO Set dimensions to be cyclic.
 #

--- a/cf/cellmethod.py
+++ b/cf/cellmethod.py
@@ -568,7 +568,7 @@ class CellMethod(cfdm.CellMethod):
         return out
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def expand_intervals(self, inplace=False, i=False):
         '''TODO
 
@@ -582,7 +582,7 @@ class CellMethod(cfdm.CellMethod):
         return c
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def change_axes(self, axis_map, inplace=False, i=False):
         '''TODO
 

--- a/cf/coordinatereference.py
+++ b/cf/coordinatereference.py
@@ -518,7 +518,7 @@ class CoordinateReference(cfdm.CoordinateReference):
         return self.match_by_identity(*identities)
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def change_identifiers(self, identity_map, coordinate=True,
                            ancillary=True, strict=False,
                            inplace=False, i=False):

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -2134,7 +2134,7 @@ place.
         # --- End: if
         return processed_partitions
 
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def diff(self, axis=-1, n=1, inplace=False):
         '''Calculate the n-th discrete difference along the given axis.
 
@@ -2569,7 +2569,7 @@ place.
             _preserve_partitions=_preserve_partitions
         )
 
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def mean_of_upper_decile(
             self, axes=None, include_decile=True, squeeze=False,
             weights=None, mtol=1, inplace=False, _preserve_partitions=False):
@@ -3280,7 +3280,7 @@ place.
         # Retrieve the axis
         axis_key = self.domain_axis(axis, key=True)
 
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def convolution_filter(self, window=None, axis=None, mode=None,
                            cval=None, origin=0, inplace=False):
         '''Return the data convolved along the given axis with the specified
@@ -3486,7 +3486,7 @@ place.
 
         return d
 
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def cumsum(self, axis, masked_as_zero=False, inplace=False):
         '''Return the data cumulatively summed along the given axis.
 
@@ -3878,7 +3878,7 @@ place.
 #            self.add_partitions(sorted(set(extra_bounds)), axis)
 #        # --- End: for
 
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def _asdatetime(self, inplace=False):
         '''Change the internal representation of data array elements from
     numeric reference times to datatime-like objects.
@@ -3943,7 +3943,7 @@ place.
         '''
         return self.dtype.kind == 'O' and self.Units.isreftime
 
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def _asreftime(self, inplace=False):
         '''Change the internal representation of data array elements from
     datatime-like objects to numeric reference times.
@@ -5999,7 +5999,7 @@ place.
         self.partitions.change_axis_names(axis_map)
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def _collapse(self, func, fpartial, ffinalise, axes=None,
                   squeeze=False, weights=None, mtol=1, units=None,
                   inplace=False, i=False, _preserve_partitions=False,
@@ -8221,7 +8221,7 @@ False
         return old
 
     # `arctan2`, AT2 seealso
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def arctan(self, inplace=False):
         '''Take the trigonometric inverse tangent of the data element-wise.
 
@@ -8308,7 +8308,7 @@ False
 #        '''
 #        return cls(numpy_arctan2(y, x), units=_units_radians)
 
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def arctanh(self, inplace=False):
         '''Take the inverse hyperbolic tangent of the data element-wise.
 
@@ -8356,7 +8356,7 @@ False
 
         return d
 
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def arcsin(self, inplace=False):
         '''Take the trigonometric inverse sine of the data element-wise.
 
@@ -8404,7 +8404,7 @@ False
 
         return d
 
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def arcsinh(self, inplace=False):
         '''Take the inverse hyperbolic sine of the data element-wise.
 
@@ -8448,7 +8448,7 @@ False
 
         return d
 
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def arccos(self, inplace=False):
         '''Take the trigonometric inverse cosine of the data element-wise.
 
@@ -8496,7 +8496,7 @@ False
 
         return d
 
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def arccosh(self, inplace=False):
         '''Take the inverse hyperbolic cosine of the data element-wise.
 
@@ -8716,7 +8716,7 @@ False
 
         return False
 
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def apply_masking(self, fill_values=None, valid_min=None,
                       valid_max=None, valid_range=None, inplace=False):
         '''Apply masking.
@@ -9791,7 +9791,7 @@ False
         return binary_mask
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def clip(self, a_min, a_max, units=None, inplace=False, i=False):
         '''Clip (limit) the values in the data array in place.
 
@@ -9933,7 +9933,7 @@ False
         for partition in self.partitions.matrix.flat:
             partition.file_close()
 
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def compressed(self, inplace=False):
         '''Return all non-masked values in a one dimensional data array.
 
@@ -10027,7 +10027,7 @@ False
         return d
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def cos(self, inplace=False, i=False):
         '''Take the trigonometric cosine of the data element-wise.
 
@@ -10388,7 +10388,7 @@ False
         '''
         return self._YMDhms('second')
 
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def uncompress(self, inplace=False):
         '''Uncompress the underlying data.
 
@@ -10668,7 +10668,7 @@ False
         return True
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def exp(self, inplace=False, i=False):
         '''Take the exponential of the data array.
 
@@ -10703,7 +10703,7 @@ False
 
         return d
 
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def insert_dimension(self, position=0, inplace=False):
         '''Expand the shape of the data array in place.
 
@@ -10805,7 +10805,7 @@ False
 
         return out
 
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     @_manage_log_level_via_verbosity
     def halo(self, size, axes=None, tripolar=None,
              fold_index=-1, inplace=False, verbose=None):
@@ -11169,7 +11169,7 @@ False
 
         return d
 
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def filled(self, fill_value=None, inplace=False):
         '''TODO
 
@@ -11509,7 +11509,7 @@ False
         return d
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def change_calendar(self, calendar, inplace=False, i=False):
         '''Change the calendar of the data array elements.
 
@@ -11538,7 +11538,7 @@ False
         return d
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def override_units(self, units, inplace=False, i=False):
         '''Override the data array units.
 
@@ -11600,7 +11600,7 @@ False
         return d
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def override_calendar(self, calendar, inplace=False, i=False):
         '''Override the calendar of the data array elements.
 
@@ -11907,7 +11907,7 @@ False
         return cf_masked
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def mask_invalid(self, inplace=False, i=False):
         '''Mask the array where invalid values occur (NaN or inf).
 
@@ -12054,7 +12054,7 @@ False
                               _preserve_partitions=_preserve_partitions)
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def flip(self, axes=None, inplace=False, i=False):
         '''Reverse the direction of axes of the data array.
 
@@ -12592,7 +12592,7 @@ False
         return out
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def swapaxes(self, axis0, axis1, inplace=False, i=False):
         '''Interchange two axes of an array.
 
@@ -12707,7 +12707,7 @@ False
                 free_memory() - cf_fm_threshold())
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     @_manage_log_level_via_verbosity
     def where(self, condition, x=None, y=None, inplace=False, i=False,
               verbose=None):
@@ -13156,7 +13156,7 @@ False
         return d
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def sin(self, inplace=False, i=False):
         '''Take the trigonometric sine of the data element-wise.
 
@@ -13212,7 +13212,7 @@ False
         return d
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def sinh(self, inplace=False):
         '''Take the hyperbolic sine of the data element-wise.
 
@@ -13268,7 +13268,7 @@ False
 
         return d
 
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def cosh(self, inplace=False):
         '''Take the hyperbolic cosine of the data element-wise.
 
@@ -13324,7 +13324,7 @@ False
         return d
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def tanh(self, inplace=False):
         '''Take the hyperbolic tangent of the data element-wise.
 
@@ -13382,7 +13382,7 @@ False
         return d
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def log(self, base=None, inplace=False, i=False):
         '''TODO
 
@@ -13414,7 +13414,7 @@ False
         return d
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def squeeze(self, axes=None, inplace=False, i=False):
         '''Remove size 1 axes from the data array.
 
@@ -13565,7 +13565,7 @@ False
 
     # `arctan2`, AT2 seealso
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def tan(self, inplace=False, i=False):
         '''Take the trigonometric tangent of the data element-wise.
 
@@ -13651,7 +13651,7 @@ False
         return self.array.tolist()
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def transpose(self, axes=None, inplace=False, i=False):
         '''Permute the axes of the data array.
 
@@ -13881,7 +13881,7 @@ False
                         calendar=calendar, chunk=chunk)
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def func(self, f, units=None, out=False, inplace=False,
              preserve_invalid=False, i=False, **kwargs):
         '''Apply an element-wise array operation to the data array.

--- a/cf/data/partitionmatrix.py
+++ b/cf/data/partitionmatrix.py
@@ -509,7 +509,7 @@ Attribute   Description
             return type(self)(new_matrix, self.axes)
 
     # 0
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def insert_dimension(self, axis, inplace=False):
         '''Insert a new size 1 axis in place.
 
@@ -607,7 +607,7 @@ Attribute   Description
         return boundaries
 
     # 0
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def swapaxes(self, axis0, axis1, inplace=False):
         '''Swap the positions of two axes.
 
@@ -724,7 +724,7 @@ Attribute   Description
         # --- End: for
 
     # 0
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def squeeze(self, inplace=False):
         '''Remove all size 1 axes.
 
@@ -767,7 +767,7 @@ Attribute   Description
 
         return p
 
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def transpose(self, axes, inplace=False):
         '''Permute the partition dimensions of the partition matrix in place.
 

--- a/cf/dimensioncoordinate.py
+++ b/cf/dimensioncoordinate.py
@@ -648,7 +648,7 @@ class DimensionCoordinate(mixin.Coordinate,
         return bounds
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def flip(self, axes=None, inplace=False, i=False):
         '''TODO
         '''
@@ -769,7 +769,7 @@ class DimensionCoordinate(mixin.Coordinate,
 #        return True
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def roll(self, axis, shift, inplace=False, i=False):
         '''TODO `{{class}}`
 

--- a/cf/mixin/coordinate.py
+++ b/cf/mixin/coordinate.py
@@ -344,7 +344,7 @@ class Coordinate:
     # ----------------------------------------------------------------
     # Methods
     # ----------------------------------------------------------------
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def autoperiod(self, inplace=False):
         '''TODO Set dimensions to be cyclic.
 

--- a/cf/mixin/properties.py
+++ b/cf/mixin/properties.py
@@ -6,6 +6,8 @@ from ..functions import (atol as cf_atol,
 from ..query import Query
 from ..units import Units
 
+from ..data import Data
+
 from ..functions import (_DEPRECATION_ERROR_METHOD,
                          _DEPRECATION_ERROR)
 
@@ -19,6 +21,18 @@ class Properties(Container):
 
     '''
     _special_properties = ()
+
+    def __new__(cls, *args, **kwargs):
+        '''Store component classes.
+
+    NOTE: If a child class requires a different component classes than
+    the ones defined here, then they must be redefined in the child
+    class.
+
+        '''
+        instance = super().__new__(cls)
+        instance._Data = Data
+        return instance
 
     # ----------------------------------------------------------------
     # Private attributes

--- a/cf/mixin/propertiesdata.py
+++ b/cf/mixin/propertiesdata.py
@@ -1590,7 +1590,7 @@ class PropertiesData(Properties):
     # Methods
     # ----------------------------------------------------------------
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def mask_invalid(self, inplace=False, i=False):
         '''Mask the array where invalid values occur.
 
@@ -1975,7 +1975,7 @@ class PropertiesData(Properties):
             "ERROR: Can't get the sum when there is no data array")
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def swapaxes(self, axis0, axis1, inplace=False):
         '''Interchange two axes of an array.
 
@@ -2497,7 +2497,7 @@ class PropertiesData(Properties):
         return data.isscalar
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def ceil(self, inplace=False, i=False):
         '''The ceiling of the data, element-wise.
 
@@ -2552,7 +2552,7 @@ class PropertiesData(Properties):
             data.chunk(chunksize)
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def clip(self, a_min, a_max, units=None, inplace=False, i=False):
         '''Limit the values in the data.
 
@@ -2706,7 +2706,7 @@ class PropertiesData(Properties):
 #        return out
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def cos(self, inplace=False, i=False):
         '''Take the trigonometric cosine of the data element-wise.
 
@@ -3238,7 +3238,7 @@ class PropertiesData(Properties):
         return True
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def convert_reference_time(self, units=None,
                                calendar_months=False,
                                calendar_years=False, inplace=False,
@@ -3413,7 +3413,7 @@ class PropertiesData(Properties):
         return v
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def flatten(self, axes=None, inplace=False):
         '''Flatten axes of the data
 
@@ -3469,7 +3469,7 @@ class PropertiesData(Properties):
             inplace=inplace)
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def floor(self, inplace=False, i=False):
         '''Floor the data array, element-wise.
 
@@ -3886,7 +3886,7 @@ class PropertiesData(Properties):
         return fillval
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def flip(self, axes=None, inplace=False, i=False):
         '''Flip (reverse the direction of) data dimensions.
 
@@ -3929,7 +3929,7 @@ class PropertiesData(Properties):
             inplace=inplace, i=i)
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def exp(self, inplace=False, i=False):
         '''The exponential of the data, element-wise.
 
@@ -3973,7 +3973,7 @@ class PropertiesData(Properties):
             inplace=inplace, i=i, delete_props=True)
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def sin(self, inplace=False, i=False):
         '''Take the trigonometric sine of the data element-wise.
 
@@ -4030,7 +4030,7 @@ class PropertiesData(Properties):
 
     # `arctan2`, AT2 seealso
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def arctan(self, inplace=False):
         '''Take the trigonometric inverse tangent of the data element-wise.
 
@@ -4080,7 +4080,7 @@ class PropertiesData(Properties):
             inplace=inplace, delete_props=True)
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def arctanh(self, inplace=False):
         '''Take the inverse hyperbolic tangent of the data element-wise.
 
@@ -4131,7 +4131,7 @@ class PropertiesData(Properties):
             inplace=inplace, delete_props=True)
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def arcsin(self, inplace=False):
         '''Take the trigonometric inverse sine of the data element-wise.
 
@@ -4183,7 +4183,7 @@ class PropertiesData(Properties):
             inplace=inplace, delete_props=True)
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def arcsinh(self, inplace=False):
         '''Take the inverse hyperbolic sine of the data element-wise.
 
@@ -4232,7 +4232,7 @@ class PropertiesData(Properties):
             inplace=inplace, delete_props=True)
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def arccos(self, inplace=False):
         '''Take the trigonometric inverse cosine of the data element-wise.
 
@@ -4284,7 +4284,7 @@ class PropertiesData(Properties):
             inplace=inplace, delete_props=True)
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def arccosh(self, inplace=False):
         '''Take the inverse hyperbolic cosine of the data element-wise.
 
@@ -4336,7 +4336,7 @@ class PropertiesData(Properties):
 
     # `arctan2`, AT2 seealso
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def tan(self, inplace=False, i=False):
         '''Take the trigonometric tangent of the data element-wise.
 
@@ -4393,7 +4393,7 @@ class PropertiesData(Properties):
             inplace=inplace, i=i, delete_props=True)
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def tanh(self, inplace=False):
         '''Take the hyperbolic tangent of the data array.
 
@@ -4452,7 +4452,7 @@ class PropertiesData(Properties):
             inplace=inplace, delete_props=True)
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def sinh(self, inplace=False):
         '''Take the hyperbolic sine of the data element-wise.
 
@@ -4509,7 +4509,7 @@ class PropertiesData(Properties):
             inplace=inplace, delete_props=True)
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def cosh(self, inplace=False):
         '''Take the hyperbolic cosine of the data element-wise.
 
@@ -4566,7 +4566,7 @@ class PropertiesData(Properties):
             inplace=inplace, delete_props=True)
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def log(self, base=None, inplace=False, i=False):
         '''The logarithm of the data array.
 
@@ -4624,7 +4624,7 @@ class PropertiesData(Properties):
             inplace=inplace, i=i, delete_props=True)
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def trunc(self, inplace=False, i=False):
         '''Truncate the data, element-wise.
 
@@ -4982,7 +4982,7 @@ class PropertiesData(Properties):
         '''
         return super().get_data(default=default, _units=False)
 
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     @_manage_log_level_via_verbosity
     def halo(self, size, axes=None, tripolar=None, fold_index=-1,
              inplace=False, verbose=None):
@@ -5102,7 +5102,7 @@ class PropertiesData(Properties):
         return v
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def override_calendar(self, calendar, inplace=False,  i=False):
         '''Override the calendar of date-time units.
 
@@ -5158,7 +5158,7 @@ class PropertiesData(Properties):
         return v
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def override_units(self, units, inplace=False, i=False):
         '''Override the units.
 
@@ -5225,7 +5225,7 @@ class PropertiesData(Properties):
         return v
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def rint(self, inplace=False, i=False):
         '''Round the data to the nearest integer, element-wise.
 
@@ -5261,7 +5261,7 @@ class PropertiesData(Properties):
             inplace=inplace, i=i)
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def round(self, decimals=0, inplace=False, i=False):
         '''Round the data to the given number of decimals.
 
@@ -5310,7 +5310,7 @@ class PropertiesData(Properties):
             inplace=inplace, i=i, decimals=decimals)
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def roll(self, iaxis, shift, inplace=False, i=False):
         '''Roll the data along an axis.
 
@@ -5341,7 +5341,7 @@ class PropertiesData(Properties):
             (iaxis, shift),
             inplace=inplace, i=i)
 
-    def set_data(self, data, copy=True):
+    def set_data(self, data, copy=True, inplace=True):
         '''Set the data.
 
     The units, calendar and fill value of the incoming `Data` instance
@@ -5356,24 +5356,38 @@ class PropertiesData(Properties):
         data: `Data`
             The data to be inserted.
 
+            {{data_like}}
+
         copy: `bool`, optional
             If False then do not copy the data prior to insertion. By
             default the data are copied.
 
+        {{inplace: `bool`, optional (default True)}}
+
+            .. versionadded:: 3.7.0
+
     :Returns:
 
-        `None`
+        `None` or `{{class}}`
+            If the operation was in-place then `None` is returned,
+            otherwise return a new `{{class}}` instance containing the
+            new data.
 
     **Examples:**
 
-    >>> d = Data(range(10))
-    >>> f.set_data(d)
+    >>> f = cf.{{class}}()
+    >>> f.set_data([1, 2, 3])
     >>> f.has_data()
     True
     >>> f.get_data()
-    <Data(10): [0, ..., 9]>
+    <CF Data(3): [1, 2, 3]>
+    >>> f.data
+    <CF Data(3): [1, 2, 3]>
     >>> f.del_data()
-    <Data(10): [0, ..., 9]>
+    <CF Data(3): [1, 2, 3]>
+    >>> g = f.set_data([4, 5, 6], inplace=False)
+    >>> g.data
+    <CF Data(3): [4, 5, 6]>
     >>> f.has_data()
     False
     >>> print(f.get_data(None))
@@ -5382,6 +5396,8 @@ class PropertiesData(Properties):
     None
 
         '''
+        data = self._Data(data, copy=False)
+
         if not data.Units:
             units = getattr(self, 'Units', None)
             if units is not None:
@@ -5392,13 +5408,15 @@ class PropertiesData(Properties):
                     data.override_units(units, inplace=True)
         # --- End: if
 
-        if copy:
-            data = data.copy()
+        return super().set_data(data, copy=copy, inplace=inplace)
 
-        self._set_component('data', data, copy=False)
+#        if copy:
+#            data = data.copy()
+#
+#        self._set_component('data', data, copy=False)
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def where(self, condition, x=None, y=None, inplace=False, i=False,
               verbose=None):
         '''Set data array elements depending on a condition.

--- a/cf/mixin/propertiesdatabounds.py
+++ b/cf/mixin/propertiesdatabounds.py
@@ -1,4 +1,3 @@
-
 import logging
 
 from numpy import size as numpy_size
@@ -804,7 +803,7 @@ class PropertiesDataBounds(PropertiesData):
         )
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def mask_invalid(self, inplace=False, i=False):
         '''Mask the array where invalid values occur.
 
@@ -956,7 +955,7 @@ class PropertiesDataBounds(PropertiesData):
     # ----------------------------------------------------------------
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def ceil(self, bounds=True, inplace=False, i=False):
         '''The ceiling of the data, element-wise.
 
@@ -1030,7 +1029,7 @@ class PropertiesDataBounds(PropertiesData):
             interior_ring.chunk(chunksize)
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def clip(self, a_min, a_max, units=None, bounds=True,
              inplace=False, i=False):
         '''Limit the values in the data.
@@ -1206,7 +1205,7 @@ class PropertiesDataBounds(PropertiesData):
 #        return out
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def cos(self, bounds=True, inplace=False,  i=False):
         '''Take the trigonometric cosine of the data element-wise.
 
@@ -1625,7 +1624,7 @@ class PropertiesDataBounds(PropertiesData):
                 return (lower >= upper).all()
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def convert_reference_time(self, units=None,
                                calendar_months=False,
                                calendar_years=False, inplace=False,
@@ -1783,7 +1782,7 @@ class PropertiesDataBounds(PropertiesData):
 
         return super().get_property(prop, default)
 
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def flatten(self, axes=None, inplace=False):
         '''Flatten axes of the data
 
@@ -1852,7 +1851,7 @@ class PropertiesDataBounds(PropertiesData):
         return v
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def floor(self, bounds=True, inplace=False, i=False):
         '''Floor the data array, element-wise.
 
@@ -2000,7 +1999,7 @@ class PropertiesDataBounds(PropertiesData):
         return ok
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def override_calendar(self, calendar, inplace=False, i=False):
         '''Override the calendar of date-time units.
 
@@ -2043,7 +2042,7 @@ class PropertiesDataBounds(PropertiesData):
             bounds=True, interior_ring=False, inplace=inplace, i=i)
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def override_units(self, units, inplace=False, i=False):
         '''Override the units.
 
@@ -2123,7 +2122,7 @@ class PropertiesDataBounds(PropertiesData):
 
         return out
 
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     @_manage_log_level_via_verbosity
     def halo(self, size, axes=None, tripolar=None, fold_index=-1,
              inplace=False, verbose=None):
@@ -2236,7 +2235,7 @@ class PropertiesDataBounds(PropertiesData):
             fold_index=fold_index, verbose=verbose)
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def flip(self, axes=None, inplace=False, i=False):
         '''Flip (reverse the direction of) data dimensions.
 
@@ -2315,7 +2314,7 @@ class PropertiesDataBounds(PropertiesData):
         return v
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def exp(self, bounds=True, inplace=False, i=False):
         '''The exponential of the data, element-wise.
 
@@ -2437,7 +2436,7 @@ class PropertiesDataBounds(PropertiesData):
         super().set_bounds(bounds, copy=False)
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def sin(self, bounds=True, inplace=False, i=False):
         '''Take the trigonometric sine of the data element-wise.
 
@@ -2495,7 +2494,7 @@ class PropertiesDataBounds(PropertiesData):
 
     # `arctan2`, AT2 seealso
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def arctan(self, bounds=True, inplace=False):
         '''Take the trigonometric inverse tangent of the data element-wise.
 
@@ -2542,7 +2541,7 @@ class PropertiesDataBounds(PropertiesData):
             _inplace_enabled_define_and_cleanup(self), 'arctan',
             inplace=inplace)
 
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def arctanh(self, bounds=True, inplace=False):
         '''Take the inverse hyperbolic tangent of the data element-wise.
 
@@ -2591,7 +2590,7 @@ class PropertiesDataBounds(PropertiesData):
             _inplace_enabled_define_and_cleanup(self), 'arctanh',
             bounds=bounds, inplace=inplace)
 
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def arcsin(self, bounds=True, inplace=False):
         '''Take the trigonometric inverse sine of the data element-wise.
 
@@ -2640,7 +2639,7 @@ class PropertiesDataBounds(PropertiesData):
             _inplace_enabled_define_and_cleanup(self), 'arcsin',
             bounds=bounds, inplace=inplace)
 
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def arcsinh(self, bounds=True, inplace=False):
         '''Take the inverse hyperbolic sine of the data element-wise.
 
@@ -2687,7 +2686,7 @@ class PropertiesDataBounds(PropertiesData):
             _inplace_enabled_define_and_cleanup(self), 'arcsinh',
             bounds=bounds, inplace=inplace)
 
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def arccos(self, bounds=True, inplace=False):
         '''Take the trigonometric inverse cosine of the data element-wise.
 
@@ -2736,7 +2735,7 @@ class PropertiesDataBounds(PropertiesData):
             _inplace_enabled_define_and_cleanup(self), 'arccos',
             bounds=bounds, inplace=inplace)
 
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def arccosh(self, bounds=True, inplace=False):
         '''Take the inverse hyperbolic cosine of the data element-wise.
 
@@ -2787,7 +2786,7 @@ class PropertiesDataBounds(PropertiesData):
             _inplace_enabled_define_and_cleanup(self), 'arccosh',
             bounds=bounds, inplace=inplace)
 
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def tanh(self, bounds=True, inplace=False):
         '''Take the hyperbolic tangent of the data element-wise.
 
@@ -2844,7 +2843,7 @@ class PropertiesDataBounds(PropertiesData):
             _inplace_enabled_define_and_cleanup(self), 'tanh',
             bounds=bounds, inplace=inplace)
 
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def sinh(self, bounds=True, inplace=False):
         '''Take the hyperbolic sine of the data element-wise.
 
@@ -2900,7 +2899,7 @@ class PropertiesDataBounds(PropertiesData):
             _inplace_enabled_define_and_cleanup(self), 'sinh',
             bounds=bounds, inplace=inplace)
 
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def cosh(self, bounds=True, inplace=False):
         '''Take the hyperbolic cosine of the data element-wise.
 
@@ -2958,7 +2957,7 @@ class PropertiesDataBounds(PropertiesData):
 
     # `arctan2`, AT2 seealso
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def tan(self, bounds=True, inplace=False, i=False):
         '''Take the trigonometric tangent of the data element-wise.
 
@@ -3014,7 +3013,7 @@ class PropertiesDataBounds(PropertiesData):
             inplace=inplace, i=i)
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def log(self, base=None, bounds=True, inplace=False, i=False):
         '''The logarithm of the data array.
 
@@ -3131,7 +3130,7 @@ class PropertiesDataBounds(PropertiesData):
         return super().squeeze(axes=axes, inplace=inplace)
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def trunc(self, bounds=True, inplace=False, i=False):
         '''Truncate the data, element-wise.
 
@@ -3411,7 +3410,7 @@ class PropertiesDataBounds(PropertiesData):
         return old
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def rint(self, bounds=True, inplace=False, i=False):
         '''Round the data to the nearest integer, element-wise.
 
@@ -3451,7 +3450,7 @@ class PropertiesDataBounds(PropertiesData):
             bounds=bounds, inplace=inplace, i=i)
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def round(self, decimals=0, bounds=True, inplace=False, i=False):
         '''Round the data to the given number of decimals.
 
@@ -3506,7 +3505,7 @@ class PropertiesDataBounds(PropertiesData):
             bounds=bounds, inplace=inplace, i=i, decimals=decimals)
 
     @_deprecated_kwarg_check('i')
-    @_inplace_enabled
+    @_inplace_enabled(default=False)
     def roll(self, iaxis, shift, inplace=False, i=False):
         '''Roll the data along an axis.
 

--- a/cf/test/test_DimensionCoordinate.py
+++ b/cf/test/test_DimensionCoordinate.py
@@ -329,8 +329,29 @@ class DimensionCoordinateTest(unittest.TestCase):
         x += 2
         self.assertTrue((x.array == (d+2)*2 + 2).all())
 
+    def test_DimensionCoordinate_set_data(self):
+        x = cf.DimensionCoordinate()
+
+        y = x.set_data(cf.Data([1, 2, 3]))
+        self.assertIsNone(y)
+        self.assertTrue(x.has_data())
+
+        # Test inplace
+        x.del_data()
+        y = x.set_data(cf.Data([1, 2, 3]), inplace=False)
+        self.assertIsInstance(y, cf.DimensionCoordinate)
+        self.assertFalse(x.has_data())
+        self.assertTrue(y.has_data())
+
+        # Exceptions should be raised for 0-d and N-d (N>=2) data
+        with self.assertRaises(Exception):
+            y = x.set_data(cf.Data([[1, 2, 3]]))
+
+        with self.assertRaises(Exception):
+            y = x.set_data(cf.Data(1))
 
 # --- End: class
+
 
 if __name__ == "__main__":
     print('Run date:', datetime.datetime.now())

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -77,7 +77,7 @@ class FieldTest(unittest.TestCase):
 #            'test_Field_convolution_filter', 'test_Field_derivative',
 #            'test_Field_moving_window'
 #        ]
-#        self.test_only = ['test_Field_match']
+#        self.test_only = ['test_Field_set_get_del_has_data']
 #        self.test_only = ['test_Field_collapse']
 #        self.test_only = ['test_Field_radius']
 #        self.test_only = ['test_Field_field_ancillary']
@@ -91,7 +91,7 @@ class FieldTest(unittest.TestCase):
 #        self.test_only = ['test_Field_mask_invalid']
 #        self.test_only = ['test_Field_test_Field_creation_commands']
 #        self.test_only = ['test_Field_section']
-#        self.test_only = ['test_Field_flip']
+#        self.test_only = ['test_Field_flatten']
 #        self.test_only = ['test_Field_Field_domain_mask']
 #        self.test_only = ['test_Field_compress_uncompress']
 #        self.test_only = ['test_Field_coordinate_reference']
@@ -294,7 +294,7 @@ class FieldTest(unittest.TestCase):
         axis = f.set_construct(cf.DomainAxis(1))
         d = cf.DimensionCoordinate()
         d.standard_name = 'time'
-        d.set_data(cf.Data(123., 'days since 2000-01-02'))
+        d.set_data(cf.Data([123.], 'days since 2000-01-02'))
         f.set_construct(d, axes=axis)
 
         g = f.flatten()
@@ -1218,7 +1218,7 @@ class FieldTest(unittest.TestCase):
         with self.assertRaises(Exception):
             _ = f.radius(default=None)
 
-    def test_Field_DATA(self):
+    def test_Field_set_get_del_has_data(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
 
@@ -1279,6 +1279,15 @@ class FieldTest(unittest.TestCase):
             g.set_data(cf.Data(list(range(9))), axes=b)
         with self.assertRaises(Exception):
             g.set_data(cf.Data(list(range(9))), axes=[b, a])
+
+        # Test inplace
+        f = self.f.copy()
+        d = f.del_data()
+        g = f.set_data(d, inplace=False)
+        self.assertIsInstance(g, cf.Field)
+        self.assertFalse(f.has_data())
+        self.assertTrue(g.has_data())
+        self.assertTrue(g.data.equals(d))
 
         g = cf.Field()
 #        with self.assertRaises(Exception):

--- a/cf/test/test_read_write.py
+++ b/cf/test/test_read_write.py
@@ -346,8 +346,9 @@ class read_writeTest(unittest.TestCase):
             for chunksize in self.chunk_sizes:
                 cf.chunksize(chunksize)
                 f = cf.read(self.filename)[0]
-                t = cf.DimensionCoordinate(data=cf.Data(
-                    123, 'days since 1750-1-1'))
+                t = cf.DimensionCoordinate(
+                    data=cf.Data([123], 'days since 1750-1-1')
+                )
 
                 t.standard_name = 'time'
                 axisT = f.set_construct(cf.DomainAxis(1))


### PR DESCRIPTION
*    implements __inplace keyword to set_data methods

*    implements a choice of default value for in place int he `@_inplace_enabled` decorator. An upshot of this is that the default has to specified in all cases. No bad thing.

*    Allows "data_like" inputs instead of `cf.Data` objects:
    _A data_like object is any object that can be converted to a Data object, i.e. numpy array_like objects, Data objects, and cf objects that contain Data objects._
