### PR TITLE
Fix for cf.aggregate failures when field units are non-valid

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -1,3 +1,13 @@
+version 3.??.?
+--------------
+----
+
+**2021-??-??**
+
+* Fix bug that causes a failure in `cf.aggregate` when otherwise
+  aggregatable fields have non-valid units
+  (https://github.com/NCAS-CMS/cf-python/issues/229)
+  
 version 3.10.0
 --------------
 ----

--- a/cf/aggregate.py
+++ b/cf/aggregate.py
@@ -1843,6 +1843,22 @@ def aggregate(
 
             continue
 
+        if not meta[0].units.isvalid:
+            if is_log_level_info(logger):
+                x = ", ".join(set(repr(m.units) for m in meta))
+                logger.info(
+                    f"Unaggregatable {meta[0].field.identity()!r} fields "
+                    f"have{exclude} been output: Non-valid units {x}"
+                )
+
+            if not exclude:
+                if copy:
+                    output_fields.extend((m.field.copy() for m in meta))
+                else:
+                    output_fields.extend((m.field for m in meta))
+
+            continue
+
         # ------------------------------------------------------------
         # Still here? Then there are 2 or more fields with this
         # signature which may be aggregatable. These fields need to be

--- a/cf/aggregate.py
+++ b/cf/aggregate.py
@@ -1853,9 +1853,9 @@ def aggregate(
 
             if not exclude:
                 if copy:
-                    output_fields.extend((m.field.copy() for m in meta))
+                    output_fields.extend(m.field.copy() for m in meta)
                 else:
-                    output_fields.extend((m.field for m in meta))
+                    output_fields.extend(m.field for m in meta)
 
             continue
 

--- a/cf/test/test_aggregate.py
+++ b/cf/test/test_aggregate.py
@@ -235,6 +235,21 @@ class aggregateTest(unittest.TestCase):
                     ),
                 )
 
+    def test_aggregate_bad_units(self):
+        f = cf.read(self.filename, squeeze=True)[0]
+
+        g = cf.FieldList(f[0])
+        g.append(f[1:])
+
+        h = cf.aggregate(g)
+        self.assertEqual(len(h), 1)
+
+        g[0].override_units(cf.Units("apples!"), inplace=True)
+        g[1].override_units(cf.Units("oranges!"), inplace=True)
+
+        h = cf.aggregate(g)
+        self.assertEqual(len(h), 2)
+
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())


### PR DESCRIPTION
Fixes: #229 