### PR TITLE
Docformatter hooks and docstring standardisation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,22 @@ repos:
       - id: black
         language_version: python3
 
+  # Also format docstrings in a consistent way, on top of 'black' requirements
+  # with the aim to auto-correct towards the Google docstring format (see
+  # https://google.github.io/styleguide/pyguide.html#381-docstrings) as much
+  # as possible (see https://github.com/myint/docformatter for docs, with
+  # configuration as below)
+  - repo: https://github.com/myint/docformatter
+    rev: v1.4
+    hooks:
+      - id: docformatter
+        # These arguments act as the configuration for docformatter. They:
+        # * make docformatter auto-format in-place if not compliant;
+        # * ensure there is a blank line after the final non-empty line;
+        # * wraps both summary and description at 72 characters (the latter
+        #   by default).
+        args: [--in-place, --blank, --wrap-summaries=72]
+
   # Additionally validate againt flake8 for other Python style enforcement
   # (see https://flake8.pycqa.org/en/latest/ for documentation and see
   # the cf-python .flake8 file for our custom flake8 configuration)

--- a/cf/aggregate.py
+++ b/cf/aggregate.py
@@ -79,9 +79,7 @@ _no_units = Units()
 
 class _HFLCache:
     """A cache for coordinate and cell measure hashes, first and last
-    values and first and last cell bounds.
-
-    """
+    values and first and last cell bounds."""
 
     def __init__(self):
         self.hash = {}
@@ -794,7 +792,8 @@ class _Meta:
         return "\n".join(strings)
 
     def coordinate_values(self):
-        """Create a report listing all coordinate cell values and bounds."""
+        """Create a report listing all coordinate cell values and
+        bounds."""
         string = ["First cell: " + str(self.first_values)]
         string.append("Last cell:  " + str(self.last_values))
         string.append("First bounds: " + str(self.first_bounds))
@@ -803,7 +802,8 @@ class _Meta:
         return "\n".join(string)
 
     def copy(self):
-        """Replace the field associated with a summary class with a deep copy."""
+        """Replace the field associated with a summary class with a deep
+        copy."""
         new = _Meta.__new__(_Meta)
         new.__dict__ = self.__dict__.copy()
         new.field = new.field.copy()
@@ -933,7 +933,8 @@ class _Meta:
         return True
 
     def coord_has_identity_and_data(self, coord, axes=None):
-        """Return a coordinate construct's identity if it has one and has data.
+        """Return a coordinate construct's identity if it has one and
+        has data.
 
         :Parameters:
 
@@ -992,7 +993,8 @@ class _Meta:
         return None
 
     def field_ancillary_has_identity_and_data(self, anc):
-        """Return a field ancillary's identity if it has one and has data.
+        """Return a field ancillary's identity if it has one and has
+        data.
 
         :Parameters:
 
@@ -1035,7 +1037,8 @@ class _Meta:
         return None
 
     def coordinate_reference_signatures(self, refs):
-        """List the structural signatures of given coordinate references.
+        """List the structural signatures of given coordinate
+        references.
 
         :Parameters:
 
@@ -1074,7 +1077,8 @@ class _Meta:
         return signatures
 
     def domain_ancillary_has_identity_and_data(self, anc, identity=None):
-        """Return a domain ancillary's identity if it has one and has data.
+        """Return a domain ancillary's identity if it has one and has
+        data.
 
         :Parameters:
 
@@ -1124,7 +1128,8 @@ class _Meta:
 
     @_manage_log_level_via_verbose_attr
     def print_info(self, signature=True):
-        """Log information on the structural signature and coordinate values.
+        """Log information on the structural signature and coordinate
+        values.
 
         :Parameters:
 
@@ -1147,7 +1152,8 @@ class _Meta:
         logger.debug("COMPLETE AGGREGATION METADATA:\n{}".format(self))
 
     def string_structural_signature(self):
-        """Return a multi-line string giving a field's structual signature.
+        """Return a multi-line string giving a field's structual
+        signature.
 
         :Returns:
 
@@ -1358,7 +1364,8 @@ class _Meta:
         )
 
     def find_coordrefs(self, key):
-        """Return all the coordinate references that point to a coordinate.
+        """Return all the coordinate references that point to a
+        coordinate.
 
         :Parameters:
 
@@ -2561,7 +2568,8 @@ def _get_hfl(
     rtol,
     atol,
 ):
-    """Return the hash value, and optionally first and last values or bounds.
+    """Return the hash value, and optionally first and last values or
+    bounds.
 
     :Parameters:
 
@@ -3002,7 +3010,8 @@ def _ok_coordinate_arrays(meta, axis, overlap, contiguous, verbose=None):
 def _aggregate_2_fields(
     m0, m1, rtol=None, atol=None, verbose=None, concatenate=True, copy=True
 ):
-    """Aggregate two fields, returning the _Meta object of the aggregated field.
+    """Aggregate two fields, returning the _Meta object of the
+    aggregated field.
 
     :Parameters:
 

--- a/cf/cellmeasure.py
+++ b/cf/cellmeasure.py
@@ -45,7 +45,7 @@ class CellMeasure(mixin.PropertiesData, cfdm.CellMeasure):
     # ----------------------------------------------------------------
     @property
     def measure(self):
-        """TODO"""
+        """TODO."""
         return self.get_measure(default=AttributeError())
 
     @measure.setter

--- a/cf/cellmethod.py
+++ b/cf/cellmethod.py
@@ -225,19 +225,15 @@ class CellMethod(cfdm.CellMethod):
         return out
 
     def __hash__(self):
-        """
-
-        x.__hash__() <==> hash(x)
-
-        """
+        """x.__hash__() <==> hash(x)"""
         return hash(str(self))
 
     def __eq__(self, y):
-        """x.__eq__(y) <==> x==y"""
+        """x.__eq__(y) <==> x==y."""
         return self.equals(y)
 
     def __ne__(self, other):
-        """x.__ne__(y) <==> x!=y"""
+        """x.__ne__(y) <==> x!=y."""
         return not self.__eq__(other)
 
     @property
@@ -509,7 +505,8 @@ class CellMethod(cfdm.CellMethod):
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     def change_axes(self, axis_map, inplace=False, i=False):
-        """Change the axes of the cell method according to a given mapping.
+        """Change the axes of the cell method according to a given
+        mapping.
 
         :Parameters:
 
@@ -681,7 +678,11 @@ class CellMethod(cfdm.CellMethod):
         )  # pragma: no cover
 
     def remove_axes(self, axes):
-        '''Deprecated at version 3.0.0. Use method 'del_axes' instead."'''
+        """Deprecated at version 3.0.0.
+
+        Use method 'del_axes' instead."
+
+        """
         _DEPRECATION_ERROR_METHOD(
             self, "remove_axes", "Use method 'del_axes' instead."
         )  # pragma: no cover

--- a/cf/cfdatetime.py
+++ b/cf/cfdatetime.py
@@ -28,8 +28,8 @@ _calendar_map = {None: "gregorian"}
 class Datetime(cftime.datetime):
     """A date-time object which supports CF calendars.
 
-    Deprecated at version 3.0.0. Use function 'cf.dt' to create
-    date-time objects instead.
+    Deprecated at version 3.0.0. Use function 'cf.dt' to create date-
+    time objects instead.
 
     """
 
@@ -398,7 +398,7 @@ def st2elements(date_string):
 
 
 def rt2dt(array, units_in, units_out=None, dummy1=None):
-    """Convert reference times  to date-time objects
+    """Convert reference times  to date-time objects.
 
     The returned array is always independent.
 
@@ -438,7 +438,7 @@ def rt2dt(array, units_in, units_out=None, dummy1=None):
 
 
 def dt2Dt(x, calendar=None):
-    """Convert a datetime.datetime object to a cf.Datetime object"""
+    """Convert a datetime.datetime object to a cf.Datetime object."""
     if not x:
         return False
     return dt(x, calendar=calendar)

--- a/cf/cfimplementation.py
+++ b/cf/cfimplementation.py
@@ -34,7 +34,7 @@ from .data import (
 
 
 class CFImplementation(cfdm.CFDMImplementation):
-    """TODO
+    """TODO.
 
     .. versionadded:: 3.0.0
 

--- a/cf/constructs.py
+++ b/cf/constructs.py
@@ -46,7 +46,8 @@ class Constructs(cfdm.Constructs):
         return super().__repr__().replace("<", "<CF ", 1)
 
     def _matching_values(self, value0, construct, value1):
-        """Whether two values match according to equality on a given construct.
+        """Whether two values match according to equality on a given
+        construct.
 
         The definition of "match" depends on the types of *value0* and
         *value1*.
@@ -67,6 +68,7 @@ class Constructs(cfdm.Constructs):
 
             `bool`
                 Whether or not the two values match.
+
         """
         if isinstance(value0, Query):
             return value0.evaluate(value1)

--- a/cf/coordinatereference.py
+++ b/cf/coordinatereference.py
@@ -91,7 +91,8 @@ class CoordinateReference(cfdm.CoordinateReference):
         return instance
 
     def __getitem__(self, key):
-        """Return a parameter value of the datum or the coordinate conversion.
+        """Return a parameter value of the datum or the coordinate
+        conversion.
 
         x.__getitem__(key) <==> x[key]
 
@@ -149,7 +150,8 @@ class CoordinateReference(cfdm.CoordinateReference):
     # Private methods
     # ----------------------------------------------------------------
     def _matching_values(self, value0, value1):
-        """Whether two coordinate reference construct identity values match.
+        """Whether two coordinate reference construct identity values
+        match.
 
         :Parameters:
 
@@ -187,8 +189,8 @@ class CoordinateReference(cfdm.CoordinateReference):
         return cr_coordinates.get(self.identity(), ())
 
     def has_bounds(self):
-        """Returns False since coordinate reference constructs do not have
-        cell bounds.
+        """Returns False since coordinate reference constructs do not
+        have cell bounds.
 
         **Examples:**
 
@@ -231,8 +233,8 @@ class CoordinateReference(cfdm.CoordinateReference):
 
     @classmethod
     def canonical_units(cls, term):
-        """Return the canonical units for a standard CF coordinate conversion
-        term.
+        """Return the canonical units for a standard CF coordinate
+        conversion term.
 
         :Parameters:
 
@@ -255,7 +257,8 @@ class CoordinateReference(cfdm.CoordinateReference):
         return cr_canonical_units.get(term, None)
 
     def close(self):
-        """Close all files referenced by coordinate conversion term values.
+        """Close all files referenced by coordinate conversion term
+        values.
 
         :Returns:
 
@@ -450,7 +453,8 @@ class CoordinateReference(cfdm.CoordinateReference):
         return True
 
     def get(self, key, default=None):
-        """Return a parameter value of the datum or the coordinate conversion.
+        """Return a parameter value of the datum or the coordinate
+        conversion.
 
         .. versionadded:: 3.0.0
 
@@ -582,7 +586,8 @@ class CoordinateReference(cfdm.CoordinateReference):
         inplace=False,
         i=False,
     ):
-        """Change the identifiers of a coordinate reference from a mapping.
+        """Change the identifiers of a coordinate reference from a
+        mapping.
 
         If an identifier is not in the provided mapping then it is
         set to `None` and thus effectively removed from the coordinate
@@ -660,6 +665,7 @@ class CoordinateReference(cfdm.CoordinateReference):
         :Return:
 
             `tuple`
+
         """
         if rtol is None:
             rtol = float(cf_rtol())
@@ -758,8 +764,9 @@ class CoordinateReference(cfdm.CoordinateReference):
 
     @property
     def conversion(self):
-        """Deprecated at version 3.0.0. Use attribute 'coordinate_conversion'
-        instead.
+        """Deprecated at version 3.0.0.
+
+        Use attribute 'coordinate_conversion' instead.
 
         """
         _DEPRECATION_ERROR_ATTRIBUTE(
@@ -781,8 +788,10 @@ class CoordinateReference(cfdm.CoordinateReference):
 
     @property
     def ancillaries(self):
-        """Deprecated at version 3.0.0. Use the
-        'coordinate_conversion.domain_ancillaries' method instead.
+        """Deprecated at version 3.0.0.
+
+        Use the 'coordinate_conversion.domain_ancillaries' method
+        instead.
 
         """
         _DEPRECATION_ERROR_ATTRIBUTE(
@@ -794,8 +803,10 @@ class CoordinateReference(cfdm.CoordinateReference):
 
     @property
     def parameters(self):
-        """Deprecated at version 3.0.0. Use methods
-        'coordinate_conversion.parameters' and 'datum.parameters' instead.
+        """Deprecated at version 3.0.0.
+
+        Use methods 'coordinate_conversion.parameters' and
+        'datum.parameters' instead.
 
         """
         _DEPRECATION_ERROR_ATTRIBUTE(
@@ -806,8 +817,10 @@ class CoordinateReference(cfdm.CoordinateReference):
         )  # pragma: no cover
 
     def clear(self, coordinates=True, parameters=True, ancillaries=True):
-        """Deprecated at version 3.0.0. Use methods
-        'coordinate_conversion.parameters' and 'datum.parameters' instead.
+        """Deprecated at version 3.0.0.
+
+        Use methods 'coordinate_conversion.parameters' and
+        'datum.parameters' instead.
 
         """
         _DEPRECATION_ERROR_METHOD(
@@ -821,6 +834,7 @@ class CoordinateReference(cfdm.CoordinateReference):
         """Return a name.
 
         Deprecated at version 3.0.0. Use the 'identity' method instead.
+
         """
         _DEPRECATION_ERROR_METHOD(
             self, "name", "Use the 'identity' method instead."
@@ -831,7 +845,9 @@ class CoordinateReference(cfdm.CoordinateReference):
         _DEPRECATION_ERROR_METHOD(self, "all_identifiers")  # pragma: no cover
 
     def set_term(self, term_type, term, value):
-        """Deprecated at version 3.0.0. Use method 'datum.set_parameter',
+        """Deprecated at version 3.0.0.
+
+        Use method 'datum.set_parameter',
         'coordinate_conversion.set_parameter' or
         'coordinate_conversion.set_domain_ancillary' instead.
 

--- a/cf/data/abstract/compressedsubarray.py
+++ b/cf/data/abstract/compressedsubarray.py
@@ -63,8 +63,8 @@ class CompressedSubarray(abc.ABC):
 
     @property
     def file(self):
-        """The file on disk which contains the compressed array, or `None` of
-         the array is in memory.
+        """The file on disk which contains the compressed array, or
+        `None` of the array is in memory.
 
         **Examples:**
 
@@ -109,8 +109,8 @@ class CompressedSubarray(abc.ABC):
         print(cf_inspect(self))
 
     def on_disk(self):
-        """True if and only if the compressed array is on disk as opposed to
-        in memory.
+        """True if and only if the compressed array is on disk as
+        opposed to in memory.
 
         **Examples:**
 
@@ -121,7 +121,8 @@ class CompressedSubarray(abc.ABC):
         return not hasattr(self.array, "__array_interface__")
 
     def unique(self):
-        """True if there is only one permanent reference to the array instance."""
+        """True if there is only one permanent reference to the array
+        instance."""
         # Note, from the Python docs for sys.getrefcount:
         # "The count returned is generally one higher than you might expect,
         # because it includes the (temporary) reference as an argument to

--- a/cf/data/abstract/filearray.py
+++ b/cf/data/abstract/filearray.py
@@ -7,7 +7,7 @@ class FileArray(Array):
     """A sub-array stored in a file.
 
     .. note:: Subclasses must define the following methods:
-              `!__getitem__`, `!__str__`, `!close` and `!open`.
+    `!__getitem__`, `!__str__`, `!close` and `!open`.
 
     """
 

--- a/cf/data/cachedarray.py
+++ b/cf/data/cachedarray.py
@@ -114,7 +114,8 @@ class CachedArray(abstract.FileArray):
     # ----------------------------------------------------------------
     @property
     def _partition_dir(self):
-        """The name of the directory containing the file storing the array."""
+        """The name of the directory containing the file storing the
+        array."""
         return self._get_component("_partition_dir")
 
     @property

--- a/cf/data/collapse_functions.py
+++ b/cf/data/collapse_functions.py
@@ -303,7 +303,8 @@ def max_fpartial(out, out1=None, group=False):
 
 
 def max_ffinalise(out, sub_samples=None):
-    """Apply any logic to finalise the collapse to the maximum of an array.
+    """Apply any logic to finalise the collapse to the maximum of an
+    array.
 
     Here mask out any values derived from a too-small sample size.
 
@@ -376,7 +377,8 @@ def min_fpartial(out, out1=None, group=False):
 
 
 def min_ffinalise(out, sub_samples=None):
-    """Apply any logic to finalise the collapse to the minimum of an array.
+    """Apply any logic to finalise the collapse to the minimum of an
+    array.
 
     Here mask out any values derived from a too-small sample size.
 
@@ -505,8 +507,8 @@ def mean_f(a, axis=None, weights=None, masked=False):
 
 
 def mean_fpartial(out, out1=None, group=False):
-    """Return the partial sample size, the partial sum and partial sum of
-    the weights.
+    """Return the partial sample size, the partial sum and partial sum
+    of the weights.
 
     :Parameters:
 
@@ -575,8 +577,8 @@ def mean_ffinalise(out, sub_samples=None):
 # mean_absolute_value
 # --------------------------------------------------------------------
 def mean_abs_f(a, axis=None, weights=None, masked=False):
-    """Return the mean of the absolute array, or the means of the absolute
-    array along an axis.
+    """Return the mean of the absolute array, or the means of the
+    absolute array along an axis.
 
     :Parameters:
 
@@ -733,7 +735,8 @@ def mid_range_fpartial(out, out1=None, group=False):
 
 
 def mid_range_ffinalise(out, sub_samples=None):
-    """Apply any logic to finalise the collapse to the array mid-range value.
+    """Apply any logic to finalise the collapse to the array mid-range
+    value.
 
     Also mask out any values derived from a too-small sample size.
 
@@ -1262,7 +1265,8 @@ def var_fpartial(out, out1=None, group=False):
 
 
 def var_ffinalise(out, sub_samples=None):
-    """Calculate the variance of the array and return it with the sample size.
+    """Calculate the variance of the array and return it with the sample
+    size.
 
     Also mask out any values derived from a too-small sample size.
 
@@ -1343,7 +1347,8 @@ sd_fpartial = var_fpartial
 
 
 def sd_ffinalise(out, sub_samples=None):
-    """Apply any logic to finalise the collapse to the standard deviation.
+    """Apply any logic to finalise the collapse to the standard
+    deviation.
 
     :Parameters:
 

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -1765,8 +1765,8 @@ class Data(Container, cfdm.Data):
         """
 
         def _mirror_slice(index, size):
-            """Return a slice object which creates the reverse of the input
-            slice.
+            """Return a slice object which creates the reverse of the
+            input slice.
 
             The step of the input slice must have a step of `.
 
@@ -2083,7 +2083,8 @@ class Data(Container, cfdm.Data):
         # --- End: if
 
     def _share_lock_files(self, parallelise):
-        """Share the lock files created by each rank for each partition."""
+        """Share the lock files created by each rank for each
+        partition."""
         if parallelise:
             # Only gather the lock files if the subarrays have been
             # gathered between procesors, otherwise this will result
@@ -2100,7 +2101,8 @@ class Data(Container, cfdm.Data):
 
     @classmethod
     def _share_partitions(cls, processed_partitions, parallelise):
-        """Share the partitions processed on each rank with every other rank."""
+        """Share the partitions processed on each rank with every other
+        rank."""
         # Share the partitions processed on each rank with every other
         # rank. If parallelise is False then there is nothing to be done
         if parallelise:
@@ -3491,8 +3493,8 @@ class Data(Container, cfdm.Data):
         origin=0,
         inplace=False,
     ):
-        """Return the data convolved along the given axis with the specified
-        filter.
+        """Return the data convolved along the given axis with the
+        specified filter.
 
         The magnitude of the integral of the filter (i.e. the sum of the
         weights defined by the *weights* parameter) affects the convolved
@@ -4099,8 +4101,8 @@ class Data(Container, cfdm.Data):
 
     @_inplace_enabled(default=False)
     def _asdatetime(self, inplace=False):
-        """Change the internal representation of data array elements from
-        numeric reference times to datetime-like objects.
+        """Change the internal representation of data array elements
+        from numeric reference times to datetime-like objects.
 
         If the calendar has not been set then the default CF calendar will
         be used and the units' and the `calendar` attribute will be
@@ -4159,13 +4161,14 @@ class Data(Container, cfdm.Data):
         return d
 
     def _isdatetime(self):
-        """True if the internal representation is a datetime-like object."""
+        """True if the internal representation is a datetime-like
+        object."""
         return self.dtype.kind == "O" and self.Units.isreftime
 
     @_inplace_enabled(default=False)
     def _asreftime(self, inplace=False):
-        """Change the internal representation of data array elements from
-        datetime-like objects to numeric reference times.
+        """Change the internal representation of data array elements
+        from datetime-like objects to numeric reference times.
 
         If the calendar has not been set then the default CF calendar will
         be used and the units' and the `calendar` attribute will be
@@ -4617,8 +4620,8 @@ class Data(Container, cfdm.Data):
         )
 
     def _binary_operation(self, other, method):
-        """Implement binary arithmetic and comparison operations with the
-        numpy broadcasting rules.
+        """Implement binary arithmetic and comparison operations with
+        the numpy broadcasting rules.
 
         It is called by the binary arithmetic and comparison
         methods, such as `__sub__`, `__imul__`, `__rdiv__`, `__lt__`, etc.
@@ -5644,7 +5647,8 @@ class Data(Container, cfdm.Data):
         return self._binary_operation(other, "__iadd__")
 
     def __radd__(self, other):
-        """The binary arithmetic operation ``+`` with reflected operands
+        """The binary arithmetic operation ``+`` with reflected
+        operands.
 
         x.__radd__(y) <==> y+x
 
@@ -5668,7 +5672,8 @@ class Data(Container, cfdm.Data):
         return self._binary_operation(other, "__isub__")
 
     def __rsub__(self, other):
-        """The binary arithmetic operation ``-`` with reflected operands
+        """The binary arithmetic operation ``-`` with reflected
+        operands.
 
         x.__rsub__(y) <==> y-x
 
@@ -5692,7 +5697,8 @@ class Data(Container, cfdm.Data):
         return self._binary_operation(other, "__imul__")
 
     def __rmul__(self, other):
-        """The binary arithmetic operation ``*`` with reflected operands
+        """The binary arithmetic operation ``*`` with reflected
+        operands.
 
         x.__rmul__(y) <==> y*x
 
@@ -5716,7 +5722,8 @@ class Data(Container, cfdm.Data):
         return self._binary_operation(other, "__idiv__")
 
     def __rdiv__(self, other):
-        """The binary arithmetic operation ``/`` with reflected operands
+        """The binary arithmetic operation ``/`` with reflected
+        operands.
 
         x.__rdiv__(y) <==> y/x
 
@@ -5740,7 +5747,8 @@ class Data(Container, cfdm.Data):
         return self._binary_operation(other, "__ifloordiv__")
 
     def __rfloordiv__(self, other):
-        """The binary arithmetic operation ``//`` with reflected operands
+        """The binary arithmetic operation ``//`` with reflected
+        operands.
 
         x.__rfloordiv__(y) <==> y//x
 
@@ -5765,7 +5773,7 @@ class Data(Container, cfdm.Data):
 
     def __rtruediv__(self, other):
         """The binary arithmetic operation ``/`` (true division) with
-        reflected operands
+        reflected operands.
 
         x.__rtruediv__(y) <==> y/x
 
@@ -5804,7 +5812,7 @@ class Data(Container, cfdm.Data):
 
     def __rpow__(self, other, modulo=None):
         """The binary arithmetic operations ``**`` and ``pow`` with
-        reflected operands
+        reflected operands.
 
         x.__rpow__(y) <==> y**x
 
@@ -5835,7 +5843,8 @@ class Data(Container, cfdm.Data):
         return self._binary_operation(other, "__imod__")
 
     def __rmod__(self, other):
-        """The binary arithmetic operation ``%`` with reflected operands
+        """The binary arithmetic operation ``%`` with reflected
+        operands.
 
         x.__rmod__(y) <==> y % x
 
@@ -5907,7 +5916,7 @@ class Data(Container, cfdm.Data):
         return self._binary_operation(other, "__iand__")
 
     def __rand__(self, other):
-        """The binary bitwise operation ``&`` with reflected operands
+        """The binary bitwise operation ``&`` with reflected operands.
 
         x.__rand__(y) <==> y&x
 
@@ -5931,7 +5940,7 @@ class Data(Container, cfdm.Data):
         return self._binary_operation(other, "__ior__")
 
     def __ror__(self, other):
-        """The binary bitwise operation ``|`` with reflected operands
+        """The binary bitwise operation ``|`` with reflected operands.
 
         x.__ror__(y) <==> y|x
 
@@ -5955,7 +5964,7 @@ class Data(Container, cfdm.Data):
         return self._binary_operation(other, "__ixor__")
 
     def __rxor__(self, other):
-        """The binary bitwise operation ``^`` with reflected operands
+        """The binary bitwise operation ``^`` with reflected operands.
 
         x.__rxor__(y) <==> y^x
 
@@ -5979,7 +5988,7 @@ class Data(Container, cfdm.Data):
         return self._binary_operation(y, "__ilshift__")
 
     def __rlshift__(self, y):
-        """The binary bitwise operation ``<<`` with reflected operands
+        """The binary bitwise operation ``<<`` with reflected operands.
 
         x.__rlshift__(y) <==> y<<x
 
@@ -6003,7 +6012,7 @@ class Data(Container, cfdm.Data):
         return self._binary_operation(y, "__irshift__")
 
     def __rrshift__(self, y):
-        """The binary bitwise operation ``>>`` with reflected operands
+        """The binary bitwise operation ``>>`` with reflected operands.
 
         x.__rrshift__(y) <==> y>>x
 
@@ -6043,7 +6052,8 @@ class Data(Container, cfdm.Data):
         return self._unary_operation("__pos__")
 
     def _all_axis_names(self):
-        """Return a set of all the dimension names in use by the data array.
+        """Return a set of all the dimension names in use by the data
+        array.
 
         Note that the output set includes dimensions of individual
         partitions which are not dimensions of the master data array.
@@ -6073,9 +6083,9 @@ class Data(Container, cfdm.Data):
     def _change_axis_names(self, axis_map):
         """Change the axis names.
 
-        The axis names are arbitrary, so mapping them to another arbitrary
-        collection does not change the data array values, units, nor axis
-        order.
+        The axis names are arbitrary, so mapping them to another
+        arbitrary collection does not change the data array values,
+        units, nor axis order.
 
         """
         # Find any axis names which are not mapped. If there are any,
@@ -6539,9 +6549,7 @@ class Data(Container, cfdm.Data):
         _parallelise_collapse_subspace=True,
         **kwargs
     ):
-        """
-
-        Collapse a subspace of a data array.
+        """Collapse a subspace of a data array.
 
         If set, *weights* and *kwargs* are passed to the function call. If
         there is a *weights* keyword argument then this should either evaluate
@@ -6578,6 +6586,7 @@ class Data(Container, cfdm.Data):
             `list`
 
         **Examples:**
+
         """
 
         ndim = self._ndim
@@ -7216,7 +7225,7 @@ class Data(Container, cfdm.Data):
 
     @property
     def _cyclic(self):
-        """Storage for axis cyclicity"""
+        """Storage for axis cyclicity."""
         return self._custom["_cyclic"]
 
     @_cyclic.setter
@@ -7242,7 +7251,11 @@ class Data(Container, cfdm.Data):
 
     @property
     def _HDF_chunks(self):
-        """The HDF chunksizes. DO NOT CHANGE IN PLACE."""
+        """The HDF chunksizes.
+
+        DO NOT CHANGE IN PLACE.
+
+        """
         return self._custom["_HDF_chunks"]
 
     @_HDF_chunks.setter
@@ -7268,7 +7281,7 @@ class Data(Container, cfdm.Data):
 
     @property
     def _ndim(self):
-        """Storage for the number of dimensions"""
+        """Storage for the number of dimensions."""
         return self._custom["_ndim"]
 
     @_ndim.setter
@@ -8452,7 +8465,8 @@ class Data(Container, cfdm.Data):
     # `arctan2`, AT2 seealso
     @_inplace_enabled(default=False)
     def arctan(self, inplace=False):
-        """Take the trigonometric inverse tangent of the data element-wise.
+        """Take the trigonometric inverse tangent of the data element-
+        wise.
 
         Units are ignored in the calculation. The result has units of radians.
 
@@ -8685,7 +8699,8 @@ class Data(Container, cfdm.Data):
 
     @_inplace_enabled(default=False)
     def arccos(self, inplace=False):
-        """Take the trigonometric inverse cosine of the data element-wise.
+        """Take the trigonometric inverse cosine of the data element-
+        wise.
 
         Units are ignored in the calculation. The result has units of radians.
 
@@ -8863,8 +8878,8 @@ class Data(Container, cfdm.Data):
         return True
 
     def allclose(self, y, rtol=None, atol=None):
-        """Returns True if two broadcastable arrays have equal values, False
-        otherwise.
+        """Returns True if two broadcastable arrays have equal values,
+        False otherwise.
 
         Two real numbers ``x`` and ``y`` are considered equal if
         ``|x-y|<=atol+rtol|y|``, where ``atol`` (the tolerance on absolute
@@ -9165,10 +9180,10 @@ class Data(Container, cfdm.Data):
 
     @classmethod
     def concatenate_data(cls, data_list, axis):
-        """Concatenates a list of Data objects into a single Data object along
-        the specified access (see cf.Data.concatenate for details). In the
-        case that the list contains only one element, that element is
-        simply returned.
+        """Concatenates a list of Data objects into a single Data object
+        along the specified access (see cf.Data.concatenate for
+        details). In the case that the list contains only one element,
+        that element is simply returned.
 
         :Parameters:
 
@@ -9196,10 +9211,10 @@ class Data(Container, cfdm.Data):
 
     @classmethod
     def reconstruct_sectioned_data(cls, sections, cyclic=(), hardmask=None):
-        """Expects a dictionary of Data objects with ordering information as
-        keys, as output by the section method when called with a Data
-        object. Returns a reconstructed cf.Data object with the sections
-        in the original order.
+        """Expects a dictionary of Data objects with ordering
+        information as keys, as output by the section method when called
+        with a Data object. Returns a reconstructed cf.Data object with
+        the sections in the original order.
 
         :Parameters:
 
@@ -10468,6 +10483,7 @@ class Data(Container, cfdm.Data):
         [0 4 4]
         >>> print(d.count((0, 1))
         8
+
         """
         config = self.partition_configuration(readonly=True)
 
@@ -10570,7 +10586,7 @@ class Data(Container, cfdm.Data):
         """Provides datetime components of the data array elements.
 
         .. seealso:: `~cf.Data.year`, ~cf.Data.month`, `~cf.Data.day`,
-                     `~cf.Data.hour`, `~cf.Data.minute`, `~cf.Data.second`
+        `~cf.Data.hour`, `~cf.Data.minute`, `~cf.Data.second`
 
         """
 
@@ -10849,7 +10865,8 @@ class Data(Container, cfdm.Data):
 
     @_display_or_return
     def dump(self, display=True, prefix=None):
-        """Return a string containing a full description of the instance.
+        """Return a string containing a full description of the
+        instance.
 
         :Parameters:
 
@@ -11671,7 +11688,7 @@ class Data(Container, cfdm.Data):
                     yield cf_masked
 
     def flatten(self, axes=None, inplace=False):
-        """Flatten axes of the data
+        """Flatten axes of the data.
 
         Any subset of the axes may be flattened.
 
@@ -12077,8 +12094,8 @@ class Data(Container, cfdm.Data):
                 partition.close()
 
     def to_memory(self, regardless=False, parallelise=False):
-        """Store each partition's data in memory in place if the
-        master array is smaller than the chunk size.
+        """Store each partition's data in memory in place if the master
+        array is smaller than the chunk size.
 
         There is no change to partitions with data that are already in memory.
 
@@ -12144,7 +12161,8 @@ class Data(Container, cfdm.Data):
         return True
 
     def partition_boundaries(self):
-        """Return the partition boundaries for each partition matrix dimension.
+        """Return the partition boundaries for each partition matrix
+        dimension.
 
         :Returns:
 
@@ -12180,7 +12198,8 @@ class Data(Container, cfdm.Data):
         return config
 
     def datum(self, *index):
-        """Return an element of the data array as a standard Python scalar.
+        """Return an element of the data array as a standard Python
+        scalar.
 
         The first and last elements are always returned with
         ``d.datum(0)`` and ``d.datum(-1)`` respectively, even if the data
@@ -12398,8 +12417,8 @@ class Data(Container, cfdm.Data):
 
     @classmethod
     def masked_all(cls, shape, dtype=None, units=None, chunk=True):
-        """Return a new data array of given shape and type with all elements
-        masked.
+        """Return a new data array of given shape and type with all
+        elements masked.
 
         .. seealso:: `empty`, `ones`, `zeros`
 
@@ -12445,8 +12464,8 @@ class Data(Container, cfdm.Data):
         _preserve_partitions=False,
         i=False,
     ):
-        """Collapse axes with the unweighted average of their maximum and
-        minimum values.
+        """Collapse axes with the unweighted average of their maximum
+        and minimum values.
 
         Missing data array elements are omitted from the calculation.
 
@@ -12621,8 +12640,8 @@ class Data(Container, cfdm.Data):
         print(cf_inspect(self))  # pragma: no cover
 
     def isclose(self, y, rtol=None, atol=None):
-        """Return where data are element-wise equal to other, broadcastable
-        data.
+        """Return where data are element-wise equal to other,
+        broadcastable data.
 
         {{equals tolerance}}
 
@@ -12805,9 +12824,8 @@ class Data(Container, cfdm.Data):
 
     @_deprecated_kwarg_check("i")
     def round(self, decimals=0, inplace=False, i=False):
-        """Evenly round elements of the data array to the given number of
-        decimals.
-
+        """Evenly round elements of the data array to the given number
+        of decimals.
 
         Values exactly halfway between rounded decimal values are rounded
         to the nearest even value. Thus 1.5 and 2.5 round to 2.0, -0.5 and
@@ -13113,16 +13131,19 @@ class Data(Container, cfdm.Data):
         return d
 
     def save_to_disk(self, itemsize=None):
-        """cf.Data.save_to_disk is dead. Use not cf.Data.fits_in_memory
-        instead."""
+        """cf.Data.save_to_disk is dead.
+
+        Use not cf.Data.fits_in_memory instead.
+
+        """
         raise NotImplementedError(
             "cf.Data.save_to_disk is dead. Use not "
             "cf.Data.fits_in_memory instead."
         )
 
     def fits_in_memory(self, itemsize):
-        """Return True if the master array is small enough to be retained in
-        memory.
+        """Return True if the master array is small enough to be
+        retained in memory.
 
         :Parameters:
 
@@ -13146,8 +13167,8 @@ class Data(Container, cfdm.Data):
         return self._size * (itemsize + 1) <= free_memory() - cf_fm_threshold()
 
     def fits_in_one_chunk_in_memory(self, itemsize):
-        """Return True if the master array is small enough to be retained in
-        memory.
+        """Return True if the master array is small enough to be
+        retained in memory.
 
         :Parameters:
 
@@ -13307,8 +13328,8 @@ class Data(Container, cfdm.Data):
         # --- End: def
 
         def _is_broadcastable(data0, data1, do_not_broadcast, is_scalar):
-            """Check that the data1 is broadcastable to data0 and
-            return data1, as a python scalar if possible.
+            """Check that the data1 is broadcastable to data0 and return
+            data1, as a python scalar if possible.
 
             .. note:: The input lists are updated inplace.
 
@@ -14329,8 +14350,8 @@ class Data(Container, cfdm.Data):
         calendar=None,
         chunk=True,
     ):
-        """Returns a new data array of given shape and type, filled with the
-        given value.
+        """Returns a new data array of given shape and type, filled with
+        the given value.
 
         .. seealso:: `empty`, `ones`, `zeros`
 
@@ -14373,14 +14394,16 @@ class Data(Container, cfdm.Data):
 
     @classmethod
     def ones(cls, shape, dtype=None, units=None, calendar=None, chunk=True):
-        """Returns a new array filled with ones of set shape and type."""
+        """Returns a new array filled with ones of set shape and
+        type."""
         return cls.full(
             shape, 1, dtype=dtype, units=units, calendar=calendar, chunk=chunk
         )
 
     @classmethod
     def zeros(cls, shape, dtype=None, units=None, calendar=None, chunk=True):
-        """Returns a new array filled with zeros of set shape and type."""
+        """Returns a new array filled with zeros of set shape and
+        type."""
         return cls.full(
             shape, 0, dtype=dtype, units=units, calendar=calendar, chunk=chunk
         )
@@ -14508,8 +14531,8 @@ class Data(Container, cfdm.Data):
         _preserve_partitions=False,
         i=False,
     ):
-        """Collapse axes with the absolute difference between their maximum
-        and minimum values.
+        """Collapse axes with the absolute difference between their
+        maximum and minimum values.
 
         Missing data array elements are omitted from the calculation.
 
@@ -15076,13 +15099,13 @@ class Data(Container, cfdm.Data):
     def section(
         self, axes, stop=None, chunks=False, min_step=1, mode="dictionary"
     ):
-        """Return a dictionary of Data objects, which are the m dimensional
-        sections of this n dimensional Data object, where m <= n. The keys
-        of the dictionary are the indices of the sections in the original
-        Data object. The m dimensions that are not sliced are marked with
-        None as a placeholder making it possible to reconstruct the
-        original data object. The corresponding values are the resulting
-        sections of type `Data`.
+        """Return a dictionary of Data objects, which are the m
+        dimensional sections of this n dimensional Data object, where m
+        <= n. The keys of the dictionary are the indices of the sections
+        in the original Data object. The m dimensions that are not
+        sliced are marked with None as a placeholder making it possible
+        to reconstruct the original data object. The corresponding
+        values are the resulting sections of type `Data`.
 
         :Parameters:
 
@@ -15234,7 +15257,8 @@ class Data(Container, cfdm.Data):
         _DEPRECATION_ERROR_ATTRIBUTE(self, "dtvarray")  # pragma: no cover
 
     def files(self):
-        """Deprecated at version 3.4.0, use method `get_filenames` instead."""
+        """Deprecated at version 3.4.0, use method `get_filenames`
+        instead."""
         _DEPRECATION_ERROR_METHOD(
             self,
             "files",
@@ -15244,13 +15268,15 @@ class Data(Container, cfdm.Data):
 
     @property
     def unsafe_array(self):
-        """Deprecated at version 3.0.0, use `array` attribute instead."""
+        """Deprecated at version 3.0.0, use `array` attribute
+        instead."""
         _DEPRECATION_ERROR_ATTRIBUTE(
             self, "unsafe_array", "Use 'array' attribute instead."
         )  # pragma: no cover
 
     def expand_dims(self, position=0, i=False):
-        """Deprecated at version 3.0.0, use method `insert_dimension` instead."""
+        """Deprecated at version 3.0.0, use method `insert_dimension`
+        instead."""
         _DEPRECATION_ERROR_METHOD(
             self,
             "expand_dims",
@@ -15449,14 +15475,14 @@ def _broadcast(a, shape):
 
 
 class AuxiliaryMask:
-    """TODO"""
+    """TODO."""
 
     def __init__(self):
-        """TODO"""
+        """TODO."""
         self._mask = []
 
     def __getitem__(self, indices):
-        """TODO"""
+        """TODO."""
         new = type(self)()
 
         for mask in self._mask:
@@ -15473,19 +15499,19 @@ class AuxiliaryMask:
     # ----------------------------------------------------------------
     @property
     def ndim(self):
-        """TODO"""
+        """TODO."""
         return self._mask[0].ndim
 
     @property
     def dtype(self):
-        """TODO"""
+        """TODO."""
         return self._mask[0].dtype
 
     # ----------------------------------------------------------------
     # Methods
     # ----------------------------------------------------------------
     def append(self, mask):
-        """TODO"""
+        """TODO."""
         self._mask.append(mask)
 
 

--- a/cf/data/filledarray.py
+++ b/cf/data/filledarray.py
@@ -136,6 +136,7 @@ class FilledArray(abstract.Array):
         0
         >>> a.size
         1
+
         """
         return self._get_component("ndim")
 
@@ -165,6 +166,7 @@ class FilledArray(abstract.Array):
         0
         >>> a.size
         1
+
         """
         return self._get_component("shape")
 

--- a/cf/data/netcdfarray.py
+++ b/cf/data/netcdfarray.py
@@ -111,7 +111,8 @@ class NetCDFArray(cfdm.NetCDFArray, abstract.FileArray):
 
     @property
     def file_pointer(self):
-        """The file pointer starting at the position of the netCDF variable."""
+        """The file pointer starting at the position of the netCDF
+        variable."""
         offset = getattr(self, "ncvar", None)
         if offset is None:
             offset = self.varid
@@ -135,8 +136,8 @@ class NetCDFArray(cfdm.NetCDFArray, abstract.FileArray):
         _close_netcdf_file(self.get_filename())
 
     def open(self):
-        """Return a `netCDF4.Dataset` object for the file containing the data
-        array.
+        """Return a `netCDF4.Dataset` object for the file containing the
+        data array.
 
         :Returns:
 

--- a/cf/data/partition.py
+++ b/cf/data/partition.py
@@ -446,8 +446,8 @@ class Partition:
         self._add_to_file_counter(1)
 
     def _decrement_file_counter(self):
-        """Subtract 1 from the Partition.file_counter if self._subarray is an
-        instance of FileArray and not a temporary FileArray.
+        """Subtract 1 from the Partition.file_counter if self._subarray
+        is an instance of FileArray and not a temporary FileArray.
 
         :Returns:
 
@@ -607,12 +607,13 @@ class Partition:
 
     @property
     def dtype(self):
-        """The data type of the master array"""
+        """The data type of the master array."""
         return self.config["dtype"]
 
     @property
     def isscalar(self):
-        """True if and only if the partition's data array is a scalar array.
+        """True if and only if the partition's data array is a scalar
+        array.
 
         **Examples:**
 
@@ -633,8 +634,9 @@ class Partition:
     def nbytes(self):
         """The size in bytes of the subarray.
 
-        The size takes into account the datatype and assumes that there is
-        a boolean mask, unless it can be ascertained that there isn't one.
+        The size takes into account the datatype and assumes that there
+        is a boolean mask, unless it can be ascertained that there isn't
+        one.
 
         """
         dtype = self.config["dtype"]
@@ -656,7 +658,8 @@ class Partition:
 
     @property
     def size(self):
-        """Number of elements in the partition's data array (not its subarray).
+        """Number of elements in the partition's data array (not its
+        subarray).
 
         **Examples:**
 
@@ -1368,8 +1371,8 @@ class Partition:
         )  # TODO check
 
     def new_part(self, indices, master_axis_to_position, master_flip):
-        """Update the `!part` attribute in-place for new indices of the master
-        array.
+        """Update the `!part` attribute in-place for new indices of the
+        master array.
 
         :Parameters:
 
@@ -1654,7 +1657,8 @@ class Partition:
         return config
 
     def overlaps(self, indices):
-        """Return True if the subarray overlaps a subspace of the master array.
+        """Return True if the subarray overlaps a subspace of the master
+        array.
 
         :Parameters:
 
@@ -1837,8 +1841,8 @@ class Partition:
     #        return True
 
     def revert(self):
-        """Completely update the partition with another partition's attributes
-        in place.
+        """Completely update the partition with another partition's
+        attributes in place.
 
         The updated partition is always dependent of the other partition.
 
@@ -1905,10 +1909,8 @@ class Partition:
     #     self.__dict__ = other.__dict__
 
     def _register_temporary_file(self):
-        """Register a temporary file on this rank that has been created on
-        another rank
-
-        """
+        """Register a temporary file on this rank that has been created
+        on another rank."""
         _partition_file = self._subarray._partition_file
         _partition_dir = self._subarray._partition_dir
         if _partition_file not in _temporary_files:
@@ -1927,10 +1929,8 @@ class Partition:
         return _lock_file
 
     def _update_lock_files(self, lock_files):
-        """Add the lock files listed in lock_files to the list of lock files
-        managed by other ranks
-
-        """
+        """Add the lock files listed in lock_files to the list of lock
+        files managed by other ranks."""
         _, _lock_file, _other_lock_files = _temporary_files[
             self._subarray._partition_file
         ]

--- a/cf/data/partitionmatrix.py
+++ b/cf/data/partitionmatrix.py
@@ -19,9 +19,7 @@ _empty_matrix = numpy_empty((), dtype=object)
 
 
 class PartitionMatrix:
-    """
-
-    A hyperrectangular partition matrix of a master data array.
+    """A hyperrectangular partition matrix of a master data array.
 
     Each of elements (called partitions) span all or part of exactly one
     sub-array of the master data array.
@@ -43,6 +41,7 @@ class PartitionMatrix:
     `!shape`    List of the partition matrix's dimension sizes.
     `!size`     The number of partitions in the partition matrix.
     ==========  ===========================================================
+
     """
 
     def __init__(self, matrix, axes):
@@ -128,7 +127,7 @@ class PartitionMatrix:
         return "<CF %s: %s>" % (self.__class__.__name__, self.shape)
 
     def __setitem__(self, indices, value):
-        """x.__setitem__(indices, y) <==> x[indices]=y
+        """x.__setitem__(indices, y) <==> x[indices]=y.
 
         Indices must be an integer, a slice object or a tuple. If a slice
         object is given then the value being assigned must be an
@@ -551,7 +550,8 @@ class PartitionMatrix:
         return p
 
     def ndenumerate(self):
-        """Return an iterator yielding pairs of array indices and values.
+        """Return an iterator yielding pairs of array indices and
+        values.
 
         :Returns:
 
@@ -655,8 +655,8 @@ class PartitionMatrix:
 
     # 0
     def set_location_map(self, data_axes, ns=None):
-        """Set the `!location` attribute of each partition of the partition
-        matrix in place.
+        """Set the `!location` attribute of each partition of the
+        partition matrix in place.
 
         :Parameters:
 
@@ -776,7 +776,8 @@ class PartitionMatrix:
 
     @_inplace_enabled(default=False)
     def transpose(self, axes, inplace=False):
-        """Permute the partition dimensions of the partition matrix in place.
+        """Permute the partition dimensions of the partition matrix in
+        place.
 
         Note that this does not change the master data array.
 

--- a/cf/decorators.py
+++ b/cf/decorators.py
@@ -22,7 +22,8 @@ _display_or_return = cfdm._display_or_return
 
 # @_deprecated_kwarg_check('i') -> example usage for decorating, using i kwarg
 def _deprecated_kwarg_check(*depr_kwargs):
-    """A wrapper for provision of positional arguments to the decorator."""
+    """A wrapper for provision of positional arguments to the
+    decorator."""
 
     def deprecated_kwarg_check_decorator(operation_method):
         """A decorator for a deprecation check on given kwargs.
@@ -75,7 +76,8 @@ def _deprecated_kwarg_check(*depr_kwargs):
 # most methods of the class (any that contain log calls should have it).
 # But this (explicit) approach may be better?
 def _manage_log_level_via_verbose_attr(method_using_verbose_attr, calls=[0]):
-    """A decorator for managing log message filtering by verbose attribute.
+    """A decorator for managing log message filtering by verbose
+    attribute.
 
     Note this has identical purpose to _manage_log_level_via_verbosity except
     it adapts the log level based on a verbose attribute of the class
@@ -99,6 +101,7 @@ def _manage_log_level_via_verbose_attr(method_using_verbose_attr, calls=[0]):
     completion of decorated functions that are called inside other decorated
     functions (see comments in 'finally' statement for further explanation).
     Note (when it is of concern) that this approach may not be thread-safe.
+
     """
 
     @wraps(method_using_verbose_attr)

--- a/cf/dimensioncoordinate.py
+++ b/cf/dimensioncoordinate.py
@@ -89,7 +89,8 @@ class DimensionCoordinate(
         return ((mx // period) * period).squeeze()
 
     def _infer_direction(self):
-        """Return True if a coordinate is increasing, otherwise return False.
+        """Return True if a coordinate is increasing, otherwise return
+        False.
 
         A dimension coordinate construct is considered to be increasing if
         its data array values are increasing in index space, or if it has
@@ -201,7 +202,8 @@ class DimensionCoordinate(
 
     @property
     def decreasing(self):
-        """True if the dimension coordinate is decreasing, otherwise False.
+        """True if the dimension coordinate is decreasing, otherwise
+        False.
 
         A dimension coordinate is increasing if its coordinate values are
         increasing in index space.
@@ -229,7 +231,8 @@ class DimensionCoordinate(
 
     @property
     def increasing(self):
-        """`True` for dimension coordinate constructs, `False` otherwise.
+        """`True` for dimension coordinate constructs, `False`
+        otherwise.
 
         A dimension coordinate is increasing if its coordinate values are
         increasing in index space.
@@ -319,8 +322,8 @@ class DimensionCoordinate(
     #        return data[..., i].squeeze(1)
 
     def direction(self):
-        """Return True if the dimension coordinate values are increasing,
-        otherwise return False.
+        """Return True if the dimension coordinate values are
+        increasing, otherwise return False.
 
         Dimension coordinates values are increasing if its coordinate
         values are increasing in index space.
@@ -685,7 +688,8 @@ class DimensionCoordinate(
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     def flip(self, axes=None, inplace=False, i=False):
-        """Flips the dimension coordinate, that is reverses its direction."""
+        """Flips the dimension coordinate, that is reverses its
+        direction."""
         d = _inplace_enabled_define_and_cleanup(self)
         super(DimensionCoordinate, d).flip(axes=axes, inplace=True)
 
@@ -890,9 +894,7 @@ class DimensionCoordinate(
     @property
     def role(self):
         """Deprecated at version 3.0.0, use `construct_type` attribute
-        instead.
-
-        """
+        instead."""
         _DEPRECATION_ERROR_ATTRIBUTE(
             self, "role", "Use attribute 'construct_type' instead"
         )  # pragma: no cover

--- a/cf/domainaxis.py
+++ b/cf/domainaxis.py
@@ -100,9 +100,11 @@ class DomainAxis(cfdm.DomainAxis):
         return new
 
     def __radd__(self, other):
-        """The binary arithmetic operation ``+`` with reflected operands.
+        """The binary arithmetic operation ``+`` with reflected
+        operands.
 
         x.__radd__(y) <==> y+x
+
         """
         return self + other
 

--- a/cf/field.py
+++ b/cf/field.py
@@ -601,7 +601,7 @@ class Field(mixin.PropertiesData, cfdm.Field):
         return super().__repr__().replace("<", "<CF ", 1)
 
     def __setitem__(self, indices, value):
-        """Called to implement assignment to x[indices]=value
+        """Called to implement assignment to x[indices]=value.
 
         x.__setitem__(indices, value) <==> x[indices]=value
 
@@ -900,8 +900,8 @@ class Field(mixin.PropertiesData, cfdm.Field):
         return True
 
     def _binary_operation_old(self, other, method):
-        """Implement binary arithmetic and comparison operations on the master
-        data array with metadata-aware broadcasting.
+        """Implement binary arithmetic and comparison operations on the
+        master data array with metadata-aware broadcasting.
 
         It is intended to be called by the binary arithmetic and
         comparison methods, such as `__sub__`, `__imul__`, `__rdiv__`,
@@ -1882,8 +1882,8 @@ class Field(mixin.PropertiesData, cfdm.Field):
         return field0
 
     def _binary_operation(self, other, method):
-        """Implement binary arithmetic and comparison operations on the master
-        data array with metadata-aware broadcasting.
+        """Implement binary arithmetic and comparison operations on the
+        master data array with metadata-aware broadcasting.
 
         It is intended to be called by the binary arithmetic and
         comparison methods, such as `__sub__`, `__imul__`, `__rdiv__`,
@@ -2444,8 +2444,8 @@ class Field(mixin.PropertiesData, cfdm.Field):
         return field0
 
     def _conform_coordinate_references(self, key, coordref=None):
-        """Where possible replace the content of coordiante refence construct
-        coordinates with coordinate construct keys.
+        """Where possible replace the content of coordiante refence
+        construct coordinates with coordinate construct keys.
 
         .. versionadded:: 3.0.0
 
@@ -2484,7 +2484,8 @@ class Field(mixin.PropertiesData, cfdm.Field):
         # --- End: for
 
     def _coordinate_reference_axes(self, key):
-        """Returns the field's set of coordinate reference axes for a key.
+        """Returns the field's set of coordinate reference axes for a
+        key.
 
         :Parameters:
 
@@ -3145,9 +3146,9 @@ class Field(mixin.PropertiesData, cfdm.Field):
     # Worker functions for regridding
     # ----------------------------------------------------------------
     def _regrid_get_latlong(self, name, axes=None):
-        """Retrieve the latitude and longitude coordinates of this field and
-        associated information. If 1D lat/long coordinates are found then
-        these are returned. Otherwise, 2D lat/long coordinates are
+        """Retrieve the latitude and longitude coordinates of this field
+        and associated information. If 1D lat/long coordinates are found
+        then these are returned. Otherwise, 2D lat/long coordinates are
         searched for and if found returned.
 
         :Parameters:
@@ -3396,8 +3397,8 @@ class Field(mixin.PropertiesData, cfdm.Field):
         return axis_keys, axis_sizes, coord_keys, coords, coords_2D
 
     def _regrid_get_cartesian_coords(self, name, axes):
-        """Retrieve the specified cartesian dimension coordinates of the field
-        and their corresponding keys.
+        """Retrieve the specified cartesian dimension coordinates of the
+        field and their corresponding keys.
 
         :Parameters:
 
@@ -3485,7 +3486,8 @@ class Field(mixin.PropertiesData, cfdm.Field):
         return axis_indices, order
 
     def _regrid_get_coord_order(self, axis_keys, coord_keys):
-        """Get the ordering of the axes for each N-D auxiliary coordinate.
+        """Get the ordering of the axes for each N-D auxiliary
+        coordinate.
 
         :Parameters:
 
@@ -3542,8 +3544,8 @@ class Field(mixin.PropertiesData, cfdm.Field):
     def _regrid_check_bounds(
         cls, src_coords, dst_coords, method, ext_coords=None
     ):
-        """Check the bounds of the coordinates for regridding and reassign the
-        regridding method if auto is selected.
+        """Check the bounds of the coordinates for regridding and
+        reassign the regridding method if auto is selected.
 
         :Parameters:
 
@@ -3651,9 +3653,9 @@ class Field(mixin.PropertiesData, cfdm.Field):
     def _regrid_get_reordered_sections(
         self, axis_order, regrid_axes, regrid_axis_indices
     ):
-        """Get a dictionary of the data sections for regridding and a list of
-        its keys reordered if necessary so that they will be looped over
-        in the order specified in axis_order.
+        """Get a dictionary of the data sections for regridding and a
+        list of its keys reordered if necessary so that they will be
+        looped over in the order specified in axis_order.
 
         :Parameters:
 
@@ -3769,8 +3771,8 @@ class Field(mixin.PropertiesData, cfdm.Field):
         return dst_mask
 
     def _regrid_fill_fields(self, src_data, srcfield, dstfield):
-        """Fill the source field with data and the destination field with fill
-        values.
+        """Fill the source field with data and the destination field
+        with fill values.
 
         :Parameters:
 
@@ -3800,8 +3802,8 @@ class Field(mixin.PropertiesData, cfdm.Field):
         dstgrid,
         dstfield,
     ):
-        """Compute the field mass for conservative regridding. The mass should
-        be the same before and after regridding.
+        """Compute the field mass for conservative regridding. The mass
+        should be the same before and after regridding.
 
         :Parameters:
 
@@ -3855,8 +3857,8 @@ class Field(mixin.PropertiesData, cfdm.Field):
     def _regrid_get_regridded_data(
         self, method, fracfield, dstfield, dstfracfield
     ):
-        """Get the regridded data of frac field as a numpy array from the
-        ESMPy fields.
+        """Get the regridded data of frac field as a numpy array from
+        the ESMPy fields.
 
         :Parameters:
 
@@ -3907,7 +3909,8 @@ class Field(mixin.PropertiesData, cfdm.Field):
         src_cyclic=False,
         dst_cyclic=False,
     ):
-        """Update the coordinate references of the new field after regridding.
+        """Update the coordinate references of the new field after
+        regridding.
 
         :Parameters:
 
@@ -4022,8 +4025,8 @@ class Field(mixin.PropertiesData, cfdm.Field):
         # --- End: for
 
     def _regrid_copy_coordinate_references(self, dst, dst_axis_keys):
-        """Copy coordinate references from the destination field to the new,
-        regridded field.
+        """Copy coordinate references from the destination field to the
+        new, regridded field.
 
         :Parameters:
 
@@ -4050,8 +4053,8 @@ class Field(mixin.PropertiesData, cfdm.Field):
 
     @classmethod
     def _regrid_use_bounds(cls, method):
-        """Returns whether to use the bounds or not in regridding. This is
-        only the case for conservative regridding.
+        """Returns whether to use the bounds or not in regridding. This
+        is only the case for conservative regridding.
 
         :Parameters:
 
@@ -5113,8 +5116,8 @@ class Field(mixin.PropertiesData, cfdm.Field):
         return True
 
     def _weights_interior_angle(self, data_lambda, data_phi):
-        """Find the interior angle between each adjacent pair of geometry
-        nodes defined on a sphere.
+        """Find the interior angle between each adjacent pair of
+        geometry nodes defined on a sphere.
 
         The interior angle of two points on the sphere is calculated with
         a special case of the Vincenty formula
@@ -5273,7 +5276,7 @@ class Field(mixin.PropertiesData, cfdm.Field):
     def _weights_measure(
         self, measure, comp, weights_axes, methods=False, auto=False
     ):
-        """Cell measure weights
+        """Cell measure weights.
 
         :Parameters:
 
@@ -6160,8 +6163,8 @@ class Field(mixin.PropertiesData, cfdm.Field):
         return w
 
     def radius(self, default=None):
-        """Return the radius used for calculating cell areas in spherical
-        polar coordinates.
+        """Return the radius used for calculating cell areas in
+        spherical polar coordinates.
 
         The radius is taken from the datums of any coordinate reference
         constucts, but if and only if this is not possible then a default
@@ -6267,8 +6270,8 @@ class Field(mixin.PropertiesData, cfdm.Field):
         return r
 
     def map_axes(self, other):
-        """Map the axis identifiers of the field to their equivalent axis
-        identifiers of another.
+        """Map the axis identifiers of the field to their equivalent
+        axis identifiers of another.
 
         :Parameters:
 
@@ -11315,7 +11318,8 @@ class Field(mixin.PropertiesData, cfdm.Field):
             group_by,
             extra_condition=None,
         ):
-            """Prepares for a collapse where the group is a TimeDuration.
+            """Prepares for a collapse where the group is a
+            TimeDuration.
 
             :Parameters:
 
@@ -11471,7 +11475,8 @@ class Field(mixin.PropertiesData, cfdm.Field):
             group_by,
             extra_condition=None,
         ):
-            """Prepares for a collapse where the group is a data interval.
+            """Prepares for a collapse where the group is a data
+            interval.
 
             :Returns:
 
@@ -11626,7 +11631,8 @@ class Field(mixin.PropertiesData, cfdm.Field):
             return classification
 
         def _discern_runs_within(classification, coord):
-            """Processes group classification for a 'within' collapse."""
+            """Processes group classification for a 'within'
+            collapse."""
             size = classification.size
             if size < 2:
                 return classification
@@ -11647,7 +11653,8 @@ class Field(mixin.PropertiesData, cfdm.Field):
             return classification
 
         def _tyu(coord, group_by, time_interval):
-            """Returns bounding values and limits for a general collapse.
+            """Returns bounding values and limits for a general
+            collapse.
 
             :Parameters:
 
@@ -12812,7 +12819,8 @@ class Field(mixin.PropertiesData, cfdm.Field):
         return True
 
     def directions(self):
-        """Return a dictionary mapping all domain axes to their directions.
+        """Return a dictionary mapping all domain axes to their
+        directions.
 
         .. seealso:: `direction`
 
@@ -15305,6 +15313,7 @@ class Field(mixin.PropertiesData, cfdm.Field):
         >>> g = f.cumsum('latitude', masked_as_zero=True)
         >>> g = f.cumsum('latitude', coordinate='mid_range')
         >>> f.cumsum('latitude', inplace=True)
+
         """
         # Retrieve the axis
         axis_key = self.domain_axis(axis, key=True)
@@ -17790,8 +17799,8 @@ class Field(mixin.PropertiesData, cfdm.Field):
         return out
 
     def get_data_axes(self, identity=None, default=ValueError()):
-        """Return the keys of the domain axis constructs spanned by the data
-        of a metadata construct.
+        """Return the keys of the domain axis constructs spanned by the
+        data of a metadata construct.
 
         .. versionadded:: 3.0.0
 
@@ -19763,7 +19772,8 @@ class Field(mixin.PropertiesData, cfdm.Field):
         i=False,
         _compute_field_mass=None,
     ):
-        """Return the field regridded onto a new latitude-longitude grid.
+        """Return the field regridded onto a new latitude-longitude
+        grid.
 
         Regridding, also called remapping or interpolation, is the process
         of changing the grid underneath field data values while preserving
@@ -21647,19 +21657,24 @@ class Field(mixin.PropertiesData, cfdm.Field):
 
     @property
     def Items(self):
-        """Deprecated at version 3.0.0. Use attribute `constructs` instead."""
+        """Deprecated at version 3.0.0.
+
+        Use attribute `constructs` instead.
+
+        """
         _DEPRECATION_ERROR_ATTRIBUTE(
             self, "Items", "Use 'constructs' attribute instead."
         )  # pragma: no cover
 
     def CM(self, xxx):
-        """Deprecated at version 3.0.0"""
+        """Deprecated at version 3.0.0."""
         _DEPRECATION_ERROR_METHOD(self, "CM")  # pragma: no cover
 
     def axis_name(self, *args, **kwargs):
         """Return the canonical name for an axis.
 
-        Deprecated at version 3.0.0. Use `domain_axis_identity` method instead.
+        Deprecated at version 3.0.0. Use `domain_axis_identity` method
+        instead.
 
         """
         _DEPRECATION_ERROR_METHOD(
@@ -21704,7 +21719,8 @@ class Field(mixin.PropertiesData, cfdm.Field):
     def expand_dims(self, position=0, axes=None, i=False, **kwargs):
         """Insert a size 1 axis into the data array.
 
-        Deprecated at version 3.0.0. Use `insert_dimension` method instead.
+        Deprecated at version 3.0.0. Use `insert_dimension` method
+        instead.
 
         """
         _DEPRECATION_ERROR_METHOD(
@@ -21735,7 +21751,9 @@ class Field(mixin.PropertiesData, cfdm.Field):
         )  # pragma: no cover
 
     def HDF_chunks(self, *chunksizes):
-        """Deprecated at version 3.0.0. Use methods 'Data.nc_hdf5_chunksizes',
+        """Deprecated at version 3.0.0.
+
+        Use methods 'Data.nc_hdf5_chunksizes',
         'Data.nc_set_hdf5_chunksizes', 'Data.nc_clear_hdf5_chunksizes'
         instead.
 
@@ -21818,6 +21836,7 @@ class Field(mixin.PropertiesData, cfdm.Field):
         """Insert a domain ancillary object into the field.
 
         Deprecated at version 3.0.0. Use method 'set_construct' instead.
+
         """
         _DEPRECATION_ERROR_METHOD(
             self, "insert_domain_anc", "Use method 'set_construct' instead."
@@ -21838,7 +21857,8 @@ class Field(mixin.PropertiesData, cfdm.Field):
     ):
         """Insert a field ancillary object into the field.
 
-        Deprecated at version 3.0.0. Use method 'set_construct' instead.g
+        Deprecated at version 3.0.0. Use method 'set_construct'
+        instead.g
 
         """
         _DEPRECATION_ERROR_METHOD(
@@ -21875,7 +21895,8 @@ class Field(mixin.PropertiesData, cfdm.Field):
     ):
         """Return the axes of a domain item of the field.
 
-        Deprecated at version 3.0.0. Use the 'get_data_axes' method instead.
+        Deprecated at version 3.0.0. Use the 'get_data_axes' method
+        instead.
 
         """
         _DEPRECATION_ERROR_METHOD(
@@ -22015,9 +22036,10 @@ class Field(mixin.PropertiesData, cfdm.Field):
         )  # pragma: no cover
 
     def unlimited(self, *args):
-        """Deprecated at version 3.0.0. Use methods
-        `DomainAxis.nc_is_unlimited`, and `DomainAxis.nc_set_unlimited`
-        instead.
+        """Deprecated at version 3.0.0.
+
+        Use methods `DomainAxis.nc_is_unlimited`, and
+        `DomainAxis.nc_set_unlimited` instead.
 
         """
         _DEPRECATION_ERROR_METHOD(

--- a/cf/fieldlist.py
+++ b/cf/fieldlist.py
@@ -275,7 +275,7 @@ class FieldList(list, cfdm.Container):
             f.close()
 
     def count(self, value):
-        """Return number of occurrences of value
+        """Return number of occurrences of value.
 
         Each field in the field list is compared with the field's
         `~cf.Field.equals` method, as opposed to the ``==`` operator.
@@ -992,7 +992,8 @@ class FieldList(list, cfdm.Container):
         return type(self)(f for f in self if f.match_by_naxes(*naxes))
 
     def select_by_rank(self, *ranks):
-        """Select field constructs by the number of domain axis constructs.
+        """Select field constructs by the number of domain axis
+        constructs.
 
         .. versionadded:: 3.0.0
 
@@ -1029,6 +1030,7 @@ class FieldList(list, cfdm.Container):
         **Examples:**
 
             TODO
+
         """
 
         return type(self)(f for f in self if f.match_by_rank(*ranks))
@@ -1390,8 +1392,9 @@ class FieldList(list, cfdm.Container):
         ignore_type=False,
         traceback=False,
     ):
-        """Deprecated at version 3.0.0. Use method 'equals' with
-        unordered=True instead.
+        """Deprecated at version 3.0.0.
+
+        Use method 'equals' with unordered=True instead.
 
         """
         _DEPRECATION_ERROR_METHOD(
@@ -1401,7 +1404,11 @@ class FieldList(list, cfdm.Container):
         )  # pragma: no cover
 
     def select1(self, *args, **kwargs):
-        """Deprecated at version 3.0.0. Use method 'fl.select_field' instead."""
+        """Deprecated at version 3.0.0.
+
+        Use method 'fl.select_field' instead.
+
+        """
         _DEPRECATION_ERROR_METHOD(
             self, "select1", "Use method 'fl.select_field' instead."
         )  # pragma: no cover

--- a/cf/flags.py
+++ b/cf/flags.py
@@ -84,7 +84,7 @@ class Flags:
         return hash(tuple(x))
 
     def __bool__(self):
-        """x.__bool__() <==> x!=0"""
+        """x.__bool__() <==> x!=0."""
         for attr in ("_flag_meanings", "_flag_values", "_flag_masks"):
             if hasattr(self, attr):
                 return True
@@ -268,7 +268,8 @@ class Flags:
 
     @_display_or_return
     def dump(self, display=True, _level=0):
-        """Return a string containing a full description of the instance.
+        """Return a string containing a full description of the
+        instance.
 
         :Parameters:
 
@@ -307,7 +308,8 @@ class Flags:
         verbose=None,
         traceback=False,
     ):
-        """True if two groups of flags are logically equal, False otherwise.
+        """True if two groups of flags are logically equal, False
+        otherwise.
 
         Note that both instances are sorted in place prior to the comparison.
 

--- a/cf/formula_terms.py
+++ b/cf/formula_terms.py
@@ -46,8 +46,8 @@ class FormulaTerms(metaclass=cfdm.core.DocstringRewriteMeta):
     )
 
     def __docstring_substitutions__(self):
-        """Define docstring substitutions that apply to this class and all of
-        its subclasses.
+        """Define docstring substitutions that apply to this class and
+        all of its subclasses.
 
         These are in addtion to, and take precendence over, docstring
         substitutions defined by the base classes of this class.
@@ -67,7 +67,8 @@ class FormulaTerms(metaclass=cfdm.core.DocstringRewriteMeta):
         return _docstring_substitution_definitions
 
     def __docstring_package_depth__(self):
-        """Return the package depth for {{package}} docstring substitutions.
+        """Return the package depth for {{package}} docstring
+        substitutions.
 
         See `_docstring_package_depth` for details.
 
@@ -87,7 +88,8 @@ class FormulaTerms(metaclass=cfdm.core.DocstringRewriteMeta):
         strict,
         bounds,
     ):
-        """Find a domain ancillary construct corresponding to a formula term.
+        """Find a domain ancillary construct corresponding to a formula
+        term.
 
         .. versionadded:: 3.8.0
 
@@ -233,8 +235,8 @@ class FormulaTerms(metaclass=cfdm.core.DocstringRewriteMeta):
 
     @staticmethod
     def _computed_standard_name(f, standard_name, coordinate_reference):
-        """Find the standard name of the computed non-parametric vertical
-        coordinates.
+        """Find the standard name of the computed non-parametric
+        vertical coordinates.
 
         {{formula terms links}}
 
@@ -336,8 +338,8 @@ class FormulaTerms(metaclass=cfdm.core.DocstringRewriteMeta):
 
     @staticmethod
     def _vertical_axis(f, keys):
-        """Find the vertical axis corresponding to the parametric vertical
-        coordinates.
+        """Find the vertical axis corresponding to the parametric
+        vertical coordinates.
 
         .. versionadded:: 3.8.0
 
@@ -373,8 +375,8 @@ class FormulaTerms(metaclass=cfdm.core.DocstringRewriteMeta):
 
     @staticmethod
     def _conform_eta(f, eta, eta_key, depth, depth_key):
-        """Transform the 'eta' term so that broadcasting will work with the
-        'depth' term.
+        """Transform the 'eta' term so that broadcasting will work with
+        the 'depth' term.
 
         This entails making sure that the trailing dimensions of 'eta' are
         the same as all of the dimensions of 'depth'.
@@ -442,9 +444,9 @@ class FormulaTerms(metaclass=cfdm.core.DocstringRewriteMeta):
 
     @staticmethod
     def _conform_computed(f, computed, computed_axes, k_axis):
-        """Move the vertical axis of the computed non-parametric vertical
-        coordinates from its current position as the last (rightmost)
-        dimension, if applicable.
+        """Move the vertical axis of the computed non-parametric
+        vertical coordinates from its current position as the last
+        (rightmost) dimension, if applicable.
 
         **Note:**
 
@@ -513,8 +515,8 @@ class FormulaTerms(metaclass=cfdm.core.DocstringRewriteMeta):
 
     @staticmethod
     def _conform_units(term, var, ref_term2, ref_units):
-        """Make sure that the units of a variable of the formula are the same
-        as the units of another formula term.
+        """Make sure that the units of a variable of the formula are the
+        same as the units of another formula term.
 
         .. versionadded:: 3.8.0
 
@@ -871,7 +873,8 @@ class FormulaTerms(metaclass=cfdm.core.DocstringRewriteMeta):
         cls, g, coordinate_reference, default_to_zero, strict
     ):
         """Compute non-parametric vertical coordinates from
-        atmosphere_hybrid_sigma_pressure_coordinate parametric coordinates.
+        atmosphere_hybrid_sigma_pressure_coordinate parametric
+        coordinates.
 
         {{formula terms links}}
 
@@ -1255,7 +1258,7 @@ class FormulaTerms(metaclass=cfdm.core.DocstringRewriteMeta):
         cls, g, coordinate_reference, default_to_zero, strict
     ):
         """Compute non-parametric vertical coordinates from
-        ocean_sigma_coordinate parametric coordinates
+        ocean_sigma_coordinate parametric coordinates.
 
         {{formula terms links}}
 
@@ -1359,8 +1362,8 @@ class FormulaTerms(metaclass=cfdm.core.DocstringRewriteMeta):
     def ocean_s_coordinate(
         cls, g, coordinate_reference, default_to_zero, strict
     ):
-        """Compute non-parametric vertical coordinates from ocean_s_coordinate
-        parametric coordinates.
+        """Compute non-parametric vertical coordinates from
+        ocean_s_coordinate parametric coordinates.
 
         {{formula terms links}}
 

--- a/cf/functions.py
+++ b/cf/functions.py
@@ -423,7 +423,8 @@ def configuration(
 
 
 def _configuration(_Configuration, **kwargs):
-    """Internal helper function to provide the logic for `cf.configuration`.
+    """Internal helper function to provide the logic for
+    `cf.configuration`.
 
     We delegate from the user-facing `cf.configuration` for two main reasons:
 
@@ -550,8 +551,8 @@ def FREE_MEMORY(*new_free_memory):
 
 
 def _WORKSPACE_FACTOR_1():
-    """The value of workspace factor 1 used in calculating the upper limit
-    to the chunksize given the free memory factor.
+    """The value of workspace factor 1 used in calculating the upper
+    limit to the chunksize given the free memory factor.
 
     :Returns:
 
@@ -563,8 +564,8 @@ def _WORKSPACE_FACTOR_1():
 
 
 def _WORKSPACE_FACTOR_2():
-    """The value of workspace factor 2 used in calculating the upper limit
-    to the chunksize given the free memory factor.
+    """The value of workspace factor 2 used in calculating the upper
+    limit to the chunksize given the free memory factor.
 
     :Returns:
 
@@ -579,9 +580,10 @@ def _cf_free_memory_factor(*new_free_memory_factor):
     """Internal alias for `cf.free_memory_factor`.
 
     Used in this module to prevent a name clash with a function keyword
-    argument (corresponding to 'import X as cf_X' etc. in other modules).
-    Note we don't use FREE_MEMORY_FACTOR() as it will likely be deprecated
-    in future.
+    argument (corresponding to 'import X as cf_X' etc. in other
+    modules). Note we don't use FREE_MEMORY_FACTOR() as it will likely
+    be deprecated in future.
+
     """
     return free_memory_factor(*new_free_memory_factor)
 
@@ -678,8 +680,8 @@ class regrid_logging(ConstantAccess):
 
 
 class collapse_parallel_mode(ConstantAccess):
-    """Which mode to use when collapse is run in parallel. There are three
-    possible modes:
+    """Which mode to use when collapse is run in parallel. There are
+    three possible modes:
 
     0.  This attempts to maximise parallelism, possibly at the expense
         of extra communication. This is the default mode.
@@ -809,9 +811,7 @@ class relaxed_identities(ConstantAccess):
 
 
 class chunksize(ConstantAccess):
-    """Set the chunksize used by LAMA for partitioning the data
-    array.
-
+    """Set the chunksize used by LAMA for partitioning the data array.
 
     This must be smaller than an upper limit determined by the free
     memory factor, which is the fraction of memory kept free as a
@@ -947,8 +947,8 @@ class tempdir(ConstantAccess):
 
 
 class of_fraction(ConstantAccess):
-    """The amount of concurrently open files above which files containing
-    data arrays may be automatically closed.
+    """The amount of concurrently open files above which files
+    containing data arrays may be automatically closed.
 
     The amount is expressed as a fraction of the maximum possible
     number of concurrently open files.
@@ -1029,8 +1029,7 @@ class of_fraction(ConstantAccess):
 
 
 class free_memory_factor(ConstantAccess):
-    """Set the fraction of memory kept free as a temporary
-    workspace.
+    """Set the fraction of memory kept free as a temporary workspace.
 
     Users should set the free memory factor through cf.set_performance
     so that the upper limit to the chunksize is recalculated
@@ -1261,14 +1260,17 @@ def _cf_chunksize(*new_chunksize):
     """Internal alias for `cf.chunksize`.
 
     Used in this module to prevent a name clash with a function keyword
-    argument (corresponding to 'import X as cf_X' etc. in other modules).
-    Note we don't use CHUNKSIZE() as it will likely be deprecated in future.
+    argument (corresponding to 'import X as cf_X' etc. in other
+    modules). Note we don't use CHUNKSIZE() as it will likely be
+    deprecated in future.
+
     """
     return chunksize(*new_chunksize)
 
 
 def fm_threshold():
-    """The amount of memory which is kept free as a temporary work space.
+    """The amount of memory which is kept free as a temporary work
+    space.
 
     :Returns:
 
@@ -1286,18 +1288,18 @@ def fm_threshold():
 
 def set_performance(chunksize=None, free_memory_factor=None):
     """Tune performance of parallelisation by setting chunksize and free
-    memory factor. By just providing the chunksize it can be changed
-    to a smaller value than an upper limit, which is determined by the
+    memory factor. By just providing the chunksize it can be changed to
+    a smaller value than an upper limit, which is determined by the
     existing free memory factor. If just the free memory factor is
-    provided then the chunksize is set to the corresponding upper
-    limit. Note that the free memory factor is the fraction of memory
-    kept free as a temporary workspace and must be a sensible value
-    between zero and one. If both arguments are provided then the free
-    memory factor is changed first and then the chunksize is set
-    provided it is consistent with the new free memory value. If any
-    of the arguments is invalid then an error is raised and no
-    parameters are changed. When called with no arguments the existing
-    values of the parameters are returned in a tuple.
+    provided then the chunksize is set to the corresponding upper limit.
+    Note that the free memory factor is the fraction of memory kept free
+    as a temporary workspace and must be a sensible value between zero
+    and one. If both arguments are provided then the free memory factor
+    is changed first and then the chunksize is set provided it is
+    consistent with the new free memory value. If any of the arguments
+    is invalid then an error is raised and no parameters are changed.
+    When called with no arguments the existing values of the parameters
+    are returned in a tuple.
 
     :Parameters:
 
@@ -1337,7 +1339,7 @@ def min_total_memory():
 
 
 def total_memory():
-    """TODO"""
+    """TODO."""
     return CONSTANTS["TOTAL_MEMORY"]
 
 
@@ -1499,8 +1501,8 @@ if _linux:
     _fd_dir = "/proc/" + str(getpid()) + "/fd"
 
     def open_files_threshold_exceeded():
-        """Return True if the total number of open files is greater than the
-        current threshold. GNU/LINUX.
+        """Return True if the total number of open files is greater than
+        the current threshold. GNU/LINUX.
 
         The threshold is defined as a fraction of the maximum possible number
         of concurrently open files (an operating system dependent amount). The
@@ -1541,8 +1543,8 @@ else:
     _process = Process(getpid())
 
     def open_files_threshold_exceeded():
-        """Return True if the total number of open files is greater than the
-        current threshold.
+        """Return True if the total number of open files is greater than
+        the current threshold.
 
         The threshold is defined as a fraction of the maximum possible number
         of concurrently open files (an operating system dependent amount). The
@@ -1685,7 +1687,8 @@ def close_one_file(file_format=None):
 
 
 def open_files(file_format=None):
-    """Return the open files containing sub-arrays of master data arrays.
+    """Return the open files containing sub-arrays of master data
+    arrays.
 
     By default all such files are returned, but the selection may be
     restricted to files of a particular format.
@@ -1734,7 +1737,8 @@ def open_files(file_format=None):
 
 
 def ufunc(name, x, *args, **kwargs):
-    """The variable must have a `!copy` method and a method called
+    """The variable must have a `!copy` method and a method called.
+
     *name*. Any optional positional and keyword arguments are passed
     unchanged to the variable's *name* method.
 
@@ -1884,7 +1888,7 @@ def _numpy_isclose(a, b, rtol=None, atol=None):
 def parse_indices(
     shape, indices, cyclic=False, reverse=False, envelope=False, mask=False
 ):
-    """TODO
+    """TODO.
 
     :Parameters:
 
@@ -2243,7 +2247,7 @@ def parse_indices(
 
 
 def get_subspace(array, indices):
-    """TODO
+    """TODO.
 
     Subset the input numpy array with the given indices. Indexing is
     similar to that of a numpy array. The differences to numpy array
@@ -3061,9 +3065,9 @@ def allclose(x, y, rtol=None, atol=None):
 def _section(
     x, axes=None, data=False, stop=None, chunks=False, min_step=1, **kwargs
 ):
-    """Return a list of m dimensional sections of a Field of n dimensions
-    or a dictionary of m dimensional sections of a Data object of n
-    dimensions, where m <= n.
+    """Return a list of m dimensional sections of a Field of n
+    dimensions or a dictionary of m dimensional sections of a Data
+    object of n dimensions, where m <= n.
 
     In the case of a `Data` object, the keys of the dictionary are the
     indices of the sections in the original Data object. The m
@@ -3135,15 +3139,16 @@ def _section(
     """
 
     def loop_over_index(x, current_index, axis_indices, indices):
-        """Expects an index to loop over in the list indices. If this is less
-        than 0 the horizontal slice defined by indices is appended to
-        the FieldList fl, if it is the specified axis indices the
-        value in indices is left as slice(None) and it calls itself
-        recursively with the next index, otherwise each index is
-        looped over. In this loop the routine is called recursively
-        with the next index. If the count of the number of slices
-        taken is greater than or equal to stop it returns before
-        taking any more slices.
+        """Expects an index to loop over in the list indices.
+
+        If this is less than 0 the horizontal slice defined by indices
+        is appended to the FieldList fl, if it is the specified axis
+        indices the value in indices is left as slice(None) and it calls
+        itself recursively with the next index, otherwise each index is
+        looped over. In this loop the routine is called recursively with
+        the next index. If the count of the number of slices taken is
+        greater than or equal to stop it returns before taking any more
+        slices.
 
         """
         if current_index < 0:
@@ -3244,7 +3249,7 @@ def _section(
 
 
 def _get_module_info(module, try_except=False):
-    """Helper function for processing modules for cf.environment"""
+    """Helper function for processing modules for cf.environment."""
     if try_except:
         try:
             importlib.import_module(module)
@@ -3527,8 +3532,8 @@ def _DEPRECATION_ERROR_SEQUENCE(instance, version="3.0.0"):
 def default_fillvals():
     """Default data array fill values for each data type.
 
-    Deprecated at version 3.0.2 and is no longer available. Use
-    function `cf.default_netCDF_fillvals` instead.
+    Deprecated at version 3.0.2 and is no longer available. Use function
+    `cf.default_netCDF_fillvals` instead.
 
     """
     _DEPRECATION_ERROR_FUNCTION(

--- a/cf/maths.py
+++ b/cf/maths.py
@@ -7,7 +7,8 @@ from .data.data import Data
 def relative_vorticity(
     u, v, wrap=None, one_sided_at_boundary=False, radius=6371229.0, cyclic=None
 ):
-    """Calculate the relative vorticity using centred finite differences.
+    """Calculate the relative vorticity using centred finite
+    differences.
 
     The relative vorticity of wind defined on a Cartesian domain (such
     as a plane projection) is defined as

--- a/cf/mixin/coordinate.py
+++ b/cf/mixin/coordinate.py
@@ -44,7 +44,8 @@ class Coordinate:
 
     @property
     def T(self):
-        """True if and only if the data are coordinates for a CF 'T' axis.
+        """True if and only if the data are coordinates for a CF 'T'
+        axis.
 
         CF 'T' axis coordinates are defined by having one or more of the
         following:
@@ -78,7 +79,8 @@ class Coordinate:
 
     @property
     def X(self):
-        """True if and only if the data are coordinates for a CF 'X' axis.
+        """True if and only if the data are coordinates for a CF 'X'
+        axis.
 
         CF 'X' axis coordinates are defined by having one or more of the
         following:
@@ -142,7 +144,8 @@ class Coordinate:
 
     @property
     def Y(self):
-        """True if and only if the data are coordinates for a CF 'Y' axis.
+        """True if and only if the data are coordinates for a CF 'Y'
+        axis.
 
         CF 'Y' axis coordinates are defined by having one or more of the
         following:
@@ -193,7 +196,8 @@ class Coordinate:
 
     @property
     def Z(self):
-        """True if and only if the data are coordinates for a CF 'Z' axis.
+        """True if and only if the data are coordinates for a CF 'Z'
+        axis.
 
         CF 'Z' axis coordinates are defined by having one or more of the
         following:

--- a/cf/mixin/properties.py
+++ b/cf/mixin/properties.py
@@ -29,9 +29,9 @@ class Properties(Container):
     def __new__(cls, *args, **kwargs):
         """Store component classes.
 
-        .. note:: If a child class requires a different component classes
-                  than the ones defined here, then they must be redefined
-                  in the child class.
+        .. note:: If a child class requires a different component
+        classes           than the ones defined here, then they must be
+        redefined           in the child class.
 
         """
         instance = super().__new__(cls)
@@ -43,8 +43,8 @@ class Properties(Container):
     # ----------------------------------------------------------------
     @property
     def _atol(self):
-        """Return the tolerance on absolute differences between real numbers,
-        as returned by the `cf.atol` function.
+        """Return the tolerance on absolute differences between real
+        numbers, as returned by the `cf.atol` function.
 
         This is used by, for example, the `_equals` method.
 
@@ -53,8 +53,8 @@ class Properties(Container):
 
     @property
     def _rtol(self):
-        """Return the tolerance on relative differences between real numbers,
-        as returned by the `cf.rtol` function.
+        """Return the tolerance on relative differences between real
+        numbers, as returned by the `cf.rtol` function.
 
         This is used by, for example, the `_equals` method.
 
@@ -1145,25 +1145,29 @@ class Properties(Container):
     # Deprecated attributes and methods
     # ----------------------------------------------------------------
     def setprop(self, *args, **kwargs):
-        """Deprecated at version 3.0.0, use method `set_property` instead."""
+        """Deprecated at version 3.0.0, use method `set_property`
+        instead."""
         _DEPRECATION_ERROR_METHOD(
             self, "setprop", "Use method 'set_property' instead"
         )  # pragma: no cover
 
     def delprop(self, prop):
-        """Deprecated at version 3.0.0, use method `del_property` instead."""
+        """Deprecated at version 3.0.0, use method `del_property`
+        instead."""
         _DEPRECATION_ERROR_METHOD(
             self, "delprop", "Use method 'del_property' instead"
         )  # pragma: no cover
 
     def hasprop(self, prop):
-        """Deprecated at version 3.0.0, use method `has_property` instead."""
+        """Deprecated at version 3.0.0, use method `has_property`
+        instead."""
         _DEPRECATION_ERROR_METHOD(
             self, "hasprop", "Use method 'has_property' instead"
         )  # pragma: no cover
 
     def getprop(self, prop):
-        """Deprecated at version 3.0.0, use method `get_property` instead."""
+        """Deprecated at version 3.0.0, use method `get_property`
+        instead."""
         _DEPRECATION_ERROR_METHOD(
             self, "getprop", "Use method 'get_property' instead"
         )  # pragma: no cover

--- a/cf/mixin/propertiesdata.py
+++ b/cf/mixin/propertiesdata.py
@@ -131,7 +131,8 @@ class PropertiesData(Properties):
         return self._binary_operation(y, "__iadd__")
 
     def __radd__(self, y):
-        """The binary arithmetic operation ``+`` with reflected operands
+        """The binary arithmetic operation ``+`` with reflected
+        operands.
 
         x.__radd__(y) <==> y+x
 
@@ -155,7 +156,8 @@ class PropertiesData(Properties):
         return self._binary_operation(y, "__isub__")
 
     def __rsub__(self, y):
-        """The binary arithmetic operation ``-`` with reflected operands
+        """The binary arithmetic operation ``-`` with reflected
+        operands.
 
         x.__rsub__(y) <==> y-x
 
@@ -179,7 +181,8 @@ class PropertiesData(Properties):
         return self._binary_operation(y, "__imul__")
 
     def __rmul__(self, y):
-        """The binary arithmetic operation ``*`` with reflected operands
+        """The binary arithmetic operation ``*`` with reflected
+        operands.
 
         x.__rmul__(y) <==> y*x
 
@@ -203,7 +206,8 @@ class PropertiesData(Properties):
         return self._binary_operation(y, "__idiv__")
 
     def __rdiv__(self, y):
-        """The binary arithmetic operation ``/`` with reflected operands
+        """The binary arithmetic operation ``/`` with reflected
+        operands.
 
         x.__rdiv__(y) <==> y/x
 
@@ -227,7 +231,8 @@ class PropertiesData(Properties):
         return self._binary_operation(y, "__ifloordiv__")
 
     def __rfloordiv__(self, y):
-        """The binary arithmetic operation ``//`` with reflected operands
+        """The binary arithmetic operation ``//`` with reflected
+        operands.
 
         x.__rfloordiv__(y) <==> y//x
 
@@ -252,7 +257,7 @@ class PropertiesData(Properties):
 
     def __rtruediv__(self, y):
         """The binary arithmetic operation ``/`` (true division) with
-        reflected operands
+        reflected operands.
 
         x.__rtruediv__(y) <==> y/x
 
@@ -288,8 +293,8 @@ class PropertiesData(Properties):
         return self._binary_operation(y, "__ipow__")
 
     def __rpow__(self, y, modulo=None):
-        """The binary arithmetic operations ``**`` and ``pow`` with reflected
-        operands
+        """The binary arithmetic operations ``**`` and ``pow`` with
+        reflected operands.
 
         x.__rpow__(y) <==> y**x
 
@@ -323,7 +328,8 @@ class PropertiesData(Properties):
         return self._binary_operation(y, "__imod__")
 
     def __rmod__(self, y):
-        """The binary arithmetic operation ``%`` with reflected operands
+        """The binary arithmetic operation ``%`` with reflected
+        operands.
 
         x.__rmod__(y) <==> y % x
 
@@ -397,7 +403,7 @@ class PropertiesData(Properties):
         return self._binary_operation(y, "__iand__")
 
     def __rand__(self, y):
-        """The binary bitwise operation ``&`` with reflected operands
+        """The binary bitwise operation ``&`` with reflected operands.
 
         x.__rand__(y) <==> y&x
 
@@ -421,7 +427,7 @@ class PropertiesData(Properties):
         return self._binary_operation(y, "__ior__")
 
     def __ror__(self, y):
-        """The binary bitwise operation ``|`` with reflected operands
+        """The binary bitwise operation ``|`` with reflected operands.
 
         x.__ror__(y) <==> y|x
 
@@ -445,7 +451,7 @@ class PropertiesData(Properties):
         return self._binary_operation(y, "__ixor__")
 
     def __rxor__(self, y):
-        """The binary bitwise operation ``^`` with reflected operands
+        """The binary bitwise operation ``^`` with reflected operands.
 
         x.__rxor__(y) <==> y^x
 
@@ -469,7 +475,7 @@ class PropertiesData(Properties):
         return self._binary_operation(y, "__ilshift__")
 
     def __rlshift__(self, y):
-        """The binary bitwise operation ``<<`` with reflected operands
+        """The binary bitwise operation ``<<`` with reflected operands.
 
         x.__rlshift__(y) <==> y<<x
 
@@ -493,7 +499,7 @@ class PropertiesData(Properties):
         return self._binary_operation(y, "__irshift__")
 
     def __rrshift__(self, y):
-        """The binary bitwise operation ``>>`` with reflected operands
+        """The binary bitwise operation ``>>`` with reflected operands.
 
         x.__rrshift__(y) <==> y>>x
 
@@ -692,12 +698,12 @@ class PropertiesData(Properties):
     #            data.change_axis_names(dim_name_map)
 
     def _conform_for_assignment(self, other):
-        """TODO"""
+        """TODO."""
         return other
 
     @_manage_log_level_via_verbosity
     def _equivalent_data(self, other, atol=None, rtol=None, verbose=None):
-        """TODO
+        """TODO.
 
         Two real numbers ``x`` and ``y`` are considered equal if
         ``|x-y|<=atol+rtol|y|``, where ``atol`` (the tolerance on absolute
@@ -824,7 +830,7 @@ class PropertiesData(Properties):
     #        return matches
 
     def __query_set__(self, values):
-        """TODO"""
+        """TODO."""
         new = self.copy()
         new.set_data(self.data.__query_set__(values), copy=False)
         return new
@@ -846,13 +852,13 @@ class PropertiesData(Properties):
     #        return new
 
     def __query_wi__(self, value):
-        """TODO"""
+        """TODO."""
         new = self.copy()
         new.set_data(self.data.__query_wi__(value), copy=False)
         return new
 
     def __query_wo__(self, value):
-        """TODO"""
+        """TODO."""
         new = self.copy()
         new.set_data(self.data.__query_wo__(value), copy=False)
         return new
@@ -905,7 +911,7 @@ class PropertiesData(Properties):
         return new
 
     def _YMDhms(self, attr):
-        """TODO"""
+        """TODO."""
         data = self.get_data(None)
         if data is None:
             raise ValueError(
@@ -984,7 +990,8 @@ class PropertiesData(Properties):
     # ----------------------------------------------------------------
     @property
     def T(self):
-        """`True` if and only if the data are coordinates for a CF 'T' axis.
+        """`True` if and only if the data are coordinates for a CF 'T'
+        axis.
 
         CF 'T' axis coordinates are defined by having units of reference
         time
@@ -1089,7 +1096,7 @@ class PropertiesData(Properties):
 
     @property
     def isperiodic(self):
-        """TODO
+        """TODO.
 
         .. versionadded:: 2.0
 
@@ -1897,8 +1904,8 @@ class PropertiesData(Properties):
         return old
 
     def range(self):
-        """The absolute difference between the maximum and minimum of the data
-        array.
+        """The absolute difference between the maximum and minimum of
+        the data array.
 
         .. seealso:: `maximum`, `mean`, `mid_range`, `minimum`,
                      `sample_size`, `standard_deviation`, `sum`,
@@ -2821,7 +2828,8 @@ class PropertiesData(Properties):
         return data.cyclic(axes, iscyclic)
 
     def datum(self, *index):
-        """Return an element of the data array as a standard Python scalar.
+        """Return an element of the data array as a standard Python
+        scalar.
 
         The first and last elements are always returned with
         ``f.datum(0)`` and ``f.datum(-1)`` respectively, even if the data
@@ -3245,7 +3253,7 @@ class PropertiesData(Properties):
         """
 
         def _convert_reftime_units(value, units, reftime):  # , calendar):
-            """sads
+            """sads.
 
             :Parameters:
 
@@ -3335,7 +3343,7 @@ class PropertiesData(Properties):
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     def flatten(self, axes=None, inplace=False):
-        """Flatten axes of the data
+        """Flatten axes of the data.
 
         Any subset of the axes may be flattened.
 
@@ -3969,7 +3977,8 @@ class PropertiesData(Properties):
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     def arctan(self, inplace=False):
-        """Take the trigonometric inverse tangent of the data element-wise.
+        """Take the trigonometric inverse tangent of the data element-
+        wise.
 
         Units are ignored in the calculation. The result has units of
         radians.
@@ -4183,7 +4192,8 @@ class PropertiesData(Properties):
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     def arccos(self, inplace=False):
-        """Take the trigonometric inverse cosine of the data element-wise.
+        """Take the trigonometric inverse cosine of the data element-
+        wise.
 
         Units are ignored in the calculation. The result has units of
         radians.
@@ -5525,24 +5535,24 @@ class PropertiesData(Properties):
 
     @property
     def Data(self):  # noqa: F811 (see github.com/PyCQA/pyflakes/issues/372)
-        """Deprecated at version 3.0.0, use `data` attribute or `get_data`
-        method instead.
-
-        """
+        """Deprecated at version 3.0.0, use `data` attribute or
+        `get_data` method instead."""
         _DEPRECATION_ERROR_ATTRIBUTE(
             self, "Data", "Use 'data' attribute or 'get_data' method instead."
         )  # pragma: no cover
 
     @data.setter
     def Data(self, value):  # noqa: F811 (see link against same-name setter)
-        """Deprecated at version 3.0.0, use `set_data` method instead."""
+        """Deprecated at version 3.0.0, use `set_data` method
+        instead."""
         _DEPRECATION_ERROR_ATTRIBUTE(
             self, "Data", "Use 'data' attribute or 'set_data' method instead."
         )  # pragma: no cover
 
     @data.deleter
     def Data(self):  # noqa: F811 (see github.com/PyCQA/pyflakes/issues/372)
-        """Deprecated at version 3.0.0, use `del_data` method instead."""
+        """Deprecated at version 3.0.0, use `del_data` method
+        instead."""
         _DEPRECATION_ERROR_ATTRIBUTE(
             self, "Data", "Use 'data' attribute or 'del_data' method instead."
         )  # pragma: no cover
@@ -5554,14 +5564,16 @@ class PropertiesData(Properties):
 
     @property
     def hasbounds(self):
-        """Deprecated at version 3.0.0, use `has_bounds` method instead."""
+        """Deprecated at version 3.0.0, use `has_bounds` method
+        instead."""
         _DEPRECATION_ERROR_ATTRIBUTE(
             self, "hasbounds", "Use 'has_bounds' method instead"
         )
 
     @property
     def hasdata(self):
-        """Deprecated at version 3.0.0, use `has_data` method instead."""
+        """Deprecated at version 3.0.0, use `has_data` method
+        instead."""
         _DEPRECATION_ERROR_ATTRIBUTE(
             self, "hasdata", "Use 'has_data' method instead"
         )
@@ -5569,9 +5581,7 @@ class PropertiesData(Properties):
     @property
     def isauxiliary(self):
         """Deprecated at version 3.7.0, use `construct_type` attribute
-        instead.
-
-        """
+        instead."""
         _DEPRECATION_ERROR_ATTRIBUTE(
             self,
             "isauxiliary",
@@ -5582,9 +5592,7 @@ class PropertiesData(Properties):
     @property
     def isdimension(self):
         """Deprecated at version 3.7.0, use `construct_type` attribute
-        instead.
-
-        """
+        instead."""
         _DEPRECATION_ERROR_ATTRIBUTE(
             self,
             "isdimension",
@@ -5595,9 +5603,7 @@ class PropertiesData(Properties):
     @property
     def isdomainancillary(self):
         """Deprecated at version 3.7.0, use `construct_type` attribute
-        instead.
-
-        """
+        instead."""
         _DEPRECATION_ERROR_ATTRIBUTE(
             self,
             "isdomainancillary",
@@ -5608,9 +5614,7 @@ class PropertiesData(Properties):
     @property
     def isfieldancillary(self):
         """Deprecated at version 3.7.0, use `construct_type` attribute
-        instead.
-
-        """
+        instead."""
         _DEPRECATION_ERROR_ATTRIBUTE(
             self,
             "isfieldancillary",
@@ -5620,9 +5624,7 @@ class PropertiesData(Properties):
     @property
     def ismeasure(self):
         """Deprecated at version 3.7.0, use `construct_type` attribute
-        instead.
-
-        """
+        instead."""
         _DEPRECATION_ERROR_ATTRIBUTE(
             self,
             "ismeasure",
@@ -5632,7 +5634,8 @@ class PropertiesData(Properties):
 
     @property
     def unsafe_array(self):
-        """Deprecated at version 3.0.0, use `array` attribute instead."""
+        """Deprecated at version 3.0.0, use `array` attribute
+        instead."""
         _DEPRECATION_ERROR_ATTRIBUTE(
             self,
             "unsafe_array",
@@ -5649,13 +5652,15 @@ class PropertiesData(Properties):
         _DEPRECATION_ERROR_METHOD(self, "asreftime")  # pragma: no cover
 
     def expand_dims(self, position=0, i=False):
-        """Deprecated at version 3.0.0, use `insert_dimension` method instead."""
+        """Deprecated at version 3.0.0, use `insert_dimension` method
+        instead."""
         _DEPRECATION_ERROR_METHOD(
             self, "expand_dims", "Use method 'insert_dimension' instead."
         )  # pragma: no cover
 
     def insert_data(self, data, copy=True):
-        """Deprecated at version 3.0.0, use `set_data` method instead."""
+        """Deprecated at version 3.0.0, use `set_data` method
+        instead."""
         _DEPRECATION_ERROR_METHOD(
             self, "insert_data", "Use method 'set_data' instead."
         )  # pragma: no cover
@@ -5663,13 +5668,15 @@ class PropertiesData(Properties):
     def name(
         self, default=None, identity=False, ncvar=False, relaxed_identity=None
     ):
-        """Deprecated at version 3.0.0, use method 'identity' instead."""
+        """Deprecated at version 3.0.0, use method 'identity'
+        instead."""
         _DEPRECATION_ERROR_METHOD(
             self, "name", "Use method 'identity' instead"
         )  # pragma: no cover
 
     def remove_data(self):
-        """Deprecated at version 3.0.0, use method `del_data` instead."""
+        """Deprecated at version 3.0.0, use method `del_data`
+        instead."""
         _DEPRECATION_ERROR_METHOD(
             self, "remove_data", "Use method 'del_data' instead."
         )  # pragma: no cover
@@ -5683,7 +5690,7 @@ class PropertiesData(Properties):
 
 
 class Subspace:
-    """TODO"""
+    """TODO."""
 
     __slots__ = ("variable",)
 

--- a/cf/mixin/propertiesdatabounds.py
+++ b/cf/mixin/propertiesdatabounds.py
@@ -36,9 +36,7 @@ logger = logging.getLogger(__name__)
 
 class PropertiesDataBounds(PropertiesData):
     """Mixin class for a data array with descriptive properties and cell
-    bounds.
-
-    """
+    bounds."""
 
     def __getitem__(self, indices):
         """Return a subspace of the field construct defined by indices.
@@ -270,7 +268,7 @@ class PropertiesDataBounds(PropertiesData):
         return self._binary_operation(other, "__iand__", False)
 
     def __rand__(self, other):
-        """The binary bitwise operation ``&`` with reflected operands
+        """The binary bitwise operation ``&`` with reflected operands.
 
         x.__rand__(y) <==> y&x
 
@@ -294,7 +292,7 @@ class PropertiesDataBounds(PropertiesData):
         return self._binary_operation(other, "__ior__", False)
 
     def __ror__(self, other):
-        """The binary bitwise operation ``|`` with reflected operands
+        """The binary bitwise operation ``|`` with reflected operands.
 
         x.__ror__(y) <==> y|x
 
@@ -318,7 +316,7 @@ class PropertiesDataBounds(PropertiesData):
         return self._binary_operation(other, "__ixor__", False)
 
     def __rxor__(self, other):
-        """The binary bitwise operation ``^`` with reflected operands
+        """The binary bitwise operation ``^`` with reflected operands.
 
         x.__rxor__(y) <==> y^x
 
@@ -342,7 +340,7 @@ class PropertiesDataBounds(PropertiesData):
         return self._binary_operation(y, "__ilshift__", False)
 
     def __rlshift__(self, y):
-        """The binary bitwise operation ``<<`` with reflected operands
+        """The binary bitwise operation ``<<`` with reflected operands.
 
         x.__rlshift__(y) <==> y<<x
 
@@ -366,7 +364,7 @@ class PropertiesDataBounds(PropertiesData):
         return self._binary_operation(y, "__irshift__", False)
 
     def __rrshift__(self, y):
-        """The binary bitwise operation ``>>`` with reflected operands
+        """The binary bitwise operation ``>>`` with reflected operands.
 
         x.__rrshift__(y) <==> y>>x
 
@@ -592,7 +590,7 @@ class PropertiesDataBounds(PropertiesData):
 
     @_manage_log_level_via_verbosity
     def _equivalent_data(self, other, rtol=None, atol=None, verbose=None):
-        """TODO
+        """TODO.
 
         Two real numbers ``x`` and ``y`` are considered equal if
         ``|x-y|<=atol+rtol|y|``, where ``atol`` (the tolerance on absolute
@@ -666,7 +664,7 @@ class PropertiesDataBounds(PropertiesData):
         return True
 
     def _YMDhms(self, attr):
-        """TODO"""
+        """TODO."""
         out = super()._YMDhms(attr)
         out.del_bounds(None)
         return out
@@ -777,7 +775,8 @@ class PropertiesDataBounds(PropertiesData):
         return v
 
     def _unary_operation(self, method, bounds=True):
-        """Implement unary arithmetic operations on the data array and bounds.
+        """Implement unary arithmetic operations on the data array and
+        bounds.
 
         :Parameters:
 
@@ -895,7 +894,7 @@ class PropertiesDataBounds(PropertiesData):
 
     @property
     def isperiodic(self):
-        """TODO
+        """TODO.
 
         .. versionadded:: 2.0
 
@@ -1409,6 +1408,7 @@ class PropertiesDataBounds(PropertiesData):
         :Returns:
 
             TODO
+
         """
         variable0 = variables[0]
 
@@ -1996,7 +1996,7 @@ class PropertiesDataBounds(PropertiesData):
 
     @_inplace_enabled(default=False)
     def flatten(self, axes=None, inplace=False):
-        """Flatten axes of the data
+        """Flatten axes of the data.
 
         Any subset of the axes may be flattened.
 
@@ -2108,8 +2108,8 @@ class PropertiesDataBounds(PropertiesData):
         )
 
     def direction(self):
-        """Return `None`, indicating that it is not specified whether the
-        values are increasing or decreasing.
+        """Return `None`, indicating that it is not specified whether
+        the values are increasing or decreasing.
 
         .. versionadded:: 2.0
 
@@ -2745,7 +2745,8 @@ class PropertiesDataBounds(PropertiesData):
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     def arctan(self, bounds=True, inplace=False):
-        """Take the trigonometric inverse tangent of the data element-wise.
+        """Take the trigonometric inverse tangent of the data element-
+        wise.
 
         Units are ignored in the calculation. The result has units of radians.
 
@@ -2948,7 +2949,8 @@ class PropertiesDataBounds(PropertiesData):
 
     @_inplace_enabled(default=False)
     def arccos(self, bounds=True, inplace=False):
-        """Take the trigonometric inverse cosine of the data element-wise.
+        """Take the trigonometric inverse cosine of the data element-
+        wise.
 
         Units are ignored in the calculation. The result has units of radians.
 
@@ -3853,22 +3855,22 @@ class PropertiesDataBounds(PropertiesData):
     # ----------------------------------------------------------------
     @property
     def hasbounds(self):
-        """Deprecated at version 3.0.0, use method `has_bounds` instead."""
+        """Deprecated at version 3.0.0, use method `has_bounds`
+        instead."""
         _DEPRECATION_ERROR_ATTRIBUTE(
             self, "hasbounds", "Use method 'has_bounds' instead."
         )  # pragma: no cover
 
     def expand_dims(self, position=0, i=False):
         """Deprecated at version 3.0.0, use method `insert_dimension`
-        instead.
-
-        """
+        instead."""
         _DEPRECATION_ERROR_METHOD(
             self, "expand_dims", "Use method 'insert_dimension' instead."
         )  # pragma: no cover
 
     def files(self):
-        """Deprecated at version 3.4.0, use method `get_filenames` instead."""
+        """Deprecated at version 3.4.0, use method `get_filenames`
+        instead."""
         _DEPRECATION_ERROR_METHOD(
             self,
             "expand_dims",

--- a/cf/mixin_container.py
+++ b/cf/mixin_container.py
@@ -15,8 +15,8 @@ class Container:
     """
 
     def __docstring_substitutions__(self):
-        """Define docstring substitutions that apply to this class and all of
-        its subclasses.
+        """Define docstring substitutions that apply to this class and
+        all of its subclasses.
 
         These are in addtion to, and take precendence over, docstring
         substitutions defined by the base classes of this class.
@@ -36,7 +36,8 @@ class Container:
         return _docstring_substitution_definitions
 
     def __docstring_package_depth__(self):
-        """Return the package depth for {{package}} docstring substitutions.
+        """Return the package depth for {{package}} docstring
+        substitutions.
 
         See `_docstring_package_depth` for details.
 

--- a/cf/query.py
+++ b/cf/query.py
@@ -353,7 +353,7 @@ class Query:
 
     @property
     def attr(self):
-        """TODO
+        """TODO.
 
         **Examples:**
 
@@ -372,7 +372,7 @@ class Query:
 
     @property
     def operator(self):
-        """TODO
+        """TODO.
 
         Compound conditions return `None`.
 
@@ -390,7 +390,7 @@ class Query:
 
     @property
     def value(self):
-        """TODO
+        """TODO.
 
         An exception is raised for compound conditions.
 
@@ -410,8 +410,8 @@ class Query:
         raise AttributeError("Compound query doesn't have attribute 'value'")
 
     def addattr(self, attr):
-        """Return a `Query` object with a new left hand side operand attribute
-        to be used during evaluation. TODO
+        """Return a `Query` object with a new left hand side operand
+        attribute to be used during evaluation. TODO.
 
         If another attribute has previously been specified, then the new
         attribute is considered to be an attribute of the existing
@@ -474,7 +474,8 @@ class Query:
 
     @_display_or_return
     def dump(self, display=True):
-        """Return a string containing a full description of the instance.
+        """Return a string containing a full description of the
+        instance.
 
         :Parameters:
 
@@ -496,7 +497,7 @@ class Query:
     @_deprecated_kwarg_check("traceback")
     @_manage_log_level_via_verbosity
     def equals(self, other, verbose=None, traceback=False):
-        """TODO"""
+        """TODO."""
         if self._compound:
             if not other._compound:
                 logger.info(
@@ -572,7 +573,8 @@ class Query:
         return True
 
     def evaluate(self, x):
-        """Evaluate the query operation for a given left hand side operand.
+        """Evaluate the query operation for a given left hand side
+        operand.
 
         Note that for the query object ``q`` and any object, ``x``,
         ``x==q`` is equivalent to ``q.evaluate(x)`` and ``x!=q`` is
@@ -759,7 +761,11 @@ class Query:
     # ----------------------------------------------------------------
     @property
     def exact(self):
-        """TODO Deprecated at version 3.0.0. Use re.compile objects instead."""
+        """TODO Deprecated at version 3.0.0.
+
+        Use re.compile objects instead.
+
+        """
         _DEPRECATION_ERROR_ATTRIBUTE(
             self, "exact", "Use 're.compile' objects instead."
         )  # pragma: no cover
@@ -1688,7 +1694,8 @@ def cellge(value, units=None):
 
 
 def celllt(value, units=None):
-    """A `Query` object for a “cell bounds strictly less than” condition.
+    """A `Query` object for a “cell bounds strictly less than”
+    condition.
 
     .. seealso:: `cf.cellsize`, `cf.contains`, `cf.cellge`,
                  `cf.cellgt`, `cf.cellne`, `cf.cellle`, `cf.cellwi`,
@@ -1719,7 +1726,8 @@ def celllt(value, units=None):
 
 
 def cellle(value, units=None):
-    """A `Query` object for a "cell bounds less than or equal" condition.
+    """A `Query` object for a "cell bounds less than or equal"
+    condition.
 
     .. seealso:: `cf.cellsize`, `cf.contains`, `cf.cellge`,
                  `cf.cellgt`, `cf.cellne`, `cf.celllt`, `cf.cellwi`,
@@ -1988,8 +1996,9 @@ def dtge(*args, **kwargs):
 
 
 def dtgt(*args, **kwargs):
-    """Deprecated at version 3.0.0. Use 'cf.gt' with a datetime object
-    value instead.
+    """Deprecated at version 3.0.0.
+
+    Use 'cf.gt' with a datetime object value instead.
 
     """
     _DEPRECATION_ERROR_FUNCTION(
@@ -1998,8 +2007,9 @@ def dtgt(*args, **kwargs):
 
 
 def dtle(*args, **kwargs):
-    """Deprecated at version 3.0.0. Use 'cf.le' with a datetime object
-    value instead.
+    """Deprecated at version 3.0.0.
+
+    Use 'cf.le' with a datetime object value instead.
 
     """
     _DEPRECATION_ERROR_FUNCTION(
@@ -2008,8 +2018,9 @@ def dtle(*args, **kwargs):
 
 
 def dtlt(*args, **kwargs):
-    """Deprecated at version 3.0.0. Use 'cf.lt' with a datetime object
-    value instead.
+    """Deprecated at version 3.0.0.
+
+    Use 'cf.lt' with a datetime object value instead.
 
     """
     _DEPRECATION_ERROR_FUNCTION(
@@ -2018,8 +2029,9 @@ def dtlt(*args, **kwargs):
 
 
 def dteq(*args, **kwargs):
-    """Deprecated at version 3.0.0. Use 'cf.eq' with a datetime object
-    value instead.
+    """Deprecated at version 3.0.0.
+
+    Use 'cf.eq' with a datetime object value instead.
 
     """
     _DEPRECATION_ERROR_FUNCTION(
@@ -2028,8 +2040,9 @@ def dteq(*args, **kwargs):
 
 
 def dtne(*args, **kwargs):
-    """Deprecated at version 3.0.0. Use 'cf.ne' with a datetime object
-    value instead.
+    """Deprecated at version 3.0.0.
+
+    Use 'cf.ne' with a datetime object value instead.
 
     """
     _DEPRECATION_ERROR_FUNCTION(

--- a/cf/read_write/netcdf/netcdfread.py
+++ b/cf/read_write/netcdf/netcdfread.py
@@ -12,15 +12,15 @@ from ...units import Units
 
 
 class NetCDFRead(cfdm.read_write.netcdf.NetCDFRead):
-    """TODO
+    """TODO.
 
     .. versionadded:: 3.0.0
 
     """
 
     def _ncdimensions(self, ncvar):
-        """Return a list of the netCDF dimensions corresponding to a netCDF
-        variable.
+        """Return a list of the netCDF dimensions corresponding to a
+        netCDF variable.
 
         If the variable has been compressed then the *implied
         uncompressed* dimensions are returned.
@@ -66,8 +66,8 @@ class NetCDFRead(cfdm.read_write.netcdf.NetCDFRead):
         return list(map(str, ncdimensions))
 
     def _get_domain_axes(self, ncvar, allow_external=False):
-        """Return the domain axis identifiers that correspond to a netCDF
-        variable's netCDF dimensions.
+        """Return the domain axis identifiers that correspond to a
+        netCDF variable's netCDF dimensions.
 
         For a CFA variable, the netCDF dimensions are taken from the
         'cfa_dimensions' netCDF attribute.
@@ -130,7 +130,7 @@ class NetCDFRead(cfdm.read_write.netcdf.NetCDFRead):
         uncompress_override=None,
         parent_ncvar=None,
     ):
-        """TODO
+        """TODO.
 
         .. versionadded:: 3.0.0
 
@@ -286,7 +286,7 @@ class NetCDFRead(cfdm.read_write.netcdf.NetCDFRead):
         loadd=None,
         **kwargs
     ):
-        """TODO
+        """TODO.
 
         .. versionadded:: 3.0.0
 
@@ -317,7 +317,7 @@ class NetCDFRead(cfdm.read_write.netcdf.NetCDFRead):
         )
 
     def _customize_read_vars(self):
-        """TODO
+        """TODO.
 
         .. versionadded:: 3.0.0
 

--- a/cf/read_write/netcdf/netcdfwrite.py
+++ b/cf/read_write/netcdf/netcdfwrite.py
@@ -12,10 +12,10 @@ from ...functions import relpath
 
 
 class NetCDFWrite(cfdm.read_write.netcdf.NetCDFWrite):
-    """TODO"""
+    """TODO."""
 
     def _write_as_cfa(self, cfvar):
-        """TODO
+        """TODO.
 
         .. versionadded:: 3.0.0
 
@@ -42,7 +42,8 @@ class NetCDFWrite(cfdm.read_write.netcdf.NetCDFWrite):
         return True
 
     def _customize_createVariable(self, cfvar, kwargs):
-        """Customise keyword arguments for `netCDF4.Dataset.createVariable`.
+        """Customise keyword arguments for
+        `netCDF4.Dataset.createVariable`.
 
         .. versionadded:: 3.0.0
 
@@ -77,7 +78,7 @@ class NetCDFWrite(cfdm.read_write.netcdf.NetCDFWrite):
         compressed=False,
         attributes={},
     ):
-        """TODO
+        """TODO.
 
         .. versionadded:: 3.0.0
 
@@ -156,7 +157,8 @@ class NetCDFWrite(cfdm.read_write.netcdf.NetCDFWrite):
     def _write_dimension_coordinate(
         self, f, key, coord, ncdim=None, coordinates=None
     ):
-        """Write a coordinate variable and its bound variable to the file.
+        """Write a coordinate variable and its bound variable to the
+        file.
 
         This also writes a new netCDF dimension to the file and, if
         required, a new netCDF dimension for the bounds.
@@ -273,7 +275,7 @@ class NetCDFWrite(cfdm.read_write.netcdf.NetCDFWrite):
         return super()._write_auxiliary_coordinate(f, key, coord, coordinates)
 
     def _change_reference_datetime(self, coord):
-        """TODO
+        """TODO.
 
         .. versionadded:: 3.0.0
 
@@ -572,8 +574,8 @@ class NetCDFWrite(cfdm.read_write.netcdf.NetCDFWrite):
         return "".join(random.choice(hexdigits) for i in range(size))
 
     def _convert_to_builtin_type(self, x):
-        """Convert a non-JSON-encodable object to a JSON-encodable built-in
-        type.
+        """Convert a non-JSON-encodable object to a JSON-encodable
+        built-in type.
 
         Possible conversions are:
 

--- a/cf/read_write/um/filearray.py
+++ b/cf/read_write/um/filearray.py
@@ -68,7 +68,7 @@ class UMFileArray(FileArray):
     """
 
     def __getitem__(self, indices):
-        """Implement indexing
+        """Implement indexing.
 
         x.__getitem__(indices) <==> x[indices]
 
@@ -158,7 +158,7 @@ class UMFileArray(FileArray):
 
     @property
     def file_pointer(self):
-        """TODO"""
+        """TODO."""
         return (self.file, self.header_offset)
 
     def close(self):

--- a/cf/read_write/um/umread.py
+++ b/cf/read_write/um/umread.py
@@ -495,7 +495,7 @@ _axis = {"area": None}
 
 
 class UMField:
-    """TODO"""
+    """TODO."""
 
     def __init__(
         self,
@@ -1109,7 +1109,7 @@ class UMField:
         return "\n".join(out)
 
     def atmosphere_hybrid_height_coordinate(self, axiscode):
-        """TODO
+        """TODO.
 
         **From appendix A of UMDP F3**
 
@@ -1246,7 +1246,7 @@ class UMField:
         return dc
 
     def depth_coordinate(self, axiscode):
-        """TODO
+        """TODO.
 
         :Parameters:
 
@@ -1310,7 +1310,8 @@ class UMField:
         return dc
 
     def atmosphere_hybrid_sigma_pressure_coordinate(self, axiscode):
-        """atmosphere_hybrid_sigma_pressure_coordinate when not an array axis
+        """atmosphere_hybrid_sigma_pressure_coordinate when not an array
+        axis.
 
         46 BULEV Upper layer boundary or BRSVD(1)
 
@@ -1407,7 +1408,7 @@ class UMField:
         return dc
 
     def create_cell_methods(self):
-        """Create the cell methods
+        """Create the cell methods.
 
         :Returns:
 
@@ -1492,7 +1493,7 @@ class UMField:
         return cell_methods
 
     def coord_axis(self, c, axiscode):
-        """TODO"""
+        """TODO."""
         axis = _coord_axis.setdefault(axiscode, None)
         if axis is not None:
             c.axis = axis
@@ -1547,7 +1548,7 @@ class UMField:
         return c
 
     def coord_names(self, coord, axiscode):
-        """TODO
+        """TODO.
 
         :Parameters:
 
@@ -1573,7 +1574,7 @@ class UMField:
         return coord
 
     def coord_positive(self, c, axiscode, domain_axis_key):
-        """TODO
+        """TODO.
 
         :Parameters:
 
@@ -1598,7 +1599,7 @@ class UMField:
         return c
 
     def ctime(self, rec):
-        """TODO"""
+        """TODO."""
         reftime = self.refUnits
         LBVTIME = tuple(self.header_vtime(rec))
         LBDTIME = tuple(self.header_dtime(rec))
@@ -1621,8 +1622,8 @@ class UMField:
         return ctime
 
     def header_vtime(self, rec):
-        """Return the list [LBYR, LBMON, LBDAT, LBHR, LBMIN] for the given
-        record.
+        """Return the list [LBYR, LBMON, LBDAT, LBHR, LBMIN] for the
+        given record.
 
         :Parameters:
 
@@ -1641,8 +1642,8 @@ class UMField:
         return rec.int_hdr[lbyr : lbmin + 1]
 
     def header_dtime(self, rec):
-        """Return the list [LBYRD, LBMOND, LBDATD, LBHRD, LBMIND] for the
-        given record.
+        """Return the list [LBYRD, LBMOND, LBDATD, LBHRD, LBMIND] for
+        the given record.
 
         :Parameters:
 
@@ -1661,8 +1662,8 @@ class UMField:
         return rec.int_hdr[lbyrd : lbmind + 1]
 
     def header_bz(self, rec):
-        """Return the list [BLEV, BRLEV, BHLEV, BHRLEV, BULEV, BHULEV] for the
-        given record.
+        """Return the list [BLEV, BRLEV, BHLEV, BHRLEV, BULEV, BHULEV]
+        for the given record.
 
         :Parameters:
 
@@ -1712,8 +1713,8 @@ class UMField:
         ]
 
     def header_z(self, rec):
-        """Return the list [LBLEV, LBUSER5, BLEV, BRLEV, BHLEV, BHRLEV, BULEV,
-        BHULEV] for the given record.
+        """Return the list [LBLEV, LBUSER5, BLEV, BRLEV, BHLEV, BHRLEV,
+        BULEV, BHULEV] for the given record.
 
         These header items are used by the compare_levels function in
         compare.c
@@ -1957,7 +1958,8 @@ class UMField:
         return data
 
     def decode_lbexp(self):
-        """Decode the integer value of LBEXP in the PP header into a runid.
+        """Decode the integer value of LBEXP in the PP header into a
+        runid.
 
         If this value has already been decoded, then it will be returned
         from the cache, otherwise the value will be decoded and then added
@@ -2011,7 +2013,8 @@ class UMField:
         return runid
 
     def dtime(self, rec):
-        """Return the elapsed time since the data time of the given record.
+        """Return the elapsed time since the data time of the given
+        record.
 
         :Parameters:
 
@@ -2099,7 +2102,7 @@ class UMField:
         return out2
 
     def latitude_longitude_2d_aux_coordinates(self, yc, xc):
-        """TODO
+        """TODO.
 
         :Parameters:
 
@@ -2194,7 +2197,7 @@ class UMField:
             )
 
     def model_level_number_coordinate(self, aux=False):
-        """model_level_number dimension or auxiliary coordinate
+        """model_level_number dimension or auxiliary coordinate.
 
         :Parameters:
 
@@ -2315,7 +2318,7 @@ class UMField:
                 logger.info(header)
 
     def pseudolevel_coordinate(self, LBUSER5):
-        """TODO"""
+        """TODO."""
         if self.nz == 1:
             array = numpy_array((LBUSER5,), dtype=self.int_hdr_dtype)
         else:
@@ -2351,7 +2354,7 @@ class UMField:
         return dc
 
     def radiation_wavelength_coordinate(self, rwl, rwl_units):
-        """TODO"""
+        """TODO."""
         array = numpy_array((rwl,), dtype=float)
         bounds = numpy_array(((0.0, rwl)), dtype=float)
 
@@ -2376,7 +2379,7 @@ class UMField:
         return dc
 
     def reference_time_Units(self):
-        """TODO"""
+        """TODO."""
         LBYR = self.int_hdr[lbyr]
         time_units = "days since {0}-1-1".format(LBYR)
         calendar = self.calendar
@@ -2393,7 +2396,7 @@ class UMField:
         return units
 
     def size_1_height_coordinate(self, axiscode, height, units):
-        """TODO"""
+        """TODO."""
         # Create the height coordinate from the information given in the
         # STASH to standard_name conversion table
 
@@ -2429,8 +2432,8 @@ class UMField:
         return dc
 
     def test_um_condition(self, um_condition, LBCODE, BPLAT, BPLON):
-        """Return `True` if a field satisfies the condition specified for a
-        STASH code to standard name conversion.
+        """Return `True` if a field satisfies the condition specified
+        for a STASH code to standard name conversion.
 
         :Parameters:
 
@@ -2487,8 +2490,8 @@ class UMField:
         return
 
     def test_um_version(self, valid_from, valid_to, um_version):
-        """Return `True` if the UM version applicable to this field is within
-        the given range.
+        """Return `True` if the UM version applicable to this field is
+        within the given range.
 
         If possible, the UM version is derived from the PP header and
         stored in the metadata object. Otherwise it is taken from the
@@ -2530,7 +2533,7 @@ class UMField:
         return False
 
     def time_coordinate(self, axiscode):
-        """Return the T dimension coordinate
+        """Return the T dimension coordinate.
 
         :Parameters:
 
@@ -2586,7 +2589,7 @@ class UMField:
         return dc
 
     def time_coordinate_from_extra_data(self, axiscode, axis):
-        """TODO"""
+        """TODO."""
         extra = self.extra
         array = extra[axis]
         bounds = extra.get(axis + "_bounds", None)
@@ -2612,7 +2615,7 @@ class UMField:
         return dc
 
     def time_coordinate_from_um_timeseries(self, axiscode, axis):
-        """TODO"""
+        """TODO."""
         # This PP/FF field is a timeseries. The validity time is
         # taken to be the time for the first sample, the data time
         # for the last sample, with the others evenly between.
@@ -2677,7 +2680,7 @@ class UMField:
         return time
 
     def dddd(self):
-        """TODO"""
+        """TODO."""
         for axis_code, extra_type in zip((11, 10), ("x", "y")):
             coord_type = extra_type + "_domain_bounds"
 
@@ -2824,8 +2827,8 @@ class UMField:
         return (unrotated_lat, unrotated_lon)
 
     def xy_coordinate(self, axiscode, axis):
-        """Create an X or Y dimension coordinate from header entries or extra
-        data.
+        """Create an X or Y dimension coordinate from header entries or
+        extra data.
 
         :Parameters:
 
@@ -2911,7 +2914,7 @@ class UMField:
 
     @_manage_log_level_via_verbose_attr
     def z_coordinate(self, axiscode):
-        """Create a Z dimension coordinate from BLEV
+        """Create a Z dimension coordinate from BLEV.
 
         :Parameters:
 
@@ -2984,7 +2987,7 @@ class UMField:
 
     @_manage_log_level_via_verbose_attr
     def z_reference_coordinate(self, axiscode):
-        """TODO"""
+        """TODO."""
         logger.info(
             "Creating Z reference coordinates from BRLEV"
         )  # pragma: no cover
@@ -3190,7 +3193,7 @@ stash2standard_name = _stash2standard_name
 
 
 class UMRead(cfdm.read_write.IORead):
-    """TODO"""
+    """TODO."""
 
     @_manage_log_level_via_verbosity
     def read(

--- a/cf/read_write/write.py
+++ b/cf/read_write/write.py
@@ -55,7 +55,6 @@ def write(
 ):
     """Write field constructs to a netCDF file.
 
-
     **File format**
 
     See the *fmt* parameter for details on which output netCDF file

--- a/cf/regrid.py
+++ b/cf/regrid.py
@@ -18,9 +18,7 @@ if _found_ESMF:
 
 class Regrid:
     """Class containing all the methods required for accessing ESMF
-    regridding through ESMPY and the associated utility methods.
-
-    """
+    regridding through ESMPY and the associated utility methods."""
 
     def __init__(
         self,
@@ -31,8 +29,9 @@ class Regrid:
         method="conservative_1st",
         ignore_degenerate=False,
     ):
-        """Creates a handle for regridding fields from a source grid to a
-        destination grid that can then be used by the run_regridding method.
+        """Creates a handle for regridding fields from a source grid to
+        a destination grid that can then be used by the run_regridding
+        method.
 
         :Parameters:
 
@@ -107,8 +106,8 @@ class Regrid:
     @staticmethod
     def initialize():
         """Check whether ESMF has been found. If not raise an import
-        error. Initialise the ESMPy manager. Whether logging is enabled or
-        not is determined by cf.regrid_logging. If it is then logging
+        error. Initialise the ESMPy manager. Whether logging is enabled
+        or not is determined by cf.regrid_logging. If it is then logging
         takes place after every call to ESMPy.
 
         :Returns:
@@ -136,9 +135,9 @@ class Regrid:
         coords_2D=False,
         coord_order=None,
     ):
-        """Create an ESMPy grid given a sequence of coordinates for use as a
-        source or destination grid in regridding. Optionally the grid may
-        have an associated mask.
+        """Create an ESMPy grid given a sequence of coordinates for use
+        as a source or destination grid in regridding. Optionally the
+        grid may have an associated mask.
 
         :Parameters:
 
@@ -415,8 +414,8 @@ class Regrid:
 
     @staticmethod
     def create_field(grid, name):
-        """Create an ESMPy field for use as a source or destination field in
-        regridding given an ESMPy grid and a name.
+        """Create an ESMPy field for use as a source or destination
+        field in regridding given an ESMPy grid and a name.
 
         :Parameters:
 
@@ -445,10 +444,10 @@ class Regrid:
 
     @staticmethod
     def concatenate_data(data_list, axis):
-        """Concatenates a list of Data objects into a single Data object along
-        the specified access (see cf.Data.concatenate for details). In the
-        case that the list contains only one element, that element is
-        simply returned.
+        """Concatenates a list of Data objects into a single Data object
+        along the specified access (see cf.Data.concatenate for
+        details). In the case that the list contains only one element,
+        that element is simply returned.
 
         :Parameters:
 
@@ -475,10 +474,10 @@ class Regrid:
 
     @staticmethod
     def reconstruct_sectioned_data(sections):
-        """Expects a dictionary of Data objects with ordering information as
-        keys, as output by the section method when called with a Data
-        object. Returns a reconstructed cf.Data object with the sections
-        in the original order.
+        """Expects a dictionary of Data objects with ordering
+        information as keys, as output by the section method when called
+        with a Data object. Returns a reconstructed cf.Data object with
+        the sections in the original order.
 
         :Parameters:
 

--- a/cf/test/create_test_files.py
+++ b/cf/test/create_test_files.py
@@ -939,7 +939,7 @@ def _make_geometry_1_file(filename):
 
 
 def _make_geometry_2_file(filename):
-    """See n.comment for details"""
+    """See n.comment for details."""
     n = netCDF4.Dataset(filename, "w", format="NETCDF3_CLASSIC")
 
     n.Conventions = "CF-" + VN
@@ -1019,7 +1019,7 @@ def _make_geometry_2_file(filename):
 
 
 def _make_geometry_3_file(filename):
-    """See n.comment for details"""
+    """See n.comment for details."""
     n = netCDF4.Dataset(filename, "w", format="NETCDF3_CLASSIC")
 
     n.Conventions = "CF-" + VN
@@ -1363,7 +1363,7 @@ def _make_interior_ring_file_2(filename):
 
 
 def _make_string_char_file(filename):
-    """See n.comment for details"""
+    """See n.comment for details."""
     n = netCDF4.Dataset(filename, "w", format="NETCDF4")
 
     n.Conventions = "CF-" + VN

--- a/cf/test/run_tests.py
+++ b/cf/test/run_tests.py
@@ -12,10 +12,12 @@ import cf
 def randomise_test_order(*_args):
     """Return a random choice from 1 or -1.
 
-    When set as the test loader method for standard (merge)sort comparison
-    to order all methods in a test case (see 'sortTestMethodsUsing'), ensures
-    they run in a random order, meaning implicit reliance on setup or state,
-    i.e. test dependencies, become evident over repeated runs.
+    When set as the test loader method for standard (merge)sort
+    comparison to order all methods in a test case (see
+    'sortTestMethodsUsing'), ensures they run in a random order, meaning
+    implicit reliance on setup or state, i.e. test dependencies, become
+    evident over repeated runs.
+
     """
     return choice([1, -1])
 

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -32,7 +32,7 @@ tmpfiles = [
 
 
 def _remove_tmpfiles():
-    """TODO"""
+    """TODO."""
     for f in tmpfiles:
         try:
             os.remove(f)

--- a/cf/test/test_Query.py
+++ b/cf/test/test_Query.py
@@ -130,7 +130,8 @@ class QueryTest(unittest.TestCase):
             )
 
     def test_Query_as_where_condition(self):
-        """Check queries work correctly as conditions in 'where' method."""
+        """Check queries work correctly as conditions in 'where'
+        method."""
         # TODO: extend test; added as-is to capture a specific bug (now fixed)
 
         s_data = cf.Data([30, 60, 90], "second")

--- a/cf/test/test_decorators.py
+++ b/cf/test/test_decorators.py
@@ -16,9 +16,8 @@ logger = cf.logging.getLogger(log_name)
 
 
 class dummyClass:
-    """Dummy class acting as container to test methods as proper instance
-    methods, mirroring their context in the codebase.
-    """
+    """Dummy class acting as container to test methods as proper
+    instance methods, mirroring their context in the codebase."""
 
     def __init__(self, verbose=None):
         self.verbose = verbose
@@ -29,9 +28,9 @@ class dummyClass:
         self.warning_message = "Best pay attention to this!"
 
     def func_2(self, good_kwarg=True, traceback=False, bad_kwarg=False):
-        """Dummy function, otherwise trivial, where a True boolean passed as
-        a traceback keyword argument will ultimately raise an error.
-        """
+        """Dummy function, otherwise trivial, where a True boolean
+        passed as a traceback keyword argument will ultimately raise an
+        error."""
         if traceback:
             cf.functions._DEPRECATION_ERROR_KWARGS(
                 self, "another_func", traceback=True
@@ -40,9 +39,9 @@ class dummyClass:
 
     @cf.decorators._deprecated_kwarg_check("traceback")
     def decorated_func_2(self, good_kwarg=True, traceback=False):
-        """Dummy function equivalent to 'func_2', but a decorator manages the
-        logic to raise the error on use of a deprecated keyword argument.
-        """
+        """Dummy function equivalent to 'func_2', but a decorator
+        manages the logic to raise the error on use of a deprecated
+        keyword argument."""
         return good_kwarg
 
     # Not testing 'bad_kwarg' here other than to the extent that it does not
@@ -51,16 +50,18 @@ class dummyClass:
     def multikwarg_decorated_func_2(
         self, good_kwarg=True, traceback=False, bad_kwarg=False
     ):
-        """Dummy function equivalent to 'func_2', but a decorator manages the
-        logic to raise the error on use of a deprecated keyword argument.
-        """
+        """Dummy function equivalent to 'func_2', but a decorator
+        manages the logic to raise the error on use of a deprecated
+        keyword argument."""
         return good_kwarg
 
     @cf.decorators._manage_log_level_via_verbose_attr
     def decorated_logging_func(self):
         """Dummy method to test _manage_log_level_via_verbose_attr.
 
-        In particular, to test it interfaces with self.verbose correctly.
+        In particular, to test it interfaces with self.verbose
+        correctly.
+
         """
         logger.debug(self.debug_message)
         logger.detail(self.detail_message)
@@ -75,9 +76,10 @@ class DecoratorsTest(unittest.TestCase):
     """Test decorators module.
 
     These are unit tests on the self-contained decorators applied to an
-    artificial, trivial & not cf-python specific class, so for the cases where
-    decorators are imported directly from cf, there is no need to duplicate
-    such tests which are already in the cf test suite.
+    artificial, trivial & not cf-python specific class, so for the cases
+    where decorators are imported directly from cf, there is no need to
+    duplicate such tests which are already in the cf test suite.
+
     """
 
     def setUp(self):

--- a/cf/test/test_docstring.py
+++ b/cf/test/test_docstring.py
@@ -10,7 +10,8 @@ import cfdm
 
 
 def _recurse_on_subclasses(klass):
-    """Return as a set all subclasses in a classes' subclass hierarchy."""
+    """Return as a set all subclasses in a classes' subclass
+    hierarchy."""
     return set(klass.__subclasses__()).union(
         [
             sub
@@ -21,11 +22,14 @@ def _recurse_on_subclasses(klass):
 
 
 def _get_all_abbrev_subclasses(klass):
-    """Return set of all subclasses in class hierarchy, filtering some out.
+    """Return set of all subclasses in class hierarchy, filtering some
+    out.
 
-    Filter out cf.mixin.properties*.Properties* (by means of there not being
-    any abbreviated cf.Properties* classes) plus any cfdm classes, since
-    this function needs to take cf subclasses from cfdm classes as well.
+    Filter out cf.mixin.properties*.Properties* (by means of there not
+    being any abbreviated cf.Properties* classes) plus any cfdm classes,
+    since this function needs to take cf subclasses from cfdm classes as
+    well.
+
     """
     return tuple(
         [

--- a/cf/test/test_dsg.py
+++ b/cf/test/test_dsg.py
@@ -21,7 +21,7 @@ tmpfiles = [
 
 
 def _remove_tmpfiles():
-    """TODO"""
+    """TODO."""
     for f in tmpfiles:
         try:
             os.remove(f)

--- a/cf/test/test_formula_terms.py
+++ b/cf/test/test_formula_terms.py
@@ -8,10 +8,8 @@ import cf
 
 
 def _formula_terms(standard_name):
-    """Return a field construct with a vertical CRS, its computed
-    non-parametric coordinates, and the computed standard name.
-
-    """
+    """Return a field construct with a vertical CRS, its computed non-
+    parametric coordinates, and the computed standard name."""
     # field: air_temperature
     field = cf.Field()
     field.set_properties({"standard_name": "air_temperature", "units": "K"})

--- a/cf/test/test_gathering.py
+++ b/cf/test/test_gathering.py
@@ -22,7 +22,7 @@ tmpfiles = [
 
 
 def _remove_tmpfiles():
-    """TODO"""
+    """TODO."""
     for f in tmpfiles:
         try:
             os.remove(f)

--- a/cf/test/test_read_write.py
+++ b/cf/test/test_read_write.py
@@ -31,7 +31,7 @@ tmpfiles = [
 
 
 def _remove_tmpfiles():
-    """TODO"""
+    """TODO."""
     for f in tmpfiles:
         try:
             os.remove(f)

--- a/cf/test/test_style.py
+++ b/cf/test/test_style.py
@@ -10,7 +10,8 @@ import cf
 
 
 class styleTest(unittest.TestCase):
-    """Test PEP8 compliance on all Python '.py' files in the 'cf' directory."""
+    """Test PEP8 compliance on all Python '.py' files in the 'cf'
+    directory."""
 
     def setUp(self):
         os.chdir(os.path.dirname(os.path.abspath(__file__)))

--- a/cf/timeduration.py
+++ b/cf/timeduration.py
@@ -388,7 +388,7 @@ class TimeDuration:
         return out
 
     def __array__(self, *dtype):
-        """TODO"""
+        """TODO."""
         return self.duration.__array__(*dtype)
 
     def __data__(self):
@@ -396,11 +396,11 @@ class TimeDuration:
         return self.duration
 
     def __deepcopy__(self, memo):
-        """Used if copy.deepcopy is called"""
+        """Used if copy.deepcopy is called."""
         return self.copy()
 
     def __neg__(self):
-        """x.__neg__() <==> -x
+        """x.__neg__() <==> -x.
 
         .. versionadded:: 1.4
 
@@ -699,7 +699,8 @@ class TimeDuration:
         return NotImplemented
 
     def __radd__(self, other):
-        """The binary arithmetic operation ``+`` with reflected operands
+        """The binary arithmetic operation ``+`` with reflected
+        operands.
 
         x.__radd__(y) <==> y+x
 
@@ -707,7 +708,8 @@ class TimeDuration:
         return self + other
 
     def __rmul__(self, other):
-        """The binary arithmetic operation ``*`` with reflected operands
+        """The binary arithmetic operation ``*`` with reflected
+        operands.
 
         x.__rmul__(y) <==> y*x
 
@@ -715,7 +717,8 @@ class TimeDuration:
         return self * other
 
     def __rsub__(self, other):
-        """The binary arithmetic operation ``-`` with reflected operands
+        """The binary arithmetic operation ``-`` with reflected
+        operands.
 
         x.__rsub__(y) <==> y - x
 
@@ -749,7 +752,8 @@ class TimeDuration:
         return NotImplemented
 
     def __rmod__(self, other):
-        """The binary arithmetic operation ``%`` with reflected operands
+        """The binary arithmetic operation ``%`` with reflected
+        operands.
 
         x.__rmod__(y) <==> y % x
 
@@ -763,7 +767,7 @@ class TimeDuration:
     # Private methods
     # ----------------------------------------------------------------
     def _binary_operation(self, other, method, inplace=False):
-        """TODO"""
+        """TODO."""
         if inplace:
             new = self
         else:
@@ -811,7 +815,7 @@ class TimeDuration:
         return new
 
     def _data_binary_operation(self, other, method, inplace=False):
-        """TODO"""
+        """TODO."""
         if inplace:
             new = self
         else:
@@ -820,7 +824,7 @@ class TimeDuration:
         return getattr(self.duration, method)(other)
 
     def _datetime_arithmetic(self, other, op):
-        """TODO
+        """TODO.
 
         .. versionadded:: 1.4
 
@@ -831,7 +835,6 @@ class TimeDuration:
             op: `str`
 
         :Returns:
-
 
         """
 
@@ -899,7 +902,7 @@ class TimeDuration:
             return _dHMS(duration, other, calendar, op)
 
     def _data_arithmetic(self, other, method, inplace=False):
-        """TODO"""
+        """TODO."""
         try:
             dt = other.datetime_array
         except ValueError:
@@ -918,7 +921,7 @@ class TimeDuration:
             return Data(dt, units=other.Units)
 
     def _offset(self, dt):
-        """TODO
+        """TODO.
 
         .. versionadded:: 1.4
 
@@ -944,7 +947,8 @@ class TimeDuration:
     # ----------------------------------------------------------------
     @property
     def iso(self):
-        """Return the time duration as an ISO 8601-like time duration string.
+        """Return the time duration as an ISO 8601-like time duration
+        string.
 
         .. versionadded:: 1.0
 
@@ -1065,8 +1069,8 @@ class TimeDuration:
     def days_in_month(
         cls, year, month, calendar=None, leap_month=2, month_lengths=None
     ):
-        """The number of days in a specific month in a specific year in a
-        specific calendar.
+        """The number of days in a specific month in a specific year in
+        a specific calendar.
 
         .. versionadded:: 1.4
 
@@ -1595,8 +1599,8 @@ class TimeDuration:
             return (dt1, dt0)
 
     def is_day_factor(self):
-        """Return True if an integer multiple of the time duration is equal
-        to one day.
+        """Return True if an integer multiple of the time duration is
+        equal to one day.
 
         .. versionadded:: 1.0
 

--- a/cf/umread_lib/cInterface.py
+++ b/cf/umread_lib/cInterface.py
@@ -26,8 +26,8 @@ class File_type(CT.Structure):
 def _get_ctypes_array(dtype, size=None):
     """Get ctypes corresponding to a numpy array of a given type.
 
-    The size should not be necessary unless the storage for the array
-    is allocated in the C code.
+    The size should not be necessary unless the storage for the array is
+    allocated in the C code.
 
     """
     kwargs = {
@@ -43,7 +43,8 @@ def _get_ctypes_array(dtype, size=None):
 
 def _gen_rec_class(int_type, float_type):
     class Rec(CT.Structure):
-        """ctypes object corresponding to the `Rec` object in the C code."""
+        """ctypes object corresponding to the `Rec` object in the C
+        code."""
 
         _fields_ = [
             ("int_hdr", _get_ctypes_array(int_type, _len_int_hdr)),
@@ -63,7 +64,8 @@ Rec64 = _gen_rec_class(numpy.int64, numpy.float64)
 
 def _gen_var_class(rec_class):
     class Var(CT.Structure):
-        """ctypes object corresponding to the `Var` object in the C code."""
+        """ctypes object corresponding to the `Var` object in the C
+        code."""
 
         _fields_ = [
             ("recs", CT.POINTER(CT.POINTER(rec_class))),
@@ -82,7 +84,8 @@ Var64 = _gen_var_class(Rec64)
 
 def _gen_file_class(var_class):
     class File(CT.Structure):
-        """ctypes object corresponding to the `File` object in the C code"""
+        """ctypes object corresponding to the `File` object in the C
+        code."""
 
         _fields_ = [
             ("fd", CT.c_int),
@@ -141,7 +144,7 @@ class CInterface:
         self.lib = CT.CDLL(lib_path)
 
     def _is_null_pointer(self, ptr):
-        """TODO
+        """TODO.
 
         :Returns:
 
@@ -199,7 +202,7 @@ class CInterface:
         }
 
     def create_file_type(self, fmt, byte_ordering, word_size):
-        """TODO
+        """TODO.
 
         :Parameters:
 
@@ -227,9 +230,9 @@ class CInterface:
 
     def set_word_size(self, val):
         """Sets the word size used to interpret returned pointers from
-         subsequent calls, in particular the pointers to PP headers
-         embedded in the tree of objects returned by `file_parse` and the
-         data array that is populated by `read_record_data`.
+        subsequent calls, in particular the pointers to PP headers
+        embedded in the tree of objects returned by `file_parse` and the
+        data array that is populated by `read_record_data`.
 
         :Parameters:
 
@@ -261,29 +264,26 @@ class CInterface:
             )
 
     def _get_ctypes_int_array(self, size=None):
-        """TODO"""
+        """TODO."""
         return _get_ctypes_array(self.file_data_int_type, size)
 
     def _get_ctypes_real_array(self, size=None):
-        """TODO"""
+        """TODO."""
         return _get_ctypes_array(self.file_data_real_type, size)
 
     def _get_empty_real_array(self, size):
-        """Get empty `numpy` real array according to word size previously set
-        with `set_word_size`.
-
-        """
+        """Get empty `numpy` real array according to word size
+        previously set with `set_word_size`."""
         return numpy.empty(size, dtype=self.file_data_real_type)
 
     def _get_empty_int_array(self, size):
-        """Get empty `numpy` integer array according to word size previously
-        set with `set_word_size`.
-
-        """
+        """Get empty `numpy` integer array according to word size
+        previously set with `set_word_size`."""
         return numpy.empty(size, dtype=self.file_data_int_type)
 
     def parse_file(self, fh, file_type):
-        """Given an open file handle, work out information from the file.
+        """Given an open file handle, work out information from the
+        file.
 
         :Parameters:
 
@@ -324,8 +324,8 @@ class CInterface:
         return rv
 
     def c_var_to_py_var(self, c_var_p):
-        """Create a `umfile.Var` object from a ctypes object corresponding to
-         'Var*' in the C code.
+        """Create a `umfile.Var` object from a ctypes object
+        corresponding to 'Var*' in the C code.
 
         :Returns:
 
@@ -347,8 +347,8 @@ class CInterface:
         return umfile.Var(recs, nz, nt, svi)
 
     def c_rec_to_py_rec(self, c_rec_p):
-        """Create a `umfile.Rec` object from a ctypes object corresponding to
-        'Rec*' in the C code.
+        """Create a `umfile.Rec` object from a ctypes object
+        corresponding to 'Rec*' in the C code.
 
         :Returns:
 
@@ -392,8 +392,8 @@ class CInterface:
         )
 
     def get_type_and_num_words(self, int_hdr):
-        """From the integer header, work out data type and number of words to
-        read (`read_record_data` requires this).
+        """From the integer header, work out data type and number of
+        words to read (`read_record_data` requires this).
 
         :Returns:
 
@@ -426,7 +426,8 @@ class CInterface:
     def get_extra_data_offset_and_length(
         self, int_hdr, data_offset, disk_length
     ):
-        """From the integer header, gets offset and length of extra data.
+        """From the integer header, gets offset and length of extra
+        data.
 
         :Returns:
 
@@ -502,7 +503,7 @@ class CInterface:
         byte_ordering,
         word_size,
     ):
-        """Reads record data from open file
+        """Reads record data from open file.
 
         inputs:
            fd - integer low-level file descriptor
@@ -512,6 +513,7 @@ class CInterface:
            word_size - 4 or 8
 
         returns: extra data as string
+
         """
         extra_data = b"\0" * extra_data_length
 
@@ -549,7 +551,7 @@ class CInterface:
         data_type,
         nwords,
     ):
-        """Reads record data from open file
+        """Reads record data from open file.
 
         inputs:
            fd - integer low-level file descriptor

--- a/cf/umread_lib/extraData.py
+++ b/cf/umread_lib/extraData.py
@@ -27,10 +27,8 @@ _codes = {
 
 
 class ExtraData(dict):
-    """
-    Extends dictionary class with a comparison method between extra
-    data for different records.
-    """
+    """Extends dictionary class with a comparison method between extra
+    data for different records."""
 
     _key_to_type = dict([(key, typ) for key, typ in _codes.values()])
 
@@ -67,7 +65,7 @@ class ExtraData(dict):
         return 0
 
     def __cmp__(self, other):
-        """Compare two extra data dictionaries returned by unpacker"""
+        """Compare two extra data dictionaries returned by unpacker."""
         if other is None:
             return 1
         ka = self.sorted_keys()
@@ -105,10 +103,8 @@ class ExtraDataUnpacker:
         self.is_swapped = not byte_ordering.startswith(sys.byteorder)
 
     def next_words(self, n):
-        """
-        return next n words as raw data string, and pop them off the
-        front of the string
-        """
+        """return next n words as raw data string, and pop them off the
+        front of the string."""
         pos = n * self.ws
         rv = self.rdata[:pos]
         assert len(rv) == pos
@@ -116,9 +112,7 @@ class ExtraDataUnpacker:
         return rv
 
     def tweak_string(self, st):
-        """
-        undo byte-swapping of string and remove trailing NULs
-        """
+        """undo byte-swapping of string and remove trailing NULs."""
         if self.is_swapped:
             # concatenate backwards substrings
             st = string.join(
@@ -133,9 +127,7 @@ class ExtraDataUnpacker:
         return st
 
     def get_data(self):
-        """
-        get list of (key, value) for extra data
-        """
+        """get list of (key, value) for extra data."""
         d = {}
         while self.rdata:
             i = numpy.fromstring(self.next_words(1), self.itype)[0]

--- a/cf/umread_lib/umfile.py
+++ b/cf/umread_lib/umfile.py
@@ -13,10 +13,8 @@ class UMFileException(Exception):
 
 
 class File:
-    """A class for a UM file that gives a view of the file including sets
-    of PP records combined into variables.
-
-    """
+    """A class for a UM file that gives a view of the file including
+    sets of PP records combined into variables."""
 
     def __init__(
         self, path, byte_ordering=None, word_size=None, fmt=None, parse=True
@@ -117,7 +115,7 @@ class File:
         self.fd = None
 
     def _detect_file_type(self):
-        """TODO
+        """TODO.
 
         :Returns:
 
@@ -137,8 +135,8 @@ class File:
         self.word_size = d["word_size"]
 
     def _add_back_refs(self):
-        """Add file attribute to `Var` objects, and both `!file` and `!var`
-        attributes to `Rec` objects.
+        """Add file attribute to `Var` objects, and both `!file` and
+        `!var` attributes to `Rec` objects.
 
         The important one is the file attribute in the `Rec` object, as
         this is used when reading data. The others are provided for extra
@@ -188,7 +186,7 @@ class Var:
             return -1
 
     def _compare_recs_by_extra_data(self, a, b):
-        """TODO
+        """TODO.
 
         :Returns:
 
@@ -198,7 +196,7 @@ class Var:
         return self._compare(a.get_extra_data(), b.get_extra_data())
 
     def _compare_recs_by_orig_order(self, a, b):
-        """TODO
+        """TODO.
 
         :Returns:
 
@@ -208,10 +206,10 @@ class Var:
         return self._compare(self.recs.index(a), self.recs.index(b))
 
     def group_records_by_extra_data(self):
-        """Returns a list of (sub)lists of records where each records within
-        each sublist has matching extra data (if any), so if the whole
-        variable has consistent extra data then the return value will be
-        of length 1.
+        """Returns a list of (sub)lists of records where each records
+        within each sublist has matching extra data (if any), so if the
+        whole variable has consistent extra data then the return value
+        will be of length 1.
 
         Within each group, the ordering of returned records is the same as
         in the `!recs` attribute.
@@ -290,8 +288,8 @@ class Rec:
 
     @classmethod
     def from_file_and_offsets(cls, file, hdr_offset, data_offset, disk_length):
-        """Instantiate a `Rec` object from the `File` object and the header
-         and data offsets.
+        """Instantiate a `Rec` object from the `File` object and the
+        header and data offsets.
 
          The headers are read in, and also the record object is ready for
          calling `get_data`.
@@ -358,8 +356,8 @@ class Rec:
         return edu.get_data()
 
     def get_extra_data(self):
-        """Get extra data associated with the record, either by reading or
-        using cached read.
+        """Get extra data associated with the record, either by reading
+        or using cached read.
 
         :Returns:
 

--- a/setup.py
+++ b/setup.py
@@ -54,10 +54,8 @@ package_data = etc_files + umread_files + test_files
 
 
 class build_umread(build):
-    """Adpated from
-    https://github.com/Turbo87/py-xcsoar/blob/master/setup.py
-
-    """
+    """Adpated from https://github.com/Turbo87/py-
+    xcsoar/blob/master/setup.py."""
 
     def run(self):
         # Run original build code


### PR DESCRIPTION
Similar to NCAS-CMS/cfunits#22, but only to auto-format to, and set up a pre-commit hook for, `docformatter`, i.e. without (additionally) the formatting to abide by check pre-commit for `pydocstyle` compliance to Google-style docstrings.

Adapting the codebase to abide by `pydocstyle` will be postponed for cf-python because it is a manual process that would have to be done manually (and very likely incrementally), and we want to get started right away on the Dask-migration related work (#182) which requires a separate branch (`dask`) to keep in sync.