### PR TITLE
fixed stored partition config

### DIFF
--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -4793,7 +4793,7 @@ place.
 
             partition._original = None
             partition._write_to_disk = False
-            partition.close()
+            partition.close(units=new_Units)
 
             if not inplace:
                 partition_s.close()

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -78,7 +78,6 @@ class DataTest(unittest.TestCase):
 
     test_only = []
 #    test_only = ['NOTHING!!!!!']
-#    test_only = ['test_Data_exp']
 #    test_only = [
 #        'test_Data_percentile',
 #        'test_Data_trigonometric_hyperbolic'
@@ -605,6 +604,41 @@ class DataTest(unittest.TestCase):
         cf.chunksize(self.original_chunksize)
         cf.free_memory_factor(original_FMF)
 
+    def test_Data_cached_arithmetic_units(self):
+        if self.test_only and inspect.stack()[0][3] not in self.test_only:
+            return
+
+        d = cf.Data(self.a, 'm')
+        e = cf.Data(self.a, 's')
+
+        f = d / e
+        self.assertEqual(f.Units, cf.Units('m s-1'))
+
+        d = cf.Data(self.a, 'days since 2000-01-02')
+        e = cf.Data(self.a, 'days since 1999-01-02')
+
+        f = d - e
+        self.assertEqual(f.Units, cf.Units('days'))
+
+        # Repeat with caching partitions to disk
+        fmt = cf.constants.CONSTANTS['FM_THRESHOLD']
+        cf.constants.CONSTANTS['FM_THRESHOLD'] = cf.total_memory()
+
+        d = cf.Data(self.a, 'm')
+        e = cf.Data(self.a, 's')
+
+        f = d / e
+        self.assertEqual(f.Units, cf.Units('m s-1'))
+
+        d = cf.Data(self.a, 'days since 2000-01-02')
+        e = cf.Data(self.a, 'days since 1999-01-02')
+
+        f = d - e
+        self.assertEqual(f.Units, cf.Units('days'))
+
+        # Reset
+        cf.constants.CONSTANTS['FM_THRESHOLD'] = fmt
+        
     def test_Data_AUXILIARY_MASK(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return


### PR DESCRIPTION
Fixes bug that caused `partition.config['units']` to be inconsistent with the units of the partition array when carrying out binary arithmetic during which the result units are different than the input units.

This is long standing, and only manifests when the partition is being cached to disk, and the result units are different than the input operand units.