### PR TITLE
New cf.read kwarg enabling CDL string input

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -1,3 +1,12 @@
+version 3.?.?
+-------------
+----
+
+**2021-??-??**
+
+* New keyword parameter to `cf.read`: ``cdl_string``
+  (https://github.com/NCAS-CMS/cf-python/issues/171)
+
 version 3.10.0
 --------------
 ----

--- a/cf/functions.py
+++ b/cf/functions.py
@@ -1837,7 +1837,15 @@ def _numpy_allclose(a, b, rtol=None, atol=None, verbose=None):
         try:
             return _numpy_ma_allclose(a, b, rtol=rtol, atol=atol)
         except (IndexError, NotImplementedError, TypeError):
-            out = _numpy_ma_all(a == b)
+            # To prevent a bug causing some header/coord-only CDL reads or
+            # aggregations to error. See also TODO comment below.
+            if a.dtype == b.dtype:
+                out = _numpy_ma_all(a == b)
+            else:
+                # TODO: is this most sensible? Or should we attempt dtype
+                # conversion and then compare? Probably we should avoid
+                # altogether by catching the different dtypes upstream?
+                out = False
             if out is _numpy_ma_masked:
                 return True
             else:

--- a/cf/read_write/read.py
+++ b/cf/read_write/read.py
@@ -596,9 +596,20 @@ def read(
         if isinstance(select, (str, Query, Pattern)):
             select = (select,)
 
+    # Manage input parameters where contradictions are possible:
+    if cdl_string and fmt:
+        if fmt == "CDL":
+            logger.info(
+                "It is not necessary to set the cf.read fmt as 'CDL' when "
+                "cdl_string is True, since that implies CDL is the format."
+            )  # pragma: no cover
+        else:
+            raise ValueError(
+                "cdl_string can only be True when the format is CDL, though "
+                "fmt is ignored in that case so there is no need to set it."
+            )
     if squeeze and unsqueeze:
         raise ValueError("squeeze and unsqueeze can not both be True")
-
     if follow_symlinks and not recursive:
         raise ValueError(
             "Can't set follow_symlinks={0} when recursive={1}".format(

--- a/cf/read_write/read.py
+++ b/cf/read_write/read.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import subprocess
 import tempfile
 
 from glob import glob
@@ -972,20 +971,7 @@ def _read_a_file(
         # Create a temporary netCDF file from input CDL
         ftype = "netCDF"
         cdl_filename = filename
-        try:
-            filename = netcdf.cdl_to_netcdf(filename)
-        except subprocess.CalledProcessError as error:
-            msg = str(error)
-            if msg.startswith(
-                "Command '['ncgen', '-knc4', '-o'"
-            ) and msg.endswith("returned non-zero exit status 1."):
-                raise ValueError(
-                    "The CDL provided is invalid so cannot be converted "
-                    "to netCDF."
-                )
-            else:
-                raise
-
+        filename = netcdf.cdl_to_netcdf(filename)
         extra_read_vars["fmt"] = "NETCDF"
 
         if not netcdf.is_netcdf_file(filename):

--- a/cf/read_write/read.py
+++ b/cf/read_write/read.py
@@ -27,6 +27,8 @@ else:
     python36 = False
 
 
+_cached_temporary_files = {}
+
 # --------------------------------------------------------------------
 # Create an implementation container and initialize a read object for
 # each format
@@ -659,8 +661,16 @@ def read(
                 prefix="cf_",
                 suffix=".cdl",
             )
-            with open(c.name, "w") as f:
+
+            c_name = c.name
+            with open(c_name, "w") as f:
                 f.write(cdl_file)
+
+            # ----------------------------------------------------------------
+            # Need to cache the TemporaryFile object so that it doesn't get
+            # deleted too soon
+            # ----------------------------------------------------------------
+            _cached_temporary_files[c_name] = c
 
             files2.append(c.name)
 

--- a/cf/read_write/read.py
+++ b/cf/read_write/read.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import tempfile
 
 from glob import glob
 from os.path import isdir
@@ -627,6 +628,17 @@ def read(
     # files
     field_counter = -1
     file_counter = 0
+
+    if cdl_string:
+        # Create a temporary CDL file from the CDL string.
+        # The validity of the CDL is tested later with attempt to
+        # convert it to netCDF.
+        c = tempfile.NamedTemporaryFile(
+            mode="wb", dir=tempfile.gettempdir(), prefix="cfdm_", suffix=".cdl"
+        )
+        with open(c.name, "w") as f:
+            f.write(files)
+        files = c.name
 
     for file_glob in flat(files):
         # Expand variables

--- a/cf/read_write/read.py
+++ b/cf/read_write/read.py
@@ -50,6 +50,7 @@ def read(
     squeeze=False,
     unsqueeze=False,
     fmt=None,
+    cdl_string=False,
     select=None,
     extra=None,
     recursive=False,
@@ -207,6 +208,10 @@ def read(
             be raised, unless the *ignore_read_error* parameter is
             True.
 
+            As a special case, if the `cdl_string` parameter is set to
+            True, the interpretation of `files` changes so that it
+            should be a string of CDL input rather than the above.
+
         external: (sequence of) `str`, optional
             Read external variables (i.e. variables which are named by
             attributes, but are not present, in the parent file given
@@ -312,6 +317,19 @@ def read(
             ``'CFA'`` for CFA-netCDF files, ``'UM'`` for PP or UM
             fields files, and ``'CDL'`` for CDL text files. By default
             files of any of these formats are read.
+
+        cdl_string: `bool`, optional
+            If True and the format to read is CDL, read a string
+            input rather than from file, where in this case (only)
+            the `files` parameter will be interpreted as a string of
+            valid CDL rather than a string providing the file location,
+            as standard.
+
+            By default, input is read from file and not from a string,
+            including when the `fmt` parameter is given as CDL. Note that
+            when `cdl_string` is True, the `fmt` parameter is ignored
+            as the format is assumed to be CDL, so it is not necessary to
+            also specify ``fmt='CDL'``.
 
         aggregate: `bool` or `dict`, optional
             If True (the default) or a dictionary (possibly empty)

--- a/cf/test/test_read_write.py
+++ b/cf/test/test_read_write.py
@@ -748,7 +748,7 @@ class read_writeTest(unittest.TestCase):
 
     def test_read_cdl_string(self):
         """Test the `cdl_string` keyword of the `read` function."""
-        # Test CDL in full, header-only and coordinate-only formats:
+        # Test CDL in full, header-only and coordinate-only type:
         tempfile_to_option_mapping = {
             tmpfile: None,
             tmpfileh: "-h",
@@ -773,6 +773,17 @@ class read_writeTest(unittest.TestCase):
             f_from_file = cf.read(tempf)  # len 1 so only one field to check
             self.assertEqual(len(f_from_str), len(f_from_file))
             self.assertEqual(f_from_str[0], f_from_file[0])
+
+            # Check compatibility with the `fmt` kwarg.
+            f0 = cf.read(cdl_string_1, cdl_string=True, fmt="CDL")  # fine
+            self.assertEqual(len(f0), len(f_from_file))
+            self.assertEqual(f0[0], f_from_file[0])
+            # If the 'fmt' and 'cdl_string' values contradict each other,
+            # alert the user to this. Note that the default fmt is None but
+            # it then gets interpreted as NETCDF, so default fmt is fine and
+            # it is tested in f_from_str above where fmt is not set.
+            with self.assertRaises(ValueError):
+                f0 = cf.read(cdl_string_1, cdl_string=True, fmt="NETCDF")
 
         # If the user forgets the cdl_string=True argument they will
         # accidentally attempt to create a file with a very long name of

--- a/cf/test/test_read_write.py
+++ b/cf/test/test_read_write.py
@@ -768,11 +768,18 @@ class read_writeTest(unittest.TestCase):
             with open(tempf, "r") as file:
                 cdl_string_1 = file.read()
 
-            # ... and now test it
+            # ... and now test it as an individual string input
             f_from_str = cf.read(cdl_string_1, cdl_string=True)
             f_from_file = cf.read(tempf)  # len 1 so only one field to check
             self.assertEqual(len(f_from_str), len(f_from_file))
             self.assertEqual(f_from_str[0], f_from_file[0])
+
+            # ... and test further by inputting it in duplicate as a sequence
+            f_from_str = cf.read([cdl_string_1, cdl_string_1], cdl_string=True)
+            f_from_file = cf.read(tempf)  # len 1 so only one field to check
+            self.assertEqual(len(f_from_str), 2 * len(f_from_file))
+            self.assertEqual(f_from_str[0], f_from_file[0])
+            self.assertEqual(f_from_str[1], f_from_file[0])
 
             # Check compatibility with the `fmt` kwarg.
             f0 = cf.read(cdl_string_1, cdl_string=True, fmt="CDL")  # fine


### PR DESCRIPTION
Close #171 using the (same) new keyword as suggested in the opening comment of that tagged Issue and in doing so, also improve the error handling for invalid CDL inputs generally.

Note that the API update with the new `cdl_string` keyword argument is (admittedly) a little clunky, given the core (and only non-keyword) argument is named `files` and always accepts file locations other than with this new keyword set to `True` where it then changes to instead accept a string of CDL input (though strictly OPenDAP URLs are also possible to already break the general pattern too, so maybe it is not so bad). However, the only alternative in practice would be to create a whole new function, `cf.read_from_string` or similar, for the case of reading from a string, only possible with CDL anyway.

So, the approach implemented in this PR to enable the feature of #171 is the most reasonable, and certainly "good enough", I think?