### PR TITLE
Fix for cf.aggregate failure when a datum or coordinate conversion parameter has an array value

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -1,3 +1,13 @@
+version 3.??.?
+--------------
+----
+
+**2021-??-??**
+
+* Fix for `cf.aggregate` failures when a datum or coordinate
+  conversion parameter has an array value
+  (https://github.com/NCAS-CMS/cf-python/issues/230)
+
 version 3.10.0
 --------------
 ----

--- a/cf/constants.py
+++ b/cf/constants.py
@@ -146,10 +146,6 @@ _stash2standard_name = {}
 # ---------------------------------------------------------------------
 cr_canonical_units = {
     "earth_radius": Units("m"),
-    "false_easting": Units("m"),
-    "projection_x_coordinate": Units("m"),
-    "false_northing": Units("m"),
-    "projection_y_coordinate": Units("m"),
     "grid_north_pole_latitude": Units("degrees_north"),
     "grid_north_pole_longitude": Units("degrees_east"),
     "inverse_flattening": Units("1"),

--- a/cf/coordinatereference.py
+++ b/cf/coordinatereference.py
@@ -26,6 +26,26 @@ _units = {}
 logger = logging.getLogger(__name__)
 
 
+def _totuple(a):
+    """Return an N-d (N>0) array as a nested tuple of Python scalars.
+
+    :Parameters:
+
+        a: numpy.ndarray
+            The numpy array
+
+    :Returns:
+
+        `tuple`
+            The array as an nested tuple of Python scalars.
+
+    """
+    try:
+        return tuple(_totuple(i) for i in a)
+    except TypeError:
+        return a
+
+
 class CoordinateReference(cfdm.CoordinateReference):
     """A coordinate reference construct of the CF data model.
 
@@ -708,6 +728,14 @@ class CoordinateReference(cfdm.CoordinateReference):
                 ):
                     # Do not add a default value to the structural signature
                     continue
+
+                # Convert value to a Python scalar if it's 0-d, or a
+                # tuple if it's N-d.
+                value = value.array
+                if not value.ndim:
+                    value = value.item()
+                else:
+                    value = _totuple(value)
 
                 append(
                     (

--- a/cf/test/test_CoordinateReference.py
+++ b/cf/test/test_CoordinateReference.py
@@ -5,6 +5,8 @@ import os
 import tempfile
 import unittest
 
+import numpy as np
+
 faulthandler.enable()  # to debug seg faults and timeouts
 
 import cf
@@ -262,6 +264,29 @@ class CoordinateReferenceTest(unittest.TestCase):
         self.assertEqual(self.hcr.get("qwerty", 12), 12)
         with self.assertRaises(Exception):
             self.hcr["qwerty"]
+
+    def test_CoordinateReference_structural_signature(self):
+        c = self.hcr.copy()
+
+        self.assertIsInstance(c.structural_signature(), tuple)
+
+        c.datum.set_parameter("test", [23])
+        s = c.structural_signature()
+        self.assertEqual(s[2], ("datum:test", (23.0,), None))
+
+        c.datum.set_parameter("test", [23, 45])
+        s = c.structural_signature()
+        self.assertEqual(s[2], ("datum:test", (23.0, 45.0), None))
+
+        c.datum.set_parameter("test", [[23, 45]])
+        s = c.structural_signature()
+        self.assertEqual(s[2], ("datum:test", ((23.0, 45.0),), None))
+
+        c.datum.set_parameter("test", np.array([[23, 45], [67, 89]]))
+        s = c.structural_signature()
+        self.assertEqual(
+            s[2], ("datum:test", ((23.0, 45.0), (67.0, 89.0)), None)
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes: #230 