### PR TITLE
Fix docstring example syntax errors and test Python 3.9

### DIFF
--- a/cf/aggregate.py
+++ b/cf/aggregate.py
@@ -2871,7 +2871,7 @@ def _ok_coordinate_arrays(meta, axis, overlap, contiguous, verbose=None):
 
     **Examples:**
 
-    >>> if not _ok_coordinate_arrays(meta, 'latitude', True, False)
+    >>> if not _ok_coordinate_arrays(meta, 'latitude', True, False):
     ...     print("Don't aggregate")
 
     """

--- a/cf/cellmethod.py
+++ b/cf/cellmethod.py
@@ -404,7 +404,7 @@ class CellMethod(cfdm.CellMethod):
 
         >>> c
         <CF CellMethod: lat: lon: mean>
-        >>> c.intervals = ['0.2 degree_N', cf.Data(0.1 'degree_E')]
+        >>> c.intervals = ['0.2 degree_N', cf.Data(0.1, 'degree_E')]
         >>> c
         <CF CellMethod: lat: lon: mean (interval: 0.1 degree_N interval: 0.2 degree_E)>
 

--- a/cf/coordinatereference.py
+++ b/cf/coordinatereference.py
@@ -618,7 +618,7 @@ class CoordinateReference(cfdm.CoordinateReference):
         >>> r.coordinates
         {'atmosphere_hybrid_height_coordinate'}
         >>> r.change_coord_identitiers({
-        ...     'atmosphere_hybrid_height_coordinate', 'dim1', 'ncvar:ak': 'aux0'
+        ...     'atmosphere_hybrid_height_coordinate', 'dim1', 'ncvar:ak', 'aux0'
         ... })
         >>> r.coordinates
         {'dim1', 'aux0'}

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -1273,7 +1273,7 @@ class Data(Container, cfdm.Data):
 
         **Examples:**
 
-        >>> d._auxiliary_mask_subspace((slice(0, 9, 2))
+        >>> d._auxiliary_mask_subspace((slice(0, 9, 2)))
 
         """
         if not self._auxiliary_mask:
@@ -1532,7 +1532,7 @@ class Data(Container, cfdm.Data):
         3
         >>> len(Data([[1, 2, 3]]))
         1
-        >>> len(Data([[1, 2, 3], [4, 5, 6]])
+        >>> len(Data([[1, 2, 3], [4, 5, 6]]))
         2
         >>> len(Data(1))
         TypeError: len() of scalar Data
@@ -8941,7 +8941,7 @@ class Data(Container, cfdm.Data):
 
         **Examples:**
 
-        >>> d = cf.Data([[0 0 0]])
+        >>> d = cf.Data([[0, 0, 0]])
         >>> d.any()
         False
         >>> d[0, 0] = cf.masked
@@ -10438,7 +10438,7 @@ class Data(Container, cfdm.Data):
         >>> d.cos(inplace=True)
         >>> d.Units
         <Units: 1>
-        >>> print9d.array)
+        >>> print(d.array)
         [[0.540302305868 -0.416146836547 -0.9899924966 --]]
 
         """
@@ -10481,7 +10481,7 @@ class Data(Container, cfdm.Data):
         [2 2 2 2]
         >>> print(d.count(1).array)
         [0 4 4]
-        >>> print(d.count((0, 1))
+        >>> print(d.count((0, 1)))
         8
 
         """
@@ -14145,7 +14145,7 @@ class Data(Container, cfdm.Data):
         >>> d.tolist()
         [1, 2]
 
-        >>> d = cf.Data(([[1, 2], [3, 4]])
+        >>> d = cf.Data(([[1, 2], [3, 4]]))
         >>> list(d)
         [array([1, 2]), array([3, 4])]      # DCH CHECK
         >>> d.tolist()
@@ -15349,7 +15349,7 @@ def _overlapping_partitions(partitions, indices, axes, master_flip):
 
     **Examples:**
 
-    >>> type f.Data
+    >>> type(f.Data)
     <class 'cf.data.Data'>
     >>> d._axes
     ['dim1', 'dim2', 'dim0']

--- a/cf/field.py
+++ b/cf/field.py
@@ -5793,7 +5793,7 @@ class Field(mixin.PropertiesData, cfdm.Field):
         array(['ok'],
               dtype='|S2')
 
-        >>> f.set_property('flag_meanings', numpy.array(['a', 'b'])
+        >>> f.set_property('flag_meanings', numpy.array(['a', 'b']))
         >>> f.get_property('flag_meanings')
         array(['a', 'b'],
               dtype='|S1')
@@ -20111,7 +20111,7 @@ class Field(mixin.PropertiesData, cfdm.Field):
         Regrid field, f, on tripolar grid to latitude-longitude grid of
         field, g.
 
-        >>> h = f.regrids(g, 'linear, src_axes={'X': 'ncdim%x', 'Y': 'ncdim%y'},
+        >>> h = f.regrids(g, 'linear', src_axes={'X': 'ncdim%x', 'Y': 'ncdim%y'},
         ...               src_cyclic=True)
 
         Regrid f to the grid of g iterating over the 'Z' axis last and the

--- a/cf/field.py
+++ b/cf/field.py
@@ -20742,12 +20742,12 @@ class Field(mixin.PropertiesData, cfdm.Field):
         Regrid the time axes of field ``f`` conservatively onto a grid
         contained in field ``g``:
 
-        >>> h = f.regridc(g, axes='T', 'conservative')
+        >>> h = f.regridc(g, axes='T', method='conservative')
 
         Regrid the T axis of field ``f`` conservatively onto the grid
         specified in the dimension coordinate ``t``:
 
-        >>> h = f.regridc({'T': t}, axes=('T'), 'conservative_1st')
+        >>> h = f.regridc({'T': t}, axes=('T'), method='conservative_1st')
 
         Regrid the T axis of field ``f`` using linear interpolation onto
         a grid contained in field ``g``:
@@ -20757,7 +20757,7 @@ class Field(mixin.PropertiesData, cfdm.Field):
         Regrid the X and Y axes of field ``f`` conservatively onto a grid
         contained in field ``g``:
 
-        >>> h = f.regridc(g, axes=('X','Y'), 'conservative_1st')
+        >>> h = f.regridc(g, axes=('X','Y'), method='conservative_1st')
 
         Regrid the X and T axes of field ``f`` conservatively onto a grid
         contained in field ``g`` using the destination mask:

--- a/cf/fieldlist.py
+++ b/cf/fieldlist.py
@@ -1112,7 +1112,7 @@ class FieldList(list, cfdm.Container):
         *not* have a long_name property of 'Air Pressure':
 
            >>> gl = cf.FieldList(f for f in fl if not
-           ...                   f.match_by_property(long_name='Air Pressure))
+           ...                   f.match_by_property(long_name='Air Pressure'))
 
         .. versionadded:: 3.0.0
 

--- a/cf/functions.py
+++ b/cf/functions.py
@@ -2615,7 +2615,7 @@ def flat(x):
     [1, 2, 3, 4]
 
     >>> import numpy
-    >>> list(cf.flat((1, [2, numpy.array([[3, 4], [5, 6]])]))
+    >>> list(cf.flat((1, [2, numpy.array([[3, 4], [5, 6]])])))
     [1, 2, 3, 4, 5, 6]
 
     >>> for a in cf.flat([1, [2, [3, 4]]]):
@@ -2653,7 +2653,7 @@ def flat(x):
     <CF Field: eastward_wind(air_pressure(5), latitude(110), longitude(106)) m s-1>
     <CF Field: eastward_wind(air_pressure(5), latitude(110), longitude(106)) m s-1>
 
-    >>> fl = cf.FieldList(cf.flat([f, [f, [f, f]]])
+    >>> fl = cf.FieldList(cf.flat([f, [f, [f, f]]]))
     >>> fl
     [<CF Field: eastward_wind(air_pressure(5), latitude(110), longitude(106)) m s-1>,
      <CF Field: eastward_wind(air_pressure(5), latitude(110), longitude(106)) m s-1>,
@@ -2821,7 +2821,7 @@ def pathjoin(path1, path2):
     '/data/archive/../archive/file.nc'
     >>> cf.pathjoin('/data/archive', '../archive/file.nc')
     '/data/archive/../archive/file.nc'
-    >>> cf.abspath(cf.pathjoin('/data/', 'archive/')
+    >>> cf.abspath(cf.pathjoin('/data/', 'archive/'))
     '/data/archive'
     >>> cf.pathjoin('http://data', 'archive/file.nc')
     'http://data/archive/file.nc'

--- a/cf/mixin/properties.py
+++ b/cf/mixin/properties.py
@@ -916,7 +916,7 @@ class Properties(Container):
         >>> f.match_by_property(standard_name='longitude')
 
         >>> f.match_by_property(
-        ...     standard_name='longitude', foo='cf.set(['bar', 'not_bar'])
+        ...     standard_name='longitude', foo=cf.set(['bar', 'not_bar']))
 
         >>> f.match_by_property(long_name=re.compile('^lon'))
 


### PR DESCRIPTION
Closes #132.

Now the linting pre-commit checks are passing after #194, I want to check if Python 3.9 passes the CI to confirm the resolution of #132. It passes for me locally as far as I can tell around the seg faults which are still occurring and under investigation (see #180), though the seg faults may also appear on the Actions jobs since we have seen them emerge there before.

Since the Actions jobs for the workflow to run the test suite are only set to be triggered by PR, I am putting in a trivial PR to trigger and inspect the jobs. These trivial commits fix  all of the syntax errors raised by doctest on the codebase (I have set up a CLI option `-d` so we can check these via `py run_tests.py -d` towards #4, though until they are all passing I won't add them to the test suite).