### PR TITLE
Enable faulthandler for all test modules

### DIFF
--- a/cf/test/create_test_files.py
+++ b/cf/test/create_test_files.py
@@ -3,6 +3,10 @@ import os
 import unittest
 
 import numpy
+
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import netCDF4
 
 import cf

--- a/cf/test/run_tests.py
+++ b/cf/test/run_tests.py
@@ -3,6 +3,9 @@ import os
 from random import choice, shuffle
 import unittest
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 

--- a/cf/test/setup_create_field.py
+++ b/cf/test/setup_create_field.py
@@ -4,6 +4,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 

--- a/cf/test/test_AuxiliaryCoordinate.py
+++ b/cf/test/test_AuxiliaryCoordinate.py
@@ -4,6 +4,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 

--- a/cf/test/test_CellMeasure.py
+++ b/cf/test/test_CellMeasure.py
@@ -4,6 +4,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 

--- a/cf/test/test_CellMethod.py
+++ b/cf/test/test_CellMethod.py
@@ -3,6 +3,9 @@ import inspect
 import os
 import unittest
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 

--- a/cf/test/test_CoordinateReference.py
+++ b/cf/test/test_CoordinateReference.py
@@ -6,6 +6,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 

--- a/cf/test/test_Count.py
+++ b/cf/test/test_Count.py
@@ -1,6 +1,9 @@
 import datetime
 import unittest
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -17,6 +17,9 @@ try:
 except Exception:
     pass  # test with this dependency will then be skipped by unittest
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 

--- a/cf/test/test_Datetime.py
+++ b/cf/test/test_Datetime.py
@@ -2,10 +2,13 @@ import datetime
 import unittest
 
 import numpy
+
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cftime
 
 import cf
-
 from cf import Units
 
 

--- a/cf/test/test_DimensionCoordinate.py
+++ b/cf/test/test_DimensionCoordinate.py
@@ -4,6 +4,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 

--- a/cf/test/test_DomainAncillary.py
+++ b/cf/test/test_DomainAncillary.py
@@ -3,6 +3,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 

--- a/cf/test/test_DomainAxis.py
+++ b/cf/test/test_DomainAxis.py
@@ -1,6 +1,9 @@
 import datetime
 import unittest
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -17,6 +17,9 @@ try:
 except Exception:
     pass  # test with this dependency will then be skipped by unittest
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 n_tmpfiles = 1
@@ -1037,6 +1040,7 @@ class FieldTest(unittest.TestCase):
         self.assertIsNone(f.flip('X', inplace=True))
         self.assertTrue(f.equals(g, verbose=1))
 
+    """
     def test_Field_close(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -1047,6 +1051,7 @@ class FieldTest(unittest.TestCase):
         _ = repr(f.data)
         for c in f.constructs.filter_by_data().values():
             _ = repr(c.data)
+    """
 
     def test_Field_anchor(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:

--- a/cf/test/test_FieldAncillary.py
+++ b/cf/test/test_FieldAncillary.py
@@ -2,6 +2,9 @@ import datetime
 import os
 import unittest
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 

--- a/cf/test/test_FieldList.py
+++ b/cf/test/test_FieldList.py
@@ -6,6 +6,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 

--- a/cf/test/test_Index.py
+++ b/cf/test/test_Index.py
@@ -1,6 +1,9 @@
 import datetime
 import unittest
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 

--- a/cf/test/test_List.py
+++ b/cf/test/test_List.py
@@ -1,6 +1,9 @@
 import datetime
 import unittest
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 

--- a/cf/test/test_Maths.py
+++ b/cf/test/test_Maths.py
@@ -5,6 +5,9 @@ import inspect
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 

--- a/cf/test/test_Partition.py
+++ b/cf/test/test_Partition.py
@@ -3,6 +3,9 @@ import inspect
 import os
 import unittest
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 

--- a/cf/test/test_Query.py
+++ b/cf/test/test_Query.py
@@ -6,6 +6,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 

--- a/cf/test/test_Regrid.py
+++ b/cf/test/test_Regrid.py
@@ -3,6 +3,9 @@ import os
 import unittest
 import inspect
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 

--- a/cf/test/test_TimeDuration.py
+++ b/cf/test/test_TimeDuration.py
@@ -4,6 +4,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 

--- a/cf/test/test_aggregate.py
+++ b/cf/test/test_aggregate.py
@@ -3,6 +3,9 @@ import os
 import unittest
 import warnings
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 # To facilitate the testing of logging outputs (see test_aggregate_verbosity)

--- a/cf/test/test_cfa.py
+++ b/cf/test/test_cfa.py
@@ -5,6 +5,9 @@ import os
 import stat
 import subprocess
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 

--- a/cf/test/test_collapse.py
+++ b/cf/test/test_collapse.py
@@ -5,6 +5,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 

--- a/cf/test/test_decorators.py
+++ b/cf/test/test_decorators.py
@@ -1,6 +1,9 @@
 import datetime
 import unittest
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 

--- a/cf/test/test_docstring.py
+++ b/cf/test/test_docstring.py
@@ -2,6 +2,9 @@ import datetime
 import inspect
 import unittest
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 import cfdm
 

--- a/cf/test/test_dsg.py
+++ b/cf/test/test_dsg.py
@@ -7,6 +7,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 n_tmpfiles = 1

--- a/cf/test/test_external.py
+++ b/cf/test/test_external.py
@@ -5,6 +5,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 

--- a/cf/test/test_formula_terms.py
+++ b/cf/test/test_formula_terms.py
@@ -1,6 +1,9 @@
 import datetime
 import unittest
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 

--- a/cf/test/test_functions.py
+++ b/cf/test/test_functions.py
@@ -6,6 +6,9 @@ import sys
 import unittest
 import inspect
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 

--- a/cf/test/test_gathering.py
+++ b/cf/test/test_gathering.py
@@ -6,6 +6,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 

--- a/cf/test/test_general.py
+++ b/cf/test/test_general.py
@@ -5,6 +5,9 @@ import numpy
 import unittest
 import atexit
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 

--- a/cf/test/test_geometry.py
+++ b/cf/test/test_geometry.py
@@ -4,8 +4,11 @@ import os
 import tempfile
 import unittest
 
-
 import numpy
+
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import netCDF4
 
 import cf

--- a/cf/test/test_groups.py
+++ b/cf/test/test_groups.py
@@ -4,6 +4,9 @@ import os
 import tempfile
 import unittest
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import netCDF4
 
 import cf

--- a/cf/test/test_pp.py
+++ b/cf/test/test_pp.py
@@ -6,6 +6,9 @@ import unittest
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 n_tmpfiles = 1

--- a/cf/test/test_read_write.py
+++ b/cf/test/test_read_write.py
@@ -9,6 +9,9 @@ import subprocess
 
 import numpy
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 

--- a/cf/test/test_style.py
+++ b/cf/test/test_style.py
@@ -3,6 +3,9 @@ import os
 import pycodestyle
 import unittest
 
+import faulthandler
+faulthandler.enable()  # to debug seg faults and timeouts
+
 import cf
 
 

--- a/setup.py
+++ b/setup.py
@@ -260,7 +260,6 @@ setup(
     ],
     packages=[
         'cf',
-        'cf.abstract',
         'cf.mixin',
         'cf.data',
         'cf.data.abstract',


### PR DESCRIPTION
This PR enables `faulthandler` for each test module, so that we can catch important information about any segmentation faults or timeouts going forward. Note that while [`pytest` enables `faulthandler` by default](https://docs.pytest.org/en/stable/usage.html#fault-handler), tests run under the `unittest` framework do not seem to have it enabled, as demonstrated by the lack of information captured in all previous and recent segmentation faults arising locally and on the CI, hence the need to add lines to explicitly import and enable it

Hopefully we will see very few seg faults once any current issue(s) leading to them are resolved, but it will always be useful to catch detail in the rare case they do occur, hence the permanent addition of these lines.

Adding these changes via a PR rather than a direct commit push to run the CI in order to capture some post-seg-fault traceback that I can use as evidence for a further issue on current seg fault problems across the test suite.