### PR TITLE
In cf.write, allow dimension coordinate constructs' netCDF names to be added to the coordinates netCDF attribute, if the user desires. Currently they are always omitted. Either way is CF-compliant.

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -2,10 +2,17 @@ version 3.7.0
 -------------
 ----
 
-**2020-09-??**
+**2020-10-??**
 
 * New method: `cf.Field.del_domain_axis`
 * New method: `cf.FieldList.unique_domains`
+* New method: `cf.Field._docstring_special_substitutions`
+* New method: `cf.Field._docstring_substitutions`
+* New method: `cf.Field._docstring_package_depth`
+* New method: `cf.Field._docstring_method_exclusions`
+* New keyword parameter to `cf.Field.set_data`: ``inplace``
+* New keyword parameter to `cf.write`: ``coordinates``
+  (https://github.com/NCAS-CMS/cf-python/issues/125)
 * Changed dependency: ``1.8.7.0<=cfdm<1.8.8.0``
 
 version 3.6.0

--- a/cf/read_write/netcdf/netcdfwrite.py
+++ b/cf/read_write/netcdf/netcdfwrite.py
@@ -136,7 +136,8 @@ class NetCDFWrite(cfdm.read_write.netcdf.NetCDFWrite):
 
             partition.close()
 
-    def _write_dimension_coordinate(self, f, key, coord, ncdim=None):
+    def _write_dimension_coordinate(self, f, key, coord, ncdim=None,
+                                    coordinates=None):
         '''Write a coordinate variable and its bound variable to the file.
 
     This also writes a new netCDF dimension to the file and, if
@@ -160,6 +161,11 @@ class NetCDFWrite(cfdm.read_write.netcdf.NetCDFWrite):
 
             .. versionadded:: 3.6.0
 
+        coordinates: `list`
+           This list may get updated in-place.
+
+            .. versionadded:: 3.7.0
+
     :Returns:
 
         `str`
@@ -169,7 +175,8 @@ class NetCDFWrite(cfdm.read_write.netcdf.NetCDFWrite):
         coord = self._change_reference_datetime(coord)
 
         return super()._write_dimension_coordinate(f, key, coord,
-                                                   ncdim=ncdim)
+                                                   ncdim=ncdim,
+                                                   coordinates=coordinates)
 
     def _write_scalar_coordinate(self, f, key, coord_1d, axis,
                                  coordinates, extra=None):

--- a/cf/read_write/write.py
+++ b/cf/read_write/write.py
@@ -30,8 +30,8 @@ def write(fields, filename, fmt='NETCDF4', overwrite=True,
           fletcher32=False, shuffle=True, reference_datetime=None,
           verbose=None, cfa_options=None, mode='w', single=None,
           double=None, variable_attributes=None, string=True,
-          warn_valid=True, group=True, HDF_chunksizes=None,
-          no_shuffle=None, unlimited=None):
+          warn_valid=True, group=True, coordinates=False,
+          HDF_chunksizes=None, no_shuffle=None, unlimited=None):
     '''Write field constructs to a netCDF file.
 
 
@@ -517,6 +517,14 @@ def write(fields, filename, fmt='NETCDF4', overwrite=True,
 
             .. versionadded:: 3.6.0
 
+        coordinates: `bool`, optional
+            If True then include CF-netCDF coordinate variable names
+            in the 'coordinates' attribute of output data
+            variables. By default only auxiliary and scalar coordinate
+            variables are included.
+
+            .. versionadded:: (cfdm) 3.7.0
+
         HDF_chunksizes: deprecated at version 3.0.0
             HDF chunk sizes may be set for individual constructs prior
             to writing, instead. See `cf.Data.nc_set_hdf5_chunksizes`.
@@ -655,6 +663,7 @@ def write(fields, filename, fmt='NETCDF4', overwrite=True,
                      shuffle=shuffle, fletcher32=fletcher32,
                      verbose=verbose, string=string,
                      warn_valid=warn_valid, group=group,
+                     coordinates=coordinates,
                      extra_write_vars=extra_write_vars)
     # --- End: if
 


### PR DESCRIPTION
Fixes #125 