### PR TITLE
Refactor and test for cf.environment

### DIFF
--- a/cf/functions.py
+++ b/cf/functions.py
@@ -4,6 +4,7 @@ import os
 import platform
 import re
 import resource
+import sys
 import ctypes.util
 # import cPickle
 import netCDF4
@@ -3193,83 +3194,64 @@ def environment(display=True, paths=True):
     cf: 3.0.1
 
     '''
-    out = []
-    out.append('Platform: ' + str(platform.platform()))
-    out.append('HDF5 library: ' + str(netCDF4. __hdf5libversion__))
-    out.append('netcdf library: ' + str(netCDF4.__netcdf4libversion__))
-    out.append(
-        'udunits2 library: ' + str(ctypes.util.find_library('udunits2')))
-    out.append('python: ' + str(platform.python_version()))
-    if paths:
-        out[-1] += ' ' + str(_sys_executable)
-
-    out.append('netCDF4: ' + str(netCDF4.__version__))
-    if paths:
-        out[-1] += ' ' + str(_os_path_abspath(netCDF4.__file__))
-
-    out.append('cftime: ' + str(cftime.__version__))
-    if paths:
-        out[-1] += ' ' + str(_os_path_abspath(cftime.__file__))
-
-    out.append('numpy: ' + str(_numpy__version__))
-    if paths:
-        out[-1] += ' ' + str(_os_path_abspath(_numpy__file__))
-
-    out.append('psutil: ' + str(psutil.__version__))
-    if paths:
-        out[-1] += ' ' + str(_os_path_abspath(psutil.__file__))
-
+    unavailable_msg = 'not available'
     try:
         import scipy
     except ImportError:
-        out.append('scipy: not available')
+        scipy_version = unavailable_msg
     else:
-        out.append('scipy: ' + str(scipy.__version__))
-        if paths:
-            out[-1] += ' ' + str(_os_path_abspath(scipy.__file__))
+        scipy_version = (scipy.__version__, _os_path_abspath(scipy.__file__))
     # --- End: try
 
     try:
         import matplotlib
     except ImportError:
-        out.append('matplotlib: not available')
+        matplotlib_version = unavailable_msg
     else:
-        out.append('matplotlib: ' + str(matplotlib.__version__))
-        if paths:
-            out[-1] += ' ' + str(_os_path_abspath(matplotlib.__file__))
+        matplotlib_version = (
+            matplotlib.__version__, _os_path_abspath(matplotlib.__file__))
     # --- End: try
 
     try:
         import ESMF
     except ImportError:
-        out.append('ESMF: not available')
+        esmf_version = unavailable_msg
     else:
-        out.append('ESMF: ' + str(ESMF.__version__))
-        if paths:
-            out[-1] += ' ' + str(_os_path_abspath(ESMF.__file__))
+        esmf_version = (ESMF.__version__, _os_path_abspath(ESMF.__file__))
     # --- End: try
-
-    out.append('cfdm: ' + str(cfdm.__version__))
-    if paths:
-        out[-1] += ' ' + str(_os_path_abspath(cfdm.__file__))
-
-    out.append('cfunits: ' + str(cfunits.__version__))
-    if paths:
-        out[-1] += ' ' + str(_os_path_abspath(cfunits.__file__))
 
     try:
         import cfplot
     except ImportError:
-        out.append('cfplot: not available')
+        cfplot_version = unavailable_msg
     else:
-        out.append('cfplot: ' + str(cfplot.__version__))
-        if paths:
-            out[-1] += ' ' + str(_os_path_abspath(cfplot.__file__))
+        cfplot_version = (
+            cfplot.__version__, _os_path_abspath(cfplot.__file__))
     # --- End: try
 
-    out.append('cf: ' + str(__version__))
-    if paths:
-        out[-1] += ' ' + str(_os_path_abspath(__file__))
+    dependency_version_paths_mapping = {
+        'Platform': (platform.platform(), ''),
+        'HDF5 library': (netCDF4.__hdf5libversion__, ''),
+        'netcdf library': (netCDF4.__netcdf4libversion__, ''),
+        'udunits2 library': (ctypes.util.find_library('udunits2'), ''),
+        'Python': (platform.python_version(), sys.executable),
+        'netCDF4': (netCDF4.__version__, _os_path_abspath(netCDF4.__file__)),
+        'cftime': (cftime.__version__, _os_path_abspath(cftime.__file__)),
+        'numpy': (_numpy__version__, _os_path_abspath(_numpy__file__)),
+        'psutil': (psutil.__version__, _os_path_abspath(psutil.__file__)),
+        'scipy': scipy_version,
+        'matplotlib': matplotlib_version,
+        'ESMF': esmf_version,
+        'cfdm': (cfdm.__version__, _os_path_abspath(cfdm.__file__)),
+        'cfunits': (cfunits.__version__, _os_path_abspath(cfunits.__file__)),
+        'cfplot': cfplot_version,
+        'cf': (__version__, _os_path_abspath(__file__)),
+    }
+    string = '{0}: {1!s}'
+    if paths:  # include path information, else exclude, when unpacking tuple
+        string += ' {2!s}'
+    out = [string.format(dep, *info)
+           for dep, info in dependency_version_paths_mapping.items()]
 
     out = '\n'.join(out)
 

--- a/cf/functions.py
+++ b/cf/functions.py
@@ -3132,7 +3132,7 @@ def _section(x, axes=None, data=False, stop=None, chunks=False,
         return fl
 
 
-def environment(display=True, paths=True, string=True):
+def environment(display=True, paths=True):
     '''Return the names and versions of the cf package and its
     dependencies.
 

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -638,7 +638,7 @@ class DataTest(unittest.TestCase):
 
         # Reset
         cf.constants.CONSTANTS['FM_THRESHOLD'] = fmt
-        
+
     def test_Data_AUXILIARY_MASK(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return

--- a/cf/test/test_aggregate.py
+++ b/cf/test/test_aggregate.py
@@ -181,7 +181,7 @@ class aggregateTest(unittest.TestCase):
                 "DEBUG:cf.aggregate:COMPLETE AGGREGATION METADATA:")
 
             # 'DEBUG' (-1) verbosity should output both log message headers...
-            with self.assertLogs(level=cf.log_level().value) as catch:
+            with self.assertLogs(level='NOTSET') as catch:
                 cf.aggregate([f0, f1], verbose=-1)
                 for header in (detail_header, debug_header):
                     self.assertTrue(
@@ -191,7 +191,7 @@ class aggregateTest(unittest.TestCase):
                     )
 
             # ...but with 'DETAIL' (3), should get only the detail-level one.
-            with self.assertLogs(level=cf.log_level().value) as catch:
+            with self.assertLogs(level='NOTSET') as catch:
                 cf.aggregate([f0, f1], verbose=3)
                 self.assertTrue(
                     any(log_item.startswith(detail_header)
@@ -206,7 +206,7 @@ class aggregateTest(unittest.TestCase):
                 )
 
             # and neither should emerge at the 'WARNING' (1) level.
-            with self.assertLogs(level=cf.log_level().value) as catch:
+            with self.assertLogs(level='NOTSET') as catch:
                 logger.warning(
                     "Dummy message to log something at warning level so that "
                     "'assertLog' does not error when no logs messages emerge."

--- a/cf/test/test_functions.py
+++ b/cf/test/test_functions.py
@@ -1,5 +1,8 @@
 import atexit
 import datetime
+import os
+import platform
+import sys
 import unittest
 import inspect
 
@@ -312,6 +315,33 @@ class functionTest(unittest.TestCase):
 
         c = cf.Configuration()
         self.assertIs(c._func, cf.configuration)
+
+    def test_environment(self):
+        if self.test_only and inspect.stack()[0][3] not in self.test_only:
+            return
+
+        e = cf.environment(display=False)
+        ep = cf.environment(display=False, paths=False)
+        self.assertIsInstance(e, str)
+        self.assertIsInstance(ep, str)
+
+        components = ['Platform: ', 'udunits2 library: ', 'numpy: ', 'cfdm: ']
+        for component in components:
+            self.assertIn(component, e)
+            self.assertIn(component, ep)
+        for component in [
+            'cf: {} {}'.format(
+                cf.__version__, os.path.abspath(cf.__file__)),
+            'Python: {} {}'.format(
+                platform.python_version(), sys.executable),
+        ]:
+            self.assertIn(component, e)
+            self.assertNotIn(component, ep)  # paths shouldn't be present here
+        for component in [
+            'cf: {}'.format(cf.__version__),
+            'Python: {}'.format(platform.python_version()),
+        ]:
+            self.assertIn(component, ep)
 
 # --- End: class
 


### PR DESCRIPTION
Some amendments relating to `cf.environment` which don't modify its behaviour in any way, namely:

* remove a defunct keyword argument from the signature;
* refactor the code which had quite a bit of duplication and wasn't as readable as it could be;
* add a basic test.
