### PR TITLE
Short-term fix for errors in reading of metadata-only CDL

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -9,6 +9,9 @@ version 3.9.0
   zero size (https://github.com/NCAS-CMS/cfdm/issues/113)
 * Fixes for changes in behaviour in cftime==1.4.0
   (https://github.com/NCAS-CMS/cf-python/issues/184)
+* Better error message in the case of a `numpy.ma.core.MaskError` occurring
+  upon reading of CDL files with only header or coordinate information
+  (https://github.com/NCAS-CMS/cf-python/issues/197)
 * Changed dependency: ``1.8.9.0<=cfdm<1.8.10.0``
 * Changed dependency: ``cftime>=1.4.0``
 * Changed dependency: ``netCDF4>=1.5.4``

--- a/cf/read_write/read.py
+++ b/cf/read_write/read.py
@@ -4,6 +4,8 @@ import os
 from glob import glob
 from os.path import isdir
 
+from numpy.ma.core import MaskError
+
 from .netcdf import NetCDFRead
 from .um import UMRead
 
@@ -915,7 +917,8 @@ def _read_a_file(
     # ----------------------------------------------------------------
     # Still here? Read the file into fields.
     # ----------------------------------------------------------------
-    if ftype == "CDL":
+    originally_cdl = ftype == "CDL"
+    if originally_cdl:
         # Create a temporary netCDF file from input CDL
         ftype = "netCDF"
         cdl_filename = filename
@@ -938,16 +941,34 @@ def _read_a_file(
     # --- End: if
 
     if ftype == "netCDF" and extra_read_vars["fmt"] in (None, "NETCDF", "CFA"):
-        fields = netcdf.read(
-            filename,
-            external=external,
-            extra=extra,
-            verbose=verbose,
-            warnings=warnings,
-            extra_read_vars=extra_read_vars,
-            mask=mask,
-            warn_valid=warn_valid,
-        )
+        # See https://github.com/NCAS-CMS/cfdm/issues/128 for context on the
+        # try/except here, which acts as a temporary fix pending decisions on
+        # the best way to handle CDL with only header or coordinate info.
+        try:
+            fields = netcdf.read(
+                filename,
+                external=external,
+                extra=extra,
+                verbose=verbose,
+                warnings=warnings,
+                extra_read_vars=extra_read_vars,
+                mask=mask,
+                warn_valid=warn_valid,
+            )
+        except MaskError:
+            # Some data required for field interpretation is missing,
+            # manifesting downstream as a NumPy MaskError.
+            if originally_cdl:
+                raise ValueError(
+                    "Unable to convert CDL without data to field construct(s) "
+                    "because there is insufficient information provided by "
+                    "the header and/or coordinates alone in this case."
+                )
+            else:
+                raise ValueError(
+                    "Unable to convert netCDF to field construct(s) because "
+                    "there is missing data."
+                )
 
     elif ftype == "UM" and extra_read_vars["fmt"] in (None, "UM"):
         fields = UM.read(


### PR DESCRIPTION
See #197 and #NCAS-CMS/cfdm#128 for details.

Note in response to the CI failing on coverage I've realised that even for this short-term fix I should add some more tests to cover metadata-only CDL, so I need to create and commit those before this can be merged.