### PR TITLE
Fixes and error messages for cf.aggregate

### DIFF
--- a/cf/aggregate.py
+++ b/cf/aggregate.py
@@ -1332,11 +1332,6 @@ def aggregate(fields,
     the *ncvar_identities* parameter forces field and metadata
     constructs to be identified by their netCDF file variable names.
 
-    **Units**
-
-
-
-
     :Parameters:
 
         fields: `FieldList` or sequence of `Field`
@@ -1616,7 +1611,11 @@ def aggregate(fields,
         dimension = (dimension,)
 
     if exist_all and equal_all:
-        raise ValueError("asdasdas  jnf0____")
+        raise ValueError(
+            "Only one of 'exist_all' and 'equal_all' can be True, since "
+            "these options are conflicting. Run 'help(cf.aggregate)' to read "
+            "descriptions of each option to see which is applicable."
+        )
 
     if equal or exist or ignore:
         properties = {
@@ -1647,7 +1646,12 @@ def aggregate(fields,
 
         if equal and exist:
             if set(equal).intersection(exist):
-                raise AttributeError("TODO 888888888888888 asdasdas  jnf0____")
+                raise AttributeError(
+                    "Only one of 'exist' and 'equal' can be True for any "
+                    "given property, since these options are conflicting. "
+                    "Run 'help(cf.aggregate)' to read descriptions of each "
+                    "option to see which is applicable."
+                )
 
         if ignore:
             ignore = _signature_properties.union(ignore)
@@ -3095,7 +3099,7 @@ def ensemble(f, prop, **kwargs):
     # Check that the fields are all compatible
     kwargs['copy'] = True
     if len(cf.aggregate(f, **kwargs)) != len(f):
-        raise ValueError("")
+        raise ValueError("Not all of the fields are compatible.")
 
     f = f.copy()
 
@@ -3118,8 +3122,11 @@ def ensemble(f, prop, **kwargs):
     kwargs['copy'] = False
     f = aggregate(f, **kwargs)
 
-    # Check that the fields were aggreageted down to one field
+    # Check that the fields were aggregated down to one field
     if len(f) != 1:
-        raise ValueError("TODO")
+        raise ValueError(
+            "The aggregation resulted in more than one field, but a single "
+            "field was expected."
+        )
 
     return f

--- a/cf/aggregate.py
+++ b/cf/aggregate.py
@@ -677,8 +677,8 @@ class _Meta:
                               (exist and p not in ex)]
             # --- End: if
 
-            self.properties = tuple(sorted(ex_all + ex +
-                                           eq_all.items() + eq.items()))
+            self.properties = tuple(
+                sorted(ex_all + ex + list(eq_all.items()) + list(eq.items())))
         # --- End: if
 
         # Attributes
@@ -1655,10 +1655,11 @@ def aggregate(fields,
 
         if ignore:
             ignore = _signature_properties.union(ignore)
-        else:
-            ignore = _signature_properties
+
     # --- End: if
 
+    if not ignore:
+        ignore = _signature_properties
     unaggregatable = False
     status = 0
 

--- a/cf/test/test_aggregate.py
+++ b/cf/test/test_aggregate.py
@@ -16,7 +16,7 @@ class aggregateTest(unittest.TestCase):
     chunk_sizes = (100000, 300, 34)
     original_chunksize = cf.chunksize()
 
-    def test_aggregate(self):
+    def test_basic_aggregate(self):
         for chunksize in self.chunk_sizes:
             cf.chunksize(chunksize)
 
@@ -124,6 +124,27 @@ class aggregateTest(unittest.TestCase):
             c.long_name = 'qwerty'
             x = cf.aggregate([c, t], field_identity='long_name')
             self.assertEqual(len(x), 1)
+
+        cf.chunksize(self.original_chunksize)
+
+    def test_aggregate_exist_equal_ignore_opts(self):
+        # TODO: extend the option-checking coverage so all options and all
+        # reasonable combinations of them are tested. For now, this is
+        # testing options that previously errored due to a bug.
+        for chunksize in self.chunk_sizes:
+            cf.chunksize(chunksize)
+
+            f = cf.read(self.filename, squeeze=True)[0]
+
+            # Use f as-is: simple test that aggregate works and does not
+            # change anything with the given options:
+            g = cf.aggregate(f, exist_all=True)[0]
+            self.assertEqual(g, f)
+            h = cf.aggregate(f, equal_all=True)[0]
+            self.assertEqual(h, f)
+
+            with self.assertRaises(ValueError):  # contradictory options
+                cf.aggregate(f, exist_all=True, equal_all=True)
 
         cf.chunksize(self.original_chunksize)
 


### PR DESCRIPTION
Close #116 with a new test to isolate the previous bug minimally, and also fill in all of the placeholders for error messages elsewhere in `cf.aggregate`.