### PR TITLE
Apply & add hook for `isort` (systematic import sorting)

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -20,8 +20,8 @@ jobs:
   # *The config. applied here is from our .pre-commit-config.yaml*
   #
   # Note the pre-commit linting includes all of the other linters configured
-  # to run as pre-commit hooks, namely black, flake8, docformatter and
-  # pydocstyle, so there is no need to set these up individually!
+  # to run as pre-commit hooks, namely black, flake8 and docformatter etc.,
+  # so there is no need to set these up individually!
   pre-commit:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,3 +51,19 @@ repos:
     rev: 3.9.1
     hooks:
       - id: flake8
+
+  # Apply the 'isort' tool to sort Python import statements systematically
+  # (see https://pycqa.github.io/isort/ for documentation). It is fully
+  # compatible with 'black' with the lines set to ensure so in the repo's
+  # pyproject.toml. Other than that and the below, no extra config is required.
+  - repo: https://github.com/pycqa/isort
+    rev: 5.8.0
+    hooks:
+      - id: isort
+        name: isort (python)
+      - id: isort
+        name: isort (cython)
+        types: [cython]
+      - id: isort
+        name: isort (pyi)
+        types: [pyi]

--- a/cf/aggregate.py
+++ b/cf/aggregate.py
@@ -1,40 +1,27 @@
 import logging
+from collections import namedtuple
+from operator import itemgetter
 
+from cfdm import is_log_level_debug, is_log_level_detail, is_log_level_info
 from numpy import argsort as numpy_argsort
 from numpy import dtype as numpy_dtype
 from numpy import sort as numpy_sort
 
-from collections import namedtuple
-from operator import itemgetter
-
-from cfdm import (
-    is_log_level_info,
-    is_log_level_debug,
-    is_log_level_detail,
-)
-
 from .auxiliarycoordinate import AuxiliaryCoordinate
-from .domainaxis import DomainAxis
-from .fieldlist import FieldList
-from .query import gt
-from .units import Units
-
+from .data.data import Data
 from .decorators import (
-    _manage_log_level_via_verbosity,
     _manage_log_level_via_verbose_attr,
+    _manage_log_level_via_verbosity,
     _reset_log_emergence_level,
 )
-
-from .functions import (
-    flat,
-    hash_array,
-    _DEPRECATION_ERROR_FUNCTION_KWARGS,
-    _numpy_allclose,
-)
-from .functions import rtol as cf_rtol, atol as cf_atol
-
-from .data.data import Data
-
+from .domainaxis import DomainAxis
+from .fieldlist import FieldList
+from .functions import _DEPRECATION_ERROR_FUNCTION_KWARGS, _numpy_allclose
+from .functions import atol as cf_atol
+from .functions import flat, hash_array
+from .functions import rtol as cf_rtol
+from .query import gt
+from .units import Units
 
 logger = logging.getLogger(__name__)
 

--- a/cf/auxiliarycoordinate.py
+++ b/cf/auxiliarycoordinate.py
@@ -1,8 +1,6 @@
 import cfdm
 
-from . import Bounds
-
-from . import mixin
+from . import Bounds, mixin
 
 
 class AuxiliaryCoordinate(

--- a/cf/bounds.py
+++ b/cf/bounds.py
@@ -1,11 +1,9 @@
 import cfdm
 
-from .data import Data
-from .units import Units
-
 from . import mixin
-
+from .data import Data
 from .decorators import _deprecated_kwarg_check
+from .units import Units
 
 
 class Bounds(mixin.Coordinate, mixin.PropertiesData, cfdm.Bounds):

--- a/cf/cellmeasure.py
+++ b/cf/cellmeasure.py
@@ -1,7 +1,6 @@
 import cfdm
 
 from . import mixin
-
 from .decorators import _deprecated_kwarg_check
 
 

--- a/cf/cellmethod.py
+++ b/cf/cellmethod.py
@@ -1,24 +1,18 @@
-import re
-
-from ast import literal_eval as ast_literal_eval
-
 import logging
+import re
+from ast import literal_eval as ast_literal_eval
 
 import cfdm
 
 from .data.data import Data
-
-from .functions import inspect as cf_inspect
-
-from .functions import _DEPRECATION_ERROR_METHOD
-
 from .decorators import (
+    _deprecated_kwarg_check,
     _inplace_enabled,
     _inplace_enabled_define_and_cleanup,
-    _deprecated_kwarg_check,
     _manage_log_level_via_verbosity,
 )
-
+from .functions import _DEPRECATION_ERROR_METHOD
+from .functions import inspect as cf_inspect
 
 logger = logging.getLogger(__name__)
 

--- a/cf/cfdatetime.py
+++ b/cf/cfdatetime.py
@@ -1,11 +1,10 @@
 import datetime
 from functools import partial
 
-import numpy as np
 import cftime
+import numpy as np
 
 from .functions import _DEPRECATION_ERROR_CLASS
-
 
 _default_calendar = "gregorian"
 

--- a/cf/cfimplementation.py
+++ b/cf/cfimplementation.py
@@ -1,28 +1,25 @@
 import cfdm
 
-from .functions import CF
-
 from . import (
     AuxiliaryCoordinate,
-    CellMethod,
+    Bounds,
     CellMeasure,
+    CellMethod,
+    CoordinateConversion,
     CoordinateReference,
+    Count,
+    Datum,
     DimensionCoordinate,
     DomainAncillary,
     DomainAxis,
     Field,
     FieldAncillary,
-    Bounds,
-    InteriorRing,
-    CoordinateConversion,
-    Datum,
-    Count,
-    List,
     Index,
+    InteriorRing,
+    List,
     NodeCountProperties,
     PartNodeCountProperties,
 )
-
 from .data import (
     Data,
     GatheredArray,
@@ -31,6 +28,7 @@ from .data import (
     RaggedIndexedArray,
     RaggedIndexedContiguousArray,
 )
+from .functions import CF
 
 
 class CFImplementation(cfdm.CFDMImplementation):

--- a/cf/constants.py
+++ b/cf/constants.py
@@ -1,21 +1,17 @@
 import logging
 import sys
-
 from enum import Enum, auto
-from psutil import virtual_memory
 from tempfile import gettempdir
 
 from numpy.ma import masked as numpy_ma_masked
+from psutil import virtual_memory
 
-from . import mpi_on
-from . import mpi_size
-
+from . import mpi_on, mpi_size
 
 if mpi_on:
     from . import mpi_comm
 
 from .units import Units
-
 
 # platform = sys.platform
 # if platform == 'darwin':

--- a/cf/constructlist.py
+++ b/cf/constructlist.py
@@ -2,19 +2,16 @@ import logging
 
 import cfdm
 
-from .mixin_container import Container
-
-from .functions import (
-    _DEPRECATION_ERROR,
-    _DEPRECATION_ERROR_KWARGS,
-    _DEPRECATION_ERROR_DICT,
-)
-
 from .decorators import (
     _deprecated_kwarg_check,
     _manage_log_level_via_verbosity,
 )
-
+from .functions import (
+    _DEPRECATION_ERROR,
+    _DEPRECATION_ERROR_DICT,
+    _DEPRECATION_ERROR_KWARGS,
+)
+from .mixin_container import Container
 
 logger = logging.getLogger(__name__)
 

--- a/cf/coordinatereference.py
+++ b/cf/coordinatereference.py
@@ -2,24 +2,24 @@ import logging
 
 import cfdm
 
-from .constants import cr_coordinates, cr_canonical_units, cr_default_values
-from .functions import allclose
-from .functions import inspect as cf_inspect, atol as cf_atol, rtol as cf_rtol
-from .query import Query
-
-from . import CoordinateConversion
-from . import Datum
-
+from . import CoordinateConversion, Datum
+from .constants import cr_canonical_units, cr_coordinates, cr_default_values
 from .data.data import Data
-
-from .functions import _DEPRECATION_ERROR_METHOD, _DEPRECATION_ERROR_ATTRIBUTE
-
 from .decorators import (
+    _deprecated_kwarg_check,
     _inplace_enabled,
     _inplace_enabled_define_and_cleanup,
-    _deprecated_kwarg_check,
     _manage_log_level_via_verbosity,
 )
+from .functions import (
+    _DEPRECATION_ERROR_ATTRIBUTE,
+    _DEPRECATION_ERROR_METHOD,
+    allclose,
+)
+from .functions import atol as cf_atol
+from .functions import inspect as cf_inspect
+from .functions import rtol as cf_rtol
+from .query import Query
 
 _units = {}
 

--- a/cf/data/abstract/compressedsubarray.py
+++ b/cf/data/abstract/compressedsubarray.py
@@ -1,5 +1,4 @@
 import abc
-
 from functools import reduce
 from operator import mul
 from sys import getrefcount

--- a/cf/data/abstract/filearray.py
+++ b/cf/data/abstract/filearray.py
@@ -1,5 +1,4 @@
 from ...functions import inspect as cf_inspect
-
 from .array import Array
 
 

--- a/cf/data/cachedarray.py
+++ b/cf/data/cachedarray.py
@@ -1,18 +1,15 @@
 from os import close
-from tempfile import mkstemp
-from tempfile import mkdtemp
+from tempfile import mkdtemp, mkstemp
 
 from numpy import load as numpy_load
 from numpy import ndarray as numpy_ndarray
 from numpy import save as numpy_save
-
 from numpy.ma import array as numpy_ma_array
 from numpy.ma import is_masked as numpy_ma_is_masked
 
-from . import abstract
-
-from ..functions import parse_indices, get_subspace
 from ..constants import CONSTANTS
+from ..functions import get_subspace, parse_indices
+from . import abstract
 
 
 class CachedArray(abstract.FileArray):

--- a/cf/data/collapse_functions.py
+++ b/cf/data/collapse_functions.py
@@ -14,7 +14,6 @@ from numpy import maximum as numpy_maximum
 from numpy import minimum as numpy_minimum
 from numpy import ndim as numpy_ndim
 from numpy import sum as numpy_sum
-
 from numpy.ma import array as numpy_ma_array
 from numpy.ma import average as numpy_ma_average
 from numpy.ma import expand_dims as numpy_ma_expand_dims

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -17,7 +17,7 @@ import cfdm
 import cftime
 import numpy
 
-# from numpy import arctan2 as numpy_arctan2  AT2
+# from numpy import arctan2 as numpy_arctan2  TODO AT2
 from numpy import arange as numpy_arange
 from numpy import arccos as numpy_arccos
 from numpy import arccosh as numpy_arccosh
@@ -92,8 +92,7 @@ from numpy.ma import nomask as numpy_ma_nomask
 from numpy.ma import where as numpy_ma_where
 from numpy.testing import suppress_warnings as numpy_testing_suppress_warnings
 
-# TODODASK - Remove the next 6 lines when the move to dask is complete
-from .. import mpi_on
+from .. import mpi_on  # TODODASK : remove when move to dask is complete
 from ..cfdatetime import dt as cf_dt
 from ..cfdatetime import dt2rt, rt2dt, st2rt
 from ..constants import masked as cf_masked
@@ -131,8 +130,6 @@ from . import (
     RaggedIndexedSubarray,
     UMArray,
 )
-
-# TODO SB post-186: decide how best to import these whilst avoiding 'import *'
 from .collapse_functions import (
     max_abs_f,
     max_abs_ffinalise,
@@ -183,13 +180,11 @@ from .collapse_functions import (
     var_ffinalise,
     var_fpartial,
 )
-
-#                       CompressedArray)
 from .filledarray import FilledArray
 from .partition import Partition
 from .partitionmatrix import PartitionMatrix
 
-if mpi_on:
+if mpi_on:  # TODODASK : remove when move to dask is complete
     from mpi4py.MPI import SUM as mpi_sum
 
     from .. import mpi_comm, mpi_rank, mpi_size

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -1,34 +1,33 @@
 import itertools
+import logging
 import operator
-
 from functools import reduce as functools_reduce
-from operator import itemgetter
-from operator import mul as operator_mul
-
 from json import dumps as json_dumps
 from json import loads as json_loads
-
 from math import ceil as math_ceil
-
-import logging
+from operator import itemgetter
+from operator import mul as operator_mul
 
 try:
     from scipy.ndimage.filters import convolve1d as scipy_convolve1d
 except ImportError:
     pass
 
+import cfdm
+import cftime
 import numpy
+
+# from numpy import arctan2 as numpy_arctan2  AT2
 from numpy import arange as numpy_arange
 from numpy import arccos as numpy_arccos
 from numpy import arccosh as numpy_arccosh
 from numpy import arcsin as numpy_arcsin
 from numpy import arcsinh as numpy_arcsinh
 from numpy import arctan as numpy_arctan
-
-# from numpy import arctan2 as numpy_arctan2  AT2
 from numpy import arctanh as numpy_arctanh
 from numpy import array as numpy_array
 from numpy import asanyarray as numpy_asanyarray
+from numpy import bool_ as numpy_bool_
 from numpy import ceil as numpy_ceil
 from numpy import cos as numpy_cos
 from numpy import cosh as numpy_cosh
@@ -40,23 +39,25 @@ from numpy import empty as numpy_empty
 from numpy import errstate as numpy_errstate
 from numpy import exp as numpy_exp
 from numpy import expand_dims as numpy_expand_dims
-from numpy import floor as numpy_floor
 from numpy import finfo as numpy_finfo
+from numpy import floating as numpy_floating
+from numpy import floor as numpy_floor
+from numpy import integer as numpy_integer
 from numpy import isnan as numpy_isnan
 from numpy import linspace as numpy_linspace
 from numpy import log as numpy_log
-from numpy import log10 as numpy_log10
 from numpy import log2 as numpy_log2
+from numpy import log10 as numpy_log10
 from numpy import nan as numpy_nan
 from numpy import nanpercentile as numpy_nanpercentile
 from numpy import ndarray as numpy_ndarray
 from numpy import ndenumerate as numpy_ndenumerate
-from numpy import ndindex as numpy_ndindex
 from numpy import ndim as numpy_ndim
+from numpy import ndindex as numpy_ndindex
 from numpy import newaxis as numpy_newaxis
 from numpy import ones as numpy_ones
-from numpy import prod as numpy_prod
 from numpy import percentile as numpy_percentile
+from numpy import prod as numpy_prod
 from numpy import ravel_multi_index as numpy_ravel_multi_index
 from numpy import reshape as numpy_reshape
 from numpy import result_type as numpy_result_type
@@ -73,13 +74,10 @@ from numpy import tile as numpy_tile
 from numpy import trunc as numpy_trunc
 from numpy import unique as numpy_unique
 from numpy import unravel_index as numpy_unravel_index
-from numpy import where as numpy_where
 from numpy import vectorize as numpy_vectorize
+from numpy import where as numpy_where
 from numpy import zeros as numpy_zeros
-from numpy import floating as numpy_floating
-from numpy import bool_ as numpy_bool_
-from numpy import integer as numpy_integer
-
+from numpy.ma import MaskedArray as numpy_ma_MaskedArray
 from numpy.ma import array as numpy_ma_array
 from numpy.ma import count as numpy_ma_count
 from numpy.ma import empty as numpy_ma_empty
@@ -90,50 +88,100 @@ from numpy.ma import masked as numpy_ma_masked
 from numpy.ma import masked_all as numpy_ma_masked_all
 from numpy.ma import masked_invalid as numpy_ma_masked_invalid
 from numpy.ma import masked_where as numpy_ma_masked_where
-from numpy.ma import MaskedArray as numpy_ma_MaskedArray
 from numpy.ma import nomask as numpy_ma_nomask
 from numpy.ma import where as numpy_ma_where
-
 from numpy.testing import suppress_warnings as numpy_testing_suppress_warnings
 
-import cftime
-import cfdm
-
-from ..cfdatetime import dt2rt, rt2dt, st2rt
+# TODODASK - Remove the next 6 lines when the move to dask is complete
+from .. import mpi_on
 from ..cfdatetime import dt as cf_dt
-from ..units import Units
+from ..cfdatetime import dt2rt, rt2dt, st2rt
 from ..constants import masked as cf_masked
-
-from ..functions import (
-    fm_threshold as cf_fm_threshold,
-    free_memory,
-    collapse_parallel_mode,
-    parse_indices,
-    _numpy_allclose,
-    _numpy_isclose,
-    pathjoin,
-    hash_array,
-    broadcast_array,
-    default_netCDF_fillvals,
-    abspath,
-)
-from ..functions import (
-    atol as cf_atol,
-    chunksize as cf_chunksize,
-    rtol as cf_rtol,
-)
-from ..functions import _DEPRECATION_ERROR_METHOD, _DEPRECATION_ERROR_ATTRIBUTE
-from ..functions import inspect as cf_inspect
-from ..functions import _section
-
-from ..mixin_container import Container
-
 from ..decorators import (
+    _deprecated_kwarg_check,
+    _display_or_return,
     _inplace_enabled,
     _inplace_enabled_define_and_cleanup,
-    _deprecated_kwarg_check,
     _manage_log_level_via_verbosity,
-    _display_or_return,
+)
+from ..functions import (
+    _DEPRECATION_ERROR_ATTRIBUTE,
+    _DEPRECATION_ERROR_METHOD,
+    _numpy_allclose,
+    _numpy_isclose,
+    _section,
+    abspath,
+)
+from ..functions import atol as cf_atol
+from ..functions import broadcast_array
+from ..functions import chunksize as cf_chunksize
+from ..functions import collapse_parallel_mode, default_netCDF_fillvals
+from ..functions import fm_threshold as cf_fm_threshold
+from ..functions import free_memory, hash_array
+from ..functions import inspect as cf_inspect
+from ..functions import parse_indices, pathjoin
+from ..functions import rtol as cf_rtol
+from ..mixin_container import Container
+from ..units import Units
+from . import (
+    GatheredSubarray,
+    NetCDFArray,
+    RaggedContiguousSubarray,
+    RaggedIndexedContiguousSubarray,
+    RaggedIndexedSubarray,
+    UMArray,
+)
+
+# TODO SB post-186: decide how best to import these whilst avoiding 'import *'
+from .collapse_functions import (
+    max_abs_f,
+    max_abs_ffinalise,
+    max_abs_fpartial,
+    max_f,
+    max_ffinalise,
+    max_fpartial,
+    mean_abs_f,
+    mean_abs_ffinalise,
+    mean_abs_fpartial,
+    mean_f,
+    mean_ffinalise,
+    mean_fpartial,
+    mid_range_f,
+    mid_range_ffinalise,
+    mid_range_fpartial,
+    min_abs_f,
+    min_abs_ffinalise,
+    min_abs_fpartial,
+    min_f,
+    min_ffinalise,
+    min_fpartial,
+    range_f,
+    range_ffinalise,
+    range_fpartial,
+    root_mean_square_f,
+    root_mean_square_ffinalise,
+    root_mean_square_fpartial,
+    sample_size_f,
+    sample_size_ffinalise,
+    sample_size_fpartial,
+    sd_f,
+    sd_ffinalise,
+    sd_fpartial,
+    sum_f,
+    sum_ffinalise,
+    sum_fpartial,
+    sum_of_squares_f,
+    sum_of_squares_ffinalise,
+    sum_of_squares_fpartial,
+    sw2_f,
+    sw2_ffinalise,
+    sw2_fpartial,
+    sw_f,
+    sw_ffinalise,
+    sw_fpartial,
+    var_f,
+    var_ffinalise,
+    var_fpartial,
 )
 
 #                       CompressedArray)
@@ -141,75 +189,10 @@ from .filledarray import FilledArray
 from .partition import Partition
 from .partitionmatrix import PartitionMatrix
 
-# TODO SB post-186: decide how best to import these whilst avoiding 'import *'
-from .collapse_functions import (
-    max_f,
-    max_fpartial,
-    max_ffinalise,
-    min_f,
-    min_fpartial,
-    min_ffinalise,
-    max_abs_f,
-    max_abs_fpartial,
-    max_abs_ffinalise,
-    min_abs_f,
-    min_abs_fpartial,
-    min_abs_ffinalise,
-    mean_f,
-    mean_fpartial,
-    mean_ffinalise,
-    mean_abs_f,
-    mean_abs_fpartial,
-    mean_abs_ffinalise,
-    root_mean_square_f,
-    root_mean_square_fpartial,
-    root_mean_square_ffinalise,
-    mid_range_f,
-    mid_range_fpartial,
-    mid_range_ffinalise,
-    range_f,
-    range_fpartial,
-    range_ffinalise,
-    sample_size_f,
-    sample_size_fpartial,
-    sample_size_ffinalise,
-    sum_f,
-    sum_fpartial,
-    sum_ffinalise,
-    sum_of_squares_f,
-    sum_of_squares_fpartial,
-    sum_of_squares_ffinalise,
-    sw_f,
-    sw_fpartial,
-    sw_ffinalise,
-    sw2_f,
-    sw2_fpartial,
-    sw2_ffinalise,
-    var_f,
-    var_fpartial,
-    var_ffinalise,
-    sd_f,
-    sd_fpartial,
-    sd_ffinalise,
-)
-
-from . import (
-    NetCDFArray,
-    UMArray,
-    GatheredSubarray,
-    RaggedContiguousSubarray,
-    RaggedIndexedSubarray,
-    RaggedIndexedContiguousSubarray,
-)
-
-# TODODASK - Remove the next 6 lines when the move to dask is complete
-from .. import mpi_on
-
 if mpi_on:
-    from .. import mpi_comm
-    from .. import mpi_size
-    from .. import mpi_rank
     from mpi4py.MPI import SUM as mpi_sum
+
+    from .. import mpi_comm, mpi_rank, mpi_size
 
 
 logger = logging.getLogger(__name__)

--- a/cf/data/filledarray.py
+++ b/cf/data/filledarray.py
@@ -1,12 +1,10 @@
 from numpy import empty as numpy_empty
 from numpy import full as numpy_full
-
 from numpy.ma import masked_all as numpy_ma_masked_all
 
-from . import abstract
-
-from ..functions import parse_indices
 from ..constants import masked as cf_masked
+from ..functions import parse_indices
+from . import abstract
 
 
 class FilledArray(abstract.Array):

--- a/cf/data/functions.py
+++ b/cf/data/functions.py
@@ -3,10 +3,8 @@ from os.path import isfile
 from netCDF4 import Dataset as netCDF4_Dataset
 
 from ..constants import _file_to_fh
-from ..functions import open_files_threshold_exceeded, close_one_file
-
+from ..functions import close_one_file, open_files_threshold_exceeded
 from ..umread_lib.umfile import File
-
 
 _file_to_UM = _file_to_fh.setdefault("UM", {})
 _file_to_Dataset = _file_to_fh.setdefault("netCDF", {})

--- a/cf/data/gatheredsubarray.py
+++ b/cf/data/gatheredsubarray.py
@@ -3,8 +3,7 @@ from operator import mul
 
 import numpy
 
-from ..functions import parse_indices, get_subspace
-
+from ..functions import get_subspace, parse_indices
 from . import abstract
 
 

--- a/cf/data/netcdfarray.py
+++ b/cf/data/netcdfarray.py
@@ -1,8 +1,7 @@
 import cfdm
 
 from . import abstract
-
-from .functions import _open_netcdf_file, _close_netcdf_file
+from .functions import _close_netcdf_file, _open_netcdf_file
 
 
 class NetCDFArray(cfdm.NetCDFArray, abstract.FileArray):

--- a/cf/data/partition.py
+++ b/cf/data/partition.py
@@ -1,15 +1,12 @@
 import atexit
 import logging
-
 from copy import deepcopy
 from functools import reduce
-from sys import getrefcount
-from os import close
-from os import remove
-from os import rmdir
-from os.path import isfile
-from operator import mul
 from itertools import product as itertools_product
+from operator import mul
+from os import close, remove, rmdir
+from os.path import isfile
+from sys import getrefcount
 from tempfile import mkstemp
 
 from numpy import array as numpy_array
@@ -19,24 +16,23 @@ from numpy import ndarray as numpy_ndarray
 from numpy import number as numpy_number
 from numpy import transpose as numpy_transpose
 from numpy import vectorize as numpy_vectorize
-
+from numpy.ma import MaskedArray as numpy_ma_MaskedArray
 from numpy.ma import is_masked as numpy_ma_is_masked
 from numpy.ma import isMA as numpy_ma_isMA
 from numpy.ma import masked_all as numpy_ma_masked_all
-from numpy.ma import MaskedArray as numpy_ma_MaskedArray
 from numpy.ma import nomask as numpy_ma_nomask
 
-# from cfunits import Units
-
+from ..functions import fm_threshold as cf_fm_threshold
+from ..functions import free_memory, get_subspace
+from ..functions import inspect as cf_inspect
 from ..units import Units
-from ..functions import get_subspace, free_memory
-from ..functions import inspect as cf_inspect, fm_threshold as cf_fm_threshold
+from .abstract import FileArray
 
 # from .filearray import  (_TempFileArray #, SharedMemoryArray,
 #                          _shared_memory_array,FileArray)
 from .cachedarray import CachedArray
 
-from .abstract import FileArray
+# from cfunits import Units
 
 
 logger = logging.getLogger(__name__)

--- a/cf/data/partitionmatrix.py
+++ b/cf/data/partitionmatrix.py
@@ -1,19 +1,14 @@
-import numpy
-
-from numpy import ndenumerate as numpy_ndenumerate
-from numpy import empty as numpy_empty
-from numpy import expand_dims as numpy_expand_dims
-from numpy import squeeze as numpy_squeeze
-
 from copy import deepcopy
 
-
-from .partition import Partition
-
-from ..functions import _DEPRECATION_ERROR_METHOD
+import numpy
+from numpy import empty as numpy_empty
+from numpy import expand_dims as numpy_expand_dims
+from numpy import ndenumerate as numpy_ndenumerate
+from numpy import squeeze as numpy_squeeze
 
 from ..decorators import _inplace_enabled, _inplace_enabled_define_and_cleanup
-
+from ..functions import _DEPRECATION_ERROR_METHOD
+from .partition import Partition
 
 _empty_matrix = numpy_empty((), dtype=object)
 

--- a/cf/data/raggedcontiguoussubarray.py
+++ b/cf/data/raggedcontiguoussubarray.py
@@ -2,10 +2,8 @@ import logging
 
 from numpy.ma import masked_all as numpy_ma_masked_all
 
-from ..functions import parse_indices, get_subspace
-
+from ..functions import get_subspace, parse_indices
 from . import abstract
-
 
 logger = logging.getLogger(__name__)
 

--- a/cf/data/raggedindexedcontiguoussubarray.py
+++ b/cf/data/raggedindexedcontiguoussubarray.py
@@ -2,10 +2,8 @@ import logging
 
 import numpy
 
-from ..functions import parse_indices, get_subspace
-
+from ..functions import get_subspace, parse_indices
 from . import abstract
-
 
 logger = logging.getLogger(__name__)
 

--- a/cf/data/raggedindexedsubarray.py
+++ b/cf/data/raggedindexedsubarray.py
@@ -2,10 +2,8 @@ import logging
 
 import numpy
 
-from ..functions import parse_indices, get_subspace
-
+from ..functions import get_subspace, parse_indices
 from . import abstract
-
 
 logger = logging.getLogger(__name__)
 

--- a/cf/data/umarray.py
+++ b/cf/data/umarray.py
@@ -1,11 +1,9 @@
 import numpy
 
-from ..functions import parse_indices, get_subspace
-from .functions import _open_um_file, _close_um_file
-
+from ..functions import get_subspace, parse_indices
 from ..umread_lib.umfile import Rec
-
 from . import abstract
+from .functions import _close_um_file, _open_um_file
 
 
 class UMArray(abstract.FileArray):

--- a/cf/decorators.py
+++ b/cf/decorators.py
@@ -1,17 +1,15 @@
 from functools import wraps
 
-from .constants import ValidLogLevels
-
-from .functions import (
-    log_level,
-    _DEPRECATION_ERROR_KWARGS,
-    _disable_logging,
-    _reset_log_emergence_level,
-    _is_valid_log_level_int,
-)
-
 import cfdm
 
+from .constants import ValidLogLevels
+from .functions import (
+    _DEPRECATION_ERROR_KWARGS,
+    _disable_logging,
+    _is_valid_log_level_int,
+    _reset_log_emergence_level,
+    log_level,
+)
 
 # Decorators (and helper functions for these) inherited from cfdm:
 _inplace_enabled = cfdm._inplace_enabled

--- a/cf/dimensioncoordinate.py
+++ b/cf/dimensioncoordinate.py
@@ -1,24 +1,17 @@
+import cfdm
 from numpy import empty as numpy_empty
 from numpy import result_type as numpy_result_type
 
-import cfdm
-
-from . import Bounds
-
-from .timeduration import TimeDuration
-from .units import Units
-
+from . import Bounds, mixin
 from .data.data import Data
-
-from . import mixin
-
-from .functions import _DEPRECATION_ERROR_KWARGS, _DEPRECATION_ERROR_ATTRIBUTE
-
 from .decorators import (
+    _deprecated_kwarg_check,
     _inplace_enabled,
     _inplace_enabled_define_and_cleanup,
-    _deprecated_kwarg_check,
 )
+from .functions import _DEPRECATION_ERROR_ATTRIBUTE, _DEPRECATION_ERROR_KWARGS
+from .timeduration import TimeDuration
+from .units import Units
 
 
 class DimensionCoordinate(

--- a/cf/domainancillary.py
+++ b/cf/domainancillary.py
@@ -1,8 +1,6 @@
 import cfdm
 
-from . import Bounds
-
-from . import mixin
+from . import Bounds, mixin
 
 
 class DomainAncillary(mixin.PropertiesDataBounds, cfdm.DomainAncillary):

--- a/cf/examplefield.py
+++ b/cf/examplefield.py
@@ -2,7 +2,6 @@ import cfdm
 
 from .cfimplementation import implementation
 
-
 _implementation = implementation()
 
 

--- a/cf/field.py
+++ b/cf/field.py
@@ -1,23 +1,21 @@
+import logging
 from collections import namedtuple
 from functools import reduce
 from operator import mul as operator_mul
-
-import logging
 
 try:
     from matplotlib.path import Path
 except ImportError:
     pass
 
+import cfdm
 import numpy as np
-
 from numpy import array as numpy_array
 from numpy import array_equal as numpy_array_equal
-
 from numpy import asanyarray as numpy_asanyarray
 from numpy import can_cast as numpy_can_cast
-from numpy import diff as numpy_diff
 from numpy import delete as numpy_delete
+from numpy import diff as numpy_diff
 from numpy import empty as numpy_empty
 from numpy import finfo as numpy_finfo
 from numpy import full as numpy_full
@@ -32,95 +30,87 @@ from numpy import squeeze as numpy_squeeze
 from numpy import tile as numpy_tile
 from numpy import unique as numpy_unique
 from numpy import where as numpy_where
-
 from numpy.ma import is_masked as numpy_ma_is_masked
 from numpy.ma import isMA as numpy_ma_isMA
-
 from numpy.ma import where as numpy_ma_where
 
-import cfdm
-
-from . import AuxiliaryCoordinate
-from . import Bounds
-from . import CellMethod
-from . import DimensionCoordinate
-from . import Domain
-from . import DomainAncillary
-from . import DomainAxis
-from . import Flags
-from . import Constructs
-from . import FieldList
-
-from . import Count
-from . import Index
-from . import List
-
+from . import (
+    AuxiliaryCoordinate,
+    Bounds,
+    CellMethod,
+    Constructs,
+    Count,
+    DimensionCoordinate,
+    Domain,
+    DomainAncillary,
+    DomainAxis,
+    FieldList,
+    Flags,
+    Index,
+    List,
+    mixin,
+)
 from .constants import masked as cf_masked
-
-from .functions import parse_indices, chunksize, _section
+from .data import (
+    Data,
+    GatheredArray,
+    RaggedContiguousArray,
+    RaggedIndexedArray,
+    RaggedIndexedContiguousArray,
+)
+from .decorators import (
+    _deprecated_kwarg_check,
+    _inplace_enabled,
+    _inplace_enabled_define_and_cleanup,
+    _manage_log_level_via_verbosity,
+)
+from .formula_terms import FormulaTerms
+from .functions import (
+    _DEPRECATION_ERROR,
+    _DEPRECATION_ERROR_ARG,
+    _DEPRECATION_ERROR_KWARG_VALUE,
+    _DEPRECATION_ERROR_KWARGS,
+    _DEPRECATION_ERROR_METHOD,
+    DeprecationError,
+    _section,
+    chunksize,
+    parse_indices,
+)
 from .functions import relaxed_identities as cf_relaxed_identities
-from .query import Query, ge, gt, le, lt, eq
-from .timeduration import TimeDuration
-from .units import Units
-from .subspacefield import SubspaceField
-
-from .data import Data
-from .data import RaggedContiguousArray
-from .data import RaggedIndexedArray
-from .data import RaggedIndexedContiguousArray
-from .data import GatheredArray
-
-from . import mixin
-
+from .query import Query, eq, ge, gt, le, lt
 from .regrid import (
+    RegridOperator,
     conservative_regridding_methods,
-    create_Grid,
     create_Field,
+    create_Grid,
     create_Regrid,
     get_cartesian_coords,
     grids_have_same_coords,
     grids_have_same_masks,
-    RegridOperator,
-    regrid_get_latlon,
-    regrid_get_axis_indices,
-    regrid_get_coord_order,
-    regrid_get_section_shape,
     regrid_check_bounds,
     regrid_check_method,
     regrid_check_use_src_mask,
-    regrid_get_reordered_sections,
-    regrid_get_destination_mask,
-    regrid_fill_fields,
     regrid_compute_field_mass,
-    regrid_get_regridded_data,
-    regrid_update_coordinate_references,
     regrid_copy_coordinate_references,
-    regrid_use_bounds,
-    regrid_update_coordinates,
-    regrid_initialize,
-    regrid_get_operator_method,
     regrid_create_operator,
+    regrid_fill_fields,
+    regrid_get_axis_indices,
+    regrid_get_coord_order,
+    regrid_get_destination_mask,
+    regrid_get_latlon,
+    regrid_get_operator_method,
+    regrid_get_regridded_data,
+    regrid_get_reordered_sections,
+    regrid_get_section_shape,
+    regrid_initialize,
+    regrid_update_coordinate_references,
+    regrid_update_coordinates,
+    regrid_use_bounds,
     run_Regrid,
 )
-
-from .functions import (
-    _DEPRECATION_ERROR,
-    _DEPRECATION_ERROR_ARG,
-    _DEPRECATION_ERROR_KWARGS,
-    _DEPRECATION_ERROR_METHOD,
-    _DEPRECATION_ERROR_KWARG_VALUE,
-    DeprecationError,
-)
-
-from .formula_terms import FormulaTerms
-
-from .decorators import (
-    _inplace_enabled,
-    _inplace_enabled_define_and_cleanup,
-    _deprecated_kwarg_check,
-    _manage_log_level_via_verbosity,
-)
-
+from .subspacefield import SubspaceField
+from .timeduration import TimeDuration
+from .units import Units
 
 logger = logging.getLogger(__name__)
 

--- a/cf/fieldlist.py
+++ b/cf/fieldlist.py
@@ -1,6 +1,4 @@
-from . import mixin
-from . import ConstructList
-
+from . import ConstructList, mixin
 from .functions import _DEPRECATION_ERROR_METHOD
 
 

--- a/cf/flags.py
+++ b/cf/flags.py
@@ -1,21 +1,19 @@
 import logging
+from copy import deepcopy
 
 from numpy import argsort as numpy_argsort
 from numpy import atleast_1d as numpy_atleast_1d
 from numpy import ndarray as numpy_ndarray
 
-from copy import deepcopy
-
-from .functions import equals as cf_equals
-from .functions import atol as cf_atol, rtol as cf_rtol
-from .functions import inspect as cf_inspect
-
 from .decorators import (
     _deprecated_kwarg_check,
-    _manage_log_level_via_verbosity,
     _display_or_return,
+    _manage_log_level_via_verbosity,
 )
-
+from .functions import atol as cf_atol
+from .functions import equals as cf_equals
+from .functions import inspect as cf_inspect
+from .functions import rtol as cf_rtol
 
 logger = logging.getLogger(__name__)
 

--- a/cf/formula_terms.py
+++ b/cf/formula_terms.py
@@ -2,19 +2,16 @@ import logging
 
 import cfdm
 
-from .units import Units
-
-from .functions import bounds_combination_mode
-
 from .constants import (
-    formula_terms_standard_names,
-    formula_terms_max_dimensions,
-    formula_terms_units,
     formula_terms_computed_standard_names,
     formula_terms_D1,
+    formula_terms_max_dimensions,
+    formula_terms_standard_names,
+    formula_terms_units,
 )
-
 from .docstring import _docstring_substitution_definitions
+from .functions import bounds_combination_mode
+from .units import Units
 
 logger = logging.getLogger(__name__)
 

--- a/cf/functions.py
+++ b/cf/functions.py
@@ -1,18 +1,30 @@
 import atexit
 import csv
+import ctypes.util
 import importlib
 import os
 import platform
 import re
 import resource
 import sys
-import ctypes.util
+import urllib.parse
+import warnings
+from collections.abc import Iterable  # just 'from collections' in Python <3.4
+from hashlib import md5 as hashlib_md5
+from marshal import dumps as marshal_dumps
+from math import ceil as math_ceil
+from os import getpid, listdir, mkdir
+from os.path import abspath as _os_path_abspath
+from os.path import dirname as _os_path_dirname
+from os.path import expanduser as _os_path_expanduser
+from os.path import expandvars as _os_path_expandvars
+from os.path import join as _os_path_join
+from os.path import relpath as _os_path_relpath
+
+import cfdm
 
 # import cPickle
 import netCDF4
-import warnings
-
-
 from numpy import __file__ as _numpy__file__
 from numpy import __version__ as _numpy__version__
 from numpy import all as _numpy_all
@@ -28,42 +40,22 @@ from numpy import size as _numpy_size
 from numpy import take as _numpy_take
 from numpy import tile as _numpy_tile
 from numpy import where as _numpy_where
-
 from numpy.ma import all as _numpy_ma_all
 from numpy.ma import allclose as _numpy_ma_allclose
 from numpy.ma import is_masked as _numpy_ma_is_masked
 from numpy.ma import isMA as _numpy_ma_isMA
 from numpy.ma import masked as _numpy_ma_masked
 from numpy.ma import take as _numpy_ma_take
+from psutil import Process, virtual_memory
 
-from collections.abc import Iterable  # just 'from collections' in Python <3.4
-from hashlib import md5 as hashlib_md5
-from marshal import dumps as marshal_dumps
-from math import ceil as math_ceil
-from os import getpid, listdir, mkdir
-from os.path import abspath as _os_path_abspath
-from os.path import expanduser as _os_path_expanduser
-from os.path import expandvars as _os_path_expandvars
-from os.path import dirname as _os_path_dirname
-from os.path import join as _os_path_join
-from os.path import relpath as _os_path_relpath
-from psutil import virtual_memory, Process
-import urllib.parse
-
-import cfdm
-
-from . import __version__, __file__
-
+from . import __file__, __version__, mpi_size
 from .constants import (
     CONSTANTS,
+    OperandBoundsCombination,
     _file_to_fh,
     _stash2standard_name,
-    OperandBoundsCombination,
 )
-
 from .docstring import _docstring_substitution_definitions
-
-from . import mpi_size
 
 
 # Instruction to close /proc/mem at exit.

--- a/cf/maths.py
+++ b/cf/maths.py
@@ -1,7 +1,6 @@
-from .functions import _DEPRECATION_ERROR_FUNCTION_KWARGS
 from . import Units
-
 from .data.data import Data
+from .functions import _DEPRECATION_ERROR_FUNCTION_KWARGS
 from .regrid import get_cartesian_coords
 
 

--- a/cf/mixin/coordinate.py
+++ b/cf/mixin/coordinate.py
@@ -1,14 +1,12 @@
 # from itertools import chain
 
+from ..data.data import Data
 from ..decorators import (
+    _deprecated_kwarg_check,
     _inplace_enabled,
     _inplace_enabled_define_and_cleanup,
-    _deprecated_kwarg_check,
 )
-
 from ..units import Units
-from ..data.data import Data
-
 
 _units_degrees = Units("degrees")
 

--- a/cf/mixin/fielddomain.py
+++ b/cf/mixin/fielddomain.py
@@ -1,5 +1,4 @@
 import logging
-
 from numbers import Integral
 
 import numpy as np
@@ -9,22 +8,20 @@ try:
 except ImportError:
     pass
 
-from ..query import Query
 from ..data import Data
-from ..units import Units
-
-from ..functions import (
-    parse_indices,
-    bounds_combination_mode,
-    _DEPRECATION_ERROR_KWARGS,
-)
-
 from ..decorators import (
+    _deprecated_kwarg_check,
     _inplace_enabled,
     _inplace_enabled_define_and_cleanup,
     _manage_log_level_via_verbosity,
-    _deprecated_kwarg_check,
 )
+from ..functions import (
+    _DEPRECATION_ERROR_KWARGS,
+    bounds_combination_mode,
+    parse_indices,
+)
+from ..query import Query
+from ..units import Units
 
 logger = logging.getLogger(__name__)
 

--- a/cf/mixin/properties.py
+++ b/cf/mixin/properties.py
@@ -1,20 +1,17 @@
 from cfdm.core.functions import deepcopy
 
-from ..functions import atol as cf_atol, rtol as cf_rtol
-
-from ..query import Query
-from ..units import Units
-
 from ..data import Data
-
 from ..functions import (
+    _DEPRECATION_ERROR,
     _DEPRECATION_ERROR_DICT,
     _DEPRECATION_ERROR_KWARGS,
     _DEPRECATION_ERROR_METHOD,
-    _DEPRECATION_ERROR,
 )
-
+from ..functions import atol as cf_atol
+from ..functions import rtol as cf_rtol
 from ..mixin_container import Container
+from ..query import Query
+from ..units import Units
 
 
 class Properties(Container):

--- a/cf/mixin/propertiesdata.py
+++ b/cf/mixin/propertiesdata.py
@@ -1,35 +1,29 @@
+import logging
 from functools import partial as functools_partial
 from itertools import chain
-
-import logging
 
 from numpy import array as numpy_array
 from numpy import result_type as numpy_result_type
 from numpy import vectorize as numpy_vectorize
 
 from ..cfdatetime import dt
-from ..functions import equivalent as cf_equivalent
-from ..functions import inspect as cf_inspect
-from ..functions import default_netCDF_fillvals
-from ..timeduration import TimeDuration
-from ..units import Units
-
 from ..data import Data
-
-from . import Properties
-
-from ..functions import (
-    _DEPRECATION_ERROR_METHOD,
-    _DEPRECATION_ERROR_ATTRIBUTE,
-)
-
 from ..decorators import (
+    _deprecated_kwarg_check,
     _inplace_enabled,
     _inplace_enabled_define_and_cleanup,
-    _deprecated_kwarg_check,
     _manage_log_level_via_verbosity,
 )
-
+from ..functions import (
+    _DEPRECATION_ERROR_ATTRIBUTE,
+    _DEPRECATION_ERROR_METHOD,
+    default_netCDF_fillvals,
+)
+from ..functions import equivalent as cf_equivalent
+from ..functions import inspect as cf_inspect
+from ..timeduration import TimeDuration
+from ..units import Units
+from . import Properties
 
 _units_None = Units()
 

--- a/cf/mixin/propertiesdatabounds.py
+++ b/cf/mixin/propertiesdatabounds.py
@@ -2,29 +2,24 @@ import logging
 
 import numpy as np
 
-from . import PropertiesData
-
+from ..data.data import Data
+from ..decorators import (
+    _deprecated_kwarg_check,
+    _inplace_enabled,
+    _inplace_enabled_define_and_cleanup,
+    _manage_log_level_via_verbosity,
+)
 from ..functions import (
-    bounds_combination_mode,
-    parse_indices,
-    _DEPRECATION_ERROR_METHOD,
     _DEPRECATION_ERROR_ATTRIBUTE,
+    _DEPRECATION_ERROR_METHOD,
+    bounds_combination_mode,
 )
 from ..functions import equivalent as cf_equivalent
 from ..functions import inspect as cf_inspect
-
-from ..decorators import (
-    _inplace_enabled,
-    _inplace_enabled_define_and_cleanup,
-    _deprecated_kwarg_check,
-    _manage_log_level_via_verbosity,
-)
-
+from ..functions import parse_indices
 from ..query import Query
 from ..units import Units
-
-from ..data.data import Data
-
+from . import PropertiesData
 
 _units_None = Units()
 

--- a/cf/query.py
+++ b/cf/query.py
@@ -1,26 +1,21 @@
 import logging
-
 from operator import __and__ as operator_and
 from operator import __or__ as operator_or
 
+from .data import Data
+from .decorators import (
+    _deprecated_kwarg_check,
+    _display_or_return,
+    _manage_log_level_via_verbosity,
+)
+from .functions import (
+    _DEPRECATION_ERROR_ATTRIBUTE,
+    _DEPRECATION_ERROR_FUNCTION,
+    _DEPRECATION_ERROR_FUNCTION_KWARGS,
+)
 from .functions import equals as _equals
 from .functions import inspect as _inspect
 from .units import Units
-
-from .data import Data
-
-from .functions import (
-    _DEPRECATION_ERROR_FUNCTION_KWARGS,
-    _DEPRECATION_ERROR_ATTRIBUTE,
-    _DEPRECATION_ERROR_FUNCTION,
-)
-
-from .decorators import (
-    _deprecated_kwarg_check,
-    _manage_log_level_via_verbosity,
-    _display_or_return,
-)
-
 
 logger = logging.getLogger(__name__)
 

--- a/cf/read_write/netcdf/netcdfread.py
+++ b/cf/read_write/netcdf/netcdfread.py
@@ -1,13 +1,11 @@
 import json
-
 from ast import literal_eval as ast_literal_eval
 
+import cfdm
 from numpy import dtype as numpy_dtype
 
-import cfdm
-
 from ...constants import _file_to_fh
-from ...functions import pathjoin, dirname
+from ...functions import dirname, pathjoin
 from ...units import Units
 
 

--- a/cf/read_write/netcdf/netcdfwrite.py
+++ b/cf/read_write/netcdf/netcdfwrite.py
@@ -1,21 +1,17 @@
 import json
 import random
-
 from os.path import isfile
-
 from string import hexdigits
 
-import numpy
-
 import cfdm
-
-from ... import DomainAncillary, Coordinate, Bounds
-from ...functions import relpath
-
+import numpy
 from netCDF4 import Dataset as netCDF4_Dataset
+
+from ... import Bounds, Coordinate, DomainAncillary
 
 # TODO: is it OK to import from here? Maybe best move these to '...functions'?
 from ...data.functions import _close_netcdf_file, _file_to_Dataset
+from ...functions import relpath
 
 
 class NetCDFWrite(cfdm.read_write.netcdf.NetCDFWrite):

--- a/cf/read_write/read.py
+++ b/cf/read_write/read.py
@@ -1,19 +1,17 @@
 import logging
 import os
 import tempfile
-
 from glob import glob
 from os.path import isdir
 
 from numpy.ma.core import MaskError
 
-from ..cfimplementation import implementation
-from ..fieldlist import FieldList
 from ..aggregate import aggregate as cf_aggregate
+from ..cfimplementation import implementation
 from ..decorators import _manage_log_level_via_verbosity
+from ..fieldlist import FieldList
+from ..functions import _DEPRECATION_ERROR_FUNCTION_KWARGS, flat
 from ..query import Query
-from ..functions import flat, _DEPRECATION_ERROR_FUNCTION_KWARGS
-
 from .netcdf import NetCDFRead
 from .um import UMRead
 

--- a/cf/read_write/um/filearray.py
+++ b/cf/read_write/um/filearray.py
@@ -1,15 +1,10 @@
 from numpy.ma import masked_where as numpy_ma_masked_where
 
 from ...constants import _file_to_fh
-from ...functions import (
-    parse_indices,
-    get_subspace,
-)
 from ...data.abstract.filearray import FileArray
-
-from .functions import _open_um_file, _close_um_file
-
+from ...functions import get_subspace, parse_indices
 from ...umread_lib.umfile import Rec
+from .functions import _close_um_file, _open_um_file
 
 _filename_to_file = _file_to_fh.setdefault("UM", {})
 

--- a/cf/read_write/um/functions.py
+++ b/cf/read_write/um/functions.py
@@ -1,9 +1,6 @@
 from ...constants import _file_to_fh
-from ...functions import (
-    open_files_threshold_exceeded,  # abspath
-    close_one_file,
-)
-
+from ...functions import open_files_threshold_exceeded  # abspath
+from ...functions import close_one_file
 from ...umread_lib.umfile import File
 
 _file_to_UM = _file_to_fh.setdefault("UM", {})

--- a/cf/read_write/um/umread.py
+++ b/cf/read_write/um/umread.py
@@ -1,9 +1,12 @@
 import itertools
 import logging
 import textwrap
-
 from datetime import datetime
 
+import cfdm
+import cftime
+from cfdm import Constructs
+from netCDF4 import date2num as netCDF4_date2num
 from numpy import arange as numpy_arange
 from numpy import arccos as numpy_arccos
 from numpy import arcsin as numpy_arcsin
@@ -24,33 +27,20 @@ from numpy import sin as numpy_sin
 from numpy import transpose as numpy_transpose
 from numpy import where as numpy_where
 
-from netCDF4 import date2num as netCDF4_date2num
-
-import cftime
-
-import cfdm
-from cfdm import Constructs
-
-from ... import __version__, __Conventions__
-from ...decorators import (
-    _manage_log_level_via_verbosity,
-    _manage_log_level_via_verbose_attr,
-)
-from ...functions import (
-    abspath,
-    load_stash2standard_name,
-)
-from ...functions import atol as cf_atol, rtol as cf_rtol
-
+from ... import __Conventions__, __version__
 from ...constants import _stash2standard_name
-
-from ...units import Units
-
-from ...data.data import Data, Partition, PartitionMatrix
-
 from ...data import UMArray
-from ...data.functions import _open_um_file, _close_um_file
-
+from ...data.data import Data, Partition, PartitionMatrix
+from ...data.functions import _close_um_file, _open_um_file
+from ...decorators import (
+    _manage_log_level_via_verbose_attr,
+    _manage_log_level_via_verbosity,
+)
+from ...functions import abspath
+from ...functions import atol as cf_atol
+from ...functions import load_stash2standard_name
+from ...functions import rtol as cf_rtol
+from ...units import Units
 
 logger = logging.getLogger(__name__)
 

--- a/cf/read_write/write.py
+++ b/cf/read_write/write.py
@@ -2,21 +2,15 @@ from os.path import abspath
 
 import numpy
 
-from .netcdf import NetCDFWrite
-
 from ..cfimplementation import implementation
-
 from ..decorators import _manage_log_level_via_verbosity
-
-from ..functions import flat
-from ..functions import _DEPRECATION_ERROR_FUNCTION_KWARGS
+from ..functions import _DEPRECATION_ERROR_FUNCTION_KWARGS, flat
+from .netcdf import NetCDFWrite
 
 # from . import mpi_on
 mpi_on = False
 if mpi_on:
-    from . import mpi_comm
-    from . import mpi_size
-    from . import mpi_rank
+    from . import mpi_comm, mpi_rank, mpi_size
 
 
 netcdf = NetCDFWrite(implementation())

--- a/cf/regrid/regridoperator.py
+++ b/cf/regrid/regridoperator.py
@@ -1,6 +1,5 @@
 from .. import _found_ESMF
 
-
 if _found_ESMF:
     try:
         import ESMF

--- a/cf/regrid/utils.py
+++ b/cf/regrid/utils.py
@@ -3,10 +3,10 @@ from operator import itemgetter
 
 import numpy as np
 
-from ..functions import regrid_logging
-from ..dimensioncoordinate import DimensionCoordinate
-from ..data import Data
 from .. import _found_ESMF
+from ..data import Data
+from ..dimensioncoordinate import DimensionCoordinate
+from ..functions import regrid_logging
 
 if _found_ESMF:
     try:

--- a/cf/test/run_tests.py
+++ b/cf/test/run_tests.py
@@ -1,11 +1,10 @@
 import datetime
 import doctest
-import importlib
 import faulthandler
+import importlib
 import os
 import pkgutil
 import unittest
-
 from argparse import ArgumentParser
 from random import choice, shuffle
 

--- a/cf/test/test_Constructs.py
+++ b/cf/test/test_Constructs.py
@@ -1,7 +1,6 @@
 import datetime
-import unittest
-
 import faulthandler
+import unittest
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cf/test/test_CoordinateReference.py
+++ b/cf/test/test_CoordinateReference.py
@@ -9,7 +9,6 @@ faulthandler.enable()  # to debug seg faults and timeouts
 
 import cf
 
-
 n_tmpfiles = 1
 tmpfiles = [
     tempfile.mkstemp("_test_CoordinateReference.nc", dir=os.getcwd())[1]

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -2,11 +2,10 @@ import datetime
 import faulthandler
 import inspect
 import itertools
-from operator import mul
 import os
 import unittest
-
 from functools import reduce
+from operator import mul
 
 import numpy
 

--- a/cf/test/test_decorators.py
+++ b/cf/test/test_decorators.py
@@ -6,7 +6,6 @@ faulthandler.enable()  # to debug seg faults and timeouts
 
 import cf
 
-
 # Note: it is important we test on the cf logging config rather than the
 # generic Python module logging (i.e. 'cf.logging' not just 'logging').
 # Also, mimic the use in the codebase by using a module-specific logger:

--- a/cf/test/test_docstring.py
+++ b/cf/test/test_docstring.py
@@ -5,8 +5,9 @@ import unittest
 
 faulthandler.enable()  # to debug seg faults and timeouts
 
-import cf
 import cfdm
+
+import cf
 
 
 def _recurse_on_subclasses(klass):

--- a/cf/test/test_gathering.py
+++ b/cf/test/test_gathering.py
@@ -11,7 +11,6 @@ faulthandler.enable()  # to debug seg faults and timeouts
 
 import cf
 
-
 n_tmpfiles = 1
 tmpfiles = [
     tempfile.mkstemp("_test_gathering.nc", dir=os.getcwd())[1]

--- a/cf/test/test_general.py
+++ b/cf/test/test_general.py
@@ -11,7 +11,6 @@ faulthandler.enable()  # to debug seg faults and timeouts
 
 import cf
 
-
 tmpfile = tempfile.mkstemp(".nc")[1]
 tmpfile2 = tempfile.mkstemp(".nca")[1]
 tmpfiles = [tmpfile, tmpfile2, "delme.nc", "delme.nca"]

--- a/cf/test/test_groups.py
+++ b/cf/test/test_groups.py
@@ -11,7 +11,6 @@ import netCDF4
 
 import cf
 
-
 n_tmpfiles = 8
 tmpfiles = [
     tempfile.mkstemp("_test_groups.nc", dir=os.getcwd())[1]

--- a/cf/test/test_read_write.py
+++ b/cf/test/test_read_write.py
@@ -14,7 +14,6 @@ faulthandler.enable()  # to debug seg faults and timeouts
 
 import cf
 
-
 n_tmpfiles = 8
 tmpfiles = [
     tempfile.mkstemp("_test_read_write.nc", dir=os.getcwd())[1]

--- a/cf/test/test_style.py
+++ b/cf/test/test_style.py
@@ -1,8 +1,9 @@
 import datetime
 import faulthandler
 import os
-import pycodestyle
 import unittest
+
+import pycodestyle
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cf/timeduration.py
+++ b/cf/timeduration.py
@@ -1,23 +1,18 @@
 import logging
-
-from operator import __add__, __sub__
-
 from collections import namedtuple
+from operator import __add__, __sub__
 
 import numpy
 
-from .cfdatetime import elements
 from .cfdatetime import dt as cf_dt
-from .functions import inspect as cf_inspect
-from .units import Units
-
+from .cfdatetime import elements
 from .data.data import Data
-
 from .decorators import (
     _deprecated_kwarg_check,
     _manage_log_level_via_verbosity,
 )
-
+from .functions import inspect as cf_inspect
+from .units import Units
 
 logger = logging.getLogger(__name__)
 

--- a/cf/umread_lib/cInterface.py
+++ b/cf/umread_lib/cInterface.py
@@ -1,12 +1,10 @@
-import os
-
 import ctypes as CT
+import os
 
 import numpy
 import numpy.ctypeslib
 
 from . import umfile
-
 
 _len_real_hdr = 19
 _len_int_hdr = 45

--- a/cf/umread_lib/extraData.py
+++ b/cf/umread_lib/extraData.py
@@ -1,5 +1,6 @@
-import sys
 import string
+import sys
+
 import numpy
 
 

--- a/cf/umread_lib/umfile.py
+++ b/cf/umread_lib/umfile.py
@@ -1,5 +1,4 @@
 import os
-
 from functools import cmp_to_key
 
 import numpy

--- a/cf/units.py
+++ b/cf/units.py
@@ -2,7 +2,6 @@ from ctypes.util import find_library
 
 from cfunits import Units as cfUnits
 
-
 _libpath = find_library("udunits2")
 if _libpath is None:
     raise FileNotFoundError(

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,12 +13,13 @@
 # out serve to show the default.
 
 import datetime
-import sys
 import os
 import re
-import cf
+import sys
 
 import cfdm
+
+import cf
 
 print("\ncf environment:")
 print("-----------------")
@@ -437,8 +438,9 @@ toggleprompt_offset_right = 25  # stops toggle and copy buttons overlapping
 # corresponding to the object in given domain with given information.
 
 import inspect
+from os.path import dirname, relpath
+
 import cf
-from os.path import relpath, dirname
 
 link_release = re.search("(\d+\.\d+\.\d+)", release).groups()[0]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,15 @@
 # the 'black' documentation.
 [tool.black]
 line-length = 79
+
+[tool.isort]
+# Set for compatibility of 'black' and 'isort' auto-formatting tools
+profile = "black"
+# ... and since we set this against the black default line length:
+line_length=79
+# Prevent isort from auto-formatting '__init__.py' file imports because
+# they require a specific non-aphabetical (etc.) ordering else they will
+# cause errors due to bad or circular importing across the modules.
+extend_skip_glob = [
+  "**/__init__.py",
+]

--- a/scripts/cfa
+++ b/scripts/cfa
@@ -3,11 +3,12 @@
 
 if __name__ == "__main__":
 
-    from getopt import getopt, GetoptError
-    import sys
     import os
-    import cf
+    import sys
+    from getopt import GetoptError, getopt
     from re import sub as re_sub
+
+    import cf
 
     library_path = os.path.dirname(os.path.abspath(cf.__file__))
 

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
-from setuptools import setup
-
-from distutils.command.build import build
-import os
 import fnmatch
+import os
 import re
 import subprocess
+from distutils.command.build import build
+
+from setuptools import setup
 
 
 def find_package_data_files(directory):


### PR DESCRIPTION
Closes NCAS-CMS/cf-python#63: no functional changes made, just automatic re-organisation of import statments with an associated pre-commit hook to make the changes in-place on attempted commit.