### PR TITLE
Fix regrid memory leak

### DIFF
--- a/cf/field.py
+++ b/cf/field.py
@@ -15823,6 +15823,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                     f"Can't regrid {self!r} with regridding operator "
                     f"{operator!r}: Source grid coordinates do not match."
                 )
+            srcgrid.destroy()
 
         # Get the destination ESMF Grid, Field and fractional Field
         if dst_regrid:
@@ -16568,6 +16569,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                     f"Can't regrid {self!r} with regridding operator "
                     f"{operator!r}: Source grid coordinates do not match."
                 )
+            srcgrid.destroy()
 
             dstgrid = regridSrc2Dst.dstfield.grid
             dstfield = regridSrc2Dst.dstfield

--- a/cf/field.py
+++ b/cf/field.py
@@ -16003,6 +16003,12 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 units=f.Units,
             )
 
+            # Release memory for source grid/fields
+            # created for this data section
+            srcfracfield.destroy()
+            srcfield.destroy()
+            srcgrid.destroy()
+
         # Construct new data from regridded sections
         new_data = Data.reconstruct_sectioned_data(sections)
 
@@ -16062,16 +16068,22 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 config={"coord": x, "period": Data(360.0, "degrees")},
             )
 
-        # Release old memory from ESMF (this ought to happen garbage
-        # collection, but it doesn't seem to work there!)
-        if destroy_old_Regrid:
-            regridSrc2Dst.destroy()
+        # Explicitly release all the memory that will not be needed anymore
+        if not dst_regrid:
+            # explicitly release memory for destination ESMF objects
+            # as they were only created locally (i.e. not originating
+            # from an existing regrid operator) and they will not be
+            # used anymore
             dstfracfield.destroy()
-            srcfracfield.destroy()
             dstfield.destroy()
-            srcfield.destroy()
             dstgrid.destroy()
-            srcgrid.destroy()
+
+            if not return_operator:
+                # explicitly release memory for ESMF Regrid and its
+                # associated objects which is safe to do so since the
+                # regrid operator was not returned so the weights will
+                # not be used anymore
+                del regridSrc2Dst
 
         return f
 
@@ -16730,6 +16742,12 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
 
             sections[k] = Data.reconstruct_sectioned_data(subsections)
 
+            # Release memory for source grid/fields
+            # created for this data section
+            srcfracfield.destroy()
+            srcfield.destroy()
+            srcgrid.destroy()
+
         # Construct new data from regridded sections
         new_data = Data.reconstruct_sectioned_data(sections)
 
@@ -16770,15 +16788,22 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
         # Insert regridded data into new field
         f.set_data(new_data, axes=self.get_data_axes())
 
-        # Release old memory
-        if destroy_old_Regrid:
-            regridSrc2Dst.destroy()
+        # Explicitly release all the memory that will not be needed anymore
+        if not dst_regrid:
+            # explicitly release memory for destination ESMF objects
+            # as they were only created locally (i.e. not originating
+            # from an existing regrid operator) and they will not be
+            # used anymore
             dstfracfield.destroy()
-            srcfracfield.destroy()
             dstfield.destroy()
-            srcfield.destroy()
             dstgrid.destroy()
-            srcgrid.destroy()
+
+            if not return_operator:
+                # explicitly release memory for ESMF Regrid and its
+                # associated objects which is safe to do so since the
+                # regrid operator was not returned so the weights will
+                # not be used anymore
+                del regridSrc2Dst
 
         return f
 

--- a/cf/field.py
+++ b/cf/field.py
@@ -16079,12 +16079,11 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
             dstfield.destroy()
             dstgrid.destroy()
 
-            if not return_operator:
-                # explicitly release memory for ESMF Regrid and its
-                # associated objects which is safe to do so since the
-                # regrid operator was not returned so the weights will
-                # not be used anymore
-                del regridSrc2Dst
+            # explicitly release memory for ESMF Regrid and its
+            # associated objects which is safe to do so since the
+            # regrid operator was not returned so the weights will
+            # not be used anymore
+            del regridSrc2Dst
 
         return f
 
@@ -16800,12 +16799,11 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
             dstfield.destroy()
             dstgrid.destroy()
 
-            if not return_operator:
-                # explicitly release memory for ESMF Regrid and its
-                # associated objects which is safe to do so since the
-                # regrid operator was not returned so the weights will
-                # not be used anymore
-                del regridSrc2Dst
+            # explicitly release memory for ESMF Regrid and its
+            # associated objects which is safe to do so since the
+            # regrid operator was not returned so the weights will
+            # not be used anymore
+            del regridSrc2Dst
 
         return f
 

--- a/cf/field.py
+++ b/cf/field.py
@@ -16004,11 +16004,10 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 units=f.Units,
             )
 
-            # Release memory for source grid/fields
-            # created for this data section
-            srcfracfield.destroy()
-            srcfield.destroy()
-            srcgrid.destroy()
+        # Release memory for source grid/fields in the data sections
+        srcfracfield.destroy()
+        srcfield.destroy()
+        srcgrid.destroy()
 
         # Construct new data from regridded sections
         new_data = Data.reconstruct_sectioned_data(sections)
@@ -16749,6 +16748,11 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 srcgrid.destroy()
 
             sections[k] = Data.reconstruct_sectioned_data(subsections)
+
+        # Release memory for source grid/fields created for data subsections
+        srcfracfield.destroy()
+        srcfield.destroy()
+        srcgrid.destroy()
 
         # Construct new data from regridded sections
         new_data = Data.reconstruct_sectioned_data(sections)

--- a/cf/field.py
+++ b/cf/field.py
@@ -16740,13 +16740,13 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                     units=f.Units,
                 )
 
-            sections[k] = Data.reconstruct_sectioned_data(subsections)
+                # Release memory for source grid/fields
+                # created for this data subsection
+                srcfracfield.destroy()
+                srcfield.destroy()
+                srcgrid.destroy()
 
-            # Release memory for source grid/fields
-            # created for this data section
-            srcfracfield.destroy()
-            srcfield.destroy()
-            srcgrid.destroy()
+            sections[k] = Data.reconstruct_sectioned_data(subsections)
 
         # Construct new data from regridded sections
         new_data = Data.reconstruct_sectioned_data(sections)

--- a/cf/field.py
+++ b/cf/field.py
@@ -15819,6 +15819,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
             if not grids_have_same_coords(
                 srcgrid, regridSrc2Dst.srcfield.grid
             ):
+                srcgrid.destroy()
                 raise ValueError(
                     f"Can't regrid {self!r} with regridding operator "
                     f"{operator!r}: Source grid coordinates do not match."
@@ -16564,6 +16565,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
             if not grids_have_same_coords(
                 srcgrid, regridSrc2Dst.srcfield.grid
             ):
+                srcgrid.destroy()
                 raise ValueError(
                     f"Can't regrid {self!r} with regridding operator "
                     f"{operator!r}: Source grid coordinates do not match."

--- a/cf/field.py
+++ b/cf/field.py
@@ -16741,12 +16741,6 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                     units=f.Units,
                 )
 
-                # Release memory for source grid/fields
-                # created for this data subsection
-                srcfracfield.destroy()
-                srcfield.destroy()
-                srcgrid.destroy()
-
             sections[k] = Data.reconstruct_sectioned_data(subsections)
 
         # Release memory for source grid/fields created for data subsections

--- a/cf/regrid/regridoperator.py
+++ b/cf/regrid/regridoperator.py
@@ -202,6 +202,17 @@ class RegridOperator:
         >>> r.destroy()
 
         """
+        # explicitly release memory for source ESMF objects
+        self._regrid.srcfield.grid.destroy()
+        self._regrid.srcfield.destroy()
+        self._regrid.src_frac_field.destroy()
+
+        # explicitly release memory for destination ESMF objects
+        self._regrid.dstfield.grid.destroy()
+        self._regrid.dstfield.destroy()
+        self._regrid.dst_frac_field.destroy()
+
+        # explicitly release memory for ESMF Regrid
         self._regrid.destroy()
 
     def get_parameter(self, parameter):

--- a/cf/regrid/utils.py
+++ b/cf/regrid/utils.py
@@ -565,9 +565,9 @@ def regrid_get_reordered_sections(
 
     """
     # If we had dynamic masking, we wouldn't need this method, we
-    # could sdimply replace it in the clling function with a call to
+    # could simply replace it in the calling function with a call to
     # Data.section. However, we don't have it, so this allows us to
-    # possibibly reduce the number of trasnistions between different
+    # possibly reduce the number of transitions between different
     # masks - each change is slow.
     data_axes = src.get_data_axes()
 

--- a/cf/regrid/utils.py
+++ b/cf/regrid/utils.py
@@ -753,6 +753,10 @@ def regrid_compute_field_mass(
     # Insert the two masses into the dictionary for comparison
     _compute_field_mass[k] = (srcmass, dstmass)
 
+    # Release memory
+    srcareafield.destroy()
+    dstareafield.destroy()
+
 
 def regrid_get_regridded_data(f, method, fracfield, dstfield, dstfracfield):
     """Get the regridded data.


### PR DESCRIPTION
resolve #222

The special methods `__del__` of `ESMF.Field` and `ESMF.Grid` objects feature calls to their respective `destroy` methods that release the memory allocated by ESMF in Fortran. When these objects go out of scope, the Python garbage collection ought to call these `__del__` methods, yet their allocated memory does not seem to be released properly, as repeatedly regridding fields results in running out of memory after a while.

After a discussion with @davidhassell, we suspect that the `ESMF.Manager` may be responsible for not making the memory release possible as long as it stays in scope. However, in `cf` the Manager is initialised but not bound to a variable name (see e.g. https://github.com/ThibHlln/cf-python/blob/d9cde28d9abd9cfeb6575c737560956f40620942/cf/field.py#L15619), so to me it goes out of scope directly in a Python sense. The [ESMF documentation](http://earthsystemmodeling.org/esmpy_doc/release/ESMF_8_1_0/html/manager.html?highlight=manager#ESMF.api.esmpymanager.Manager) says that _"The Manager will be created when the first ESMPy object is created if it is not created explicitly by the user"_. So I suspect that the Manager stays around (as a Fortran object I suppose) even if not bound to a name in Python's namespace (which may also very well be the case for Fields/Grids objects then).

In the `cf` regridding, there are ESMF fields and grids created during each call to `regrids`/`regridc`. If these are explicitly releasing memory (through calls to their destroy methods), this does seem to eliminate the running out of memory when repeatedly calling the regridding methods. Note, calling the destroy methods on these objects several times does not raise an error, if memory was already released, it remains silent. So this PR does just that, i.e. it explicitly releases memory for all ESMF objects as soon as they are not required anymore. This does not provide as explanation for why the destroy calls in Python's garbage collection are not working/not enough, but it seems to be a cheap and harmless solution that solves the problem.

I am attaching these [field files](https://github.com/NCAS-CMS/cf-python/files/6717379/fields.zip) if you'd like to test the following script:
```python
fld_src = cf.read('fld_src_3d.nc')[0]  # try also with 'fld_src_2d.nc'
fld_dst = cf.read('fld_dst_3d.nc')[0]  # try also with 'fld_dst_2d.nc'

regrid_op = fld_src.regrids(fld_dst, 'conservative', return_operator=True)
print('regrid weights generated')

for _ in range(5000):
    fld_src.regrids(regrid_op)
```

Before this PR, after the expensive generation of the weights (it may take a short while), the memory was building up very quickly in the loop until running out of memory (using 8GB of RAM for my test), while with the modifications in this PR the memory now remains stable across the loop.