### PR TITLE
Re-establish configurable verbosity for cf.aggregate

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -1,3 +1,12 @@
+version 3.?.?
+-------------
+----
+
+**2020-??-??**
+
+* Fixed bug that prevented the verbosity from changing to any value specified
+  as a ``verbose`` keyword parameter to `cf.aggregate` (only).
+
 version 3.7.0
 -------------
 ----

--- a/cf/aggregate.py
+++ b/cf/aggregate.py
@@ -1049,6 +1049,7 @@ class _Meta:
 
         return anc_identity
 
+    @_manage_log_level_via_verbose_attr
     def print_info(self, signature=True):
         '''TODO
 

--- a/cf/test/test_aggregate.py
+++ b/cf/test/test_aggregate.py
@@ -21,7 +21,6 @@ class aggregateTest(unittest.TestCase):
     chunk_sizes = (100000, 300, 34)
     original_chunksize = cf.chunksize()
 
-    """
     def test_basic_aggregate(self):
         for chunksize in self.chunk_sizes:
             cf.chunksize(chunksize)
@@ -171,7 +170,6 @@ class aggregateTest(unittest.TestCase):
                 cf.aggregate(f, exist_all=True, equal_all=True)
 
         cf.chunksize(self.original_chunksize)
-    """
 
     def test_aggregate_verbosity(self):
         for chunksize in self.chunk_sizes:

--- a/cf/test/test_aggregate.py
+++ b/cf/test/test_aggregate.py
@@ -5,6 +5,10 @@ import warnings
 
 import cf
 
+# To facilitate the testing of logging outputs (see test_aggregate_verbosity)
+log_name = __name__
+logger = cf.logging.getLogger(log_name)
+
 
 class aggregateTest(unittest.TestCase):
     filename = os.path.join(
@@ -17,6 +21,7 @@ class aggregateTest(unittest.TestCase):
     chunk_sizes = (100000, 300, 34)
     original_chunksize = cf.chunksize()
 
+    """
     def test_basic_aggregate(self):
         for chunksize in self.chunk_sizes:
             cf.chunksize(chunksize)
@@ -166,6 +171,59 @@ class aggregateTest(unittest.TestCase):
                 cf.aggregate(f, exist_all=True, equal_all=True)
 
         cf.chunksize(self.original_chunksize)
+    """
+
+    def test_aggregate_verbosity(self):
+        for chunksize in self.chunk_sizes:
+            f0 = cf.example_field(0)
+            f1 = cf.example_field(1)
+
+            detail_header = "DETAIL:cf.aggregate:STRUCTURAL SIGNATURE:"
+            debug_header = (
+                "DEBUG:cf.aggregate:COMPLETE AGGREGATION METADATA:")
+
+            # 'DEBUG' (-1) verbosity should output both log message headers...
+            with self.assertLogs(level=cf.log_level()) as catch:
+                cf.aggregate([f0, f1], verbose=-1)
+                for header in (detail_header, debug_header):
+                    self.assertTrue(
+                        any(log_item.startswith(header)
+                            for log_item in catch.output),
+                        "No log entry begins with '{}'".format(header)
+                    )
+
+            # ...but with 'DETAIL' (3), should get only the detail-level one.
+            with self.assertLogs(level=cf.log_level()) as catch:
+                cf.aggregate([f0, f1], verbose=3)
+                self.assertTrue(
+                    any(log_item.startswith(detail_header)
+                        for log_item in catch.output),
+                    "No log entry begins with '{}'".format(detail_header)
+                )
+                self.assertFalse(
+                    any(log_item.startswith(debug_header)
+                        for log_item in catch.output),
+                    "A log entry begins with '{}' but should not".format(
+                        debug_header)
+                )
+
+            # and neither should emerge at the 'WARNING' (1) level.
+            with self.assertLogs(level=cf.log_level()) as catch:
+                logger.warning(
+                    "Dummy message to log something at warning level so that "
+                    "'assertLog' does not error when no logs messages emerge."
+                )
+                # Note: can use assertNoLogs in Python 3.10 to avoid this, see:
+                # https://bugs.python.org/issue39385
+
+                cf.aggregate([f0, f1], verbose=1)
+                for header in (detail_header, debug_header):
+                    self.assertFalse(
+                        any(log_item.startswith(header)
+                            for log_item in catch.output),
+                        "A log entry begins with '{}' but should not".format(
+                            header)
+                    )
 
 # --- End: class
 


### PR DESCRIPTION
Fix bug alluded to in #150 (though it is not the core of the issue raised there, so it does not resolve it), namely that the verbosity keyword is ineffectual:

> I also tried to debug this issue with argument verbose. However, no matter what value that I set to verbose, there was not any extra information shown.

This turned out to be because a decorator was not applied to a central method for logging output during aggregation, `print_info`. A one-line change to add the decorator fixes the problem.

To ensure it did fix it and for robustness I have added a unit tests for the verbosity on `cf.aggregate` specifically (though the verbosity decorators are themselves unit tested, `cf.aggregate` in particular warrants a specific test that the verbosity is managed correctly since it involves a mix of the two decorators, `_manage_log_level_via_verbosity` and `_manage_log_level_via_verbose_attr`, and there could be bugs emerging from combined use).