### PR TITLE
Concerning `Field.get_coordinate_reference`

### DIFF
--- a/cf/mixin/fielddomain.py
+++ b/cf/mixin/fielddomain.py
@@ -2207,7 +2207,7 @@ class FieldDomain:
         )
 
     def get_coordinate_reference(
-        self, identity=None, key=False, construct=None, default=ValueError()
+        self, *identity, key=False, construct=None, default=ValueError()
     ):
         """TODO.
 
@@ -2277,8 +2277,8 @@ class FieldDomain:
 
         """
         if construct is None:
-            return self.coordinate_reference(
-                identity=identity, key=key, default=default
+            return self.coordinate_references(
+                *identity, key=key, default=default
             )
 
         out = []
@@ -2287,7 +2287,6 @@ class FieldDomain:
         if c_key is None:
             if default is None:
                 return
-
             return self._default(
                 default, f"Can't identify construct from {construct!r}"
             )

--- a/cf/mixin/fielddomain.py
+++ b/cf/mixin/fielddomain.py
@@ -2277,7 +2277,7 @@ class FieldDomain:
 
         """
         if construct is None:
-            return self.coordinate_references(
+            return self.coordinate_reference(
                 *identity, key=key, default=default
             )
 

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -2337,6 +2337,31 @@ class FieldTest(unittest.TestCase):
             key,
         )
 
+        # Get
+        self.assertEqual(len(f.get_coordinate_reference()), 2)
+        self.assertEqual(
+            len(f.get_coordinate_reference("coordinatereference0")), 1
+        )
+        self.assertEqual(
+            len(f.get_coordinate_reference("coordinatereference1")), 1
+        )
+
+        for identity in (
+            "coordinatereference1",
+            "key%coordinatereference0",
+            "standard_name:atmosphere_hybrid_height_coordinate",
+            "grid_mapping_name:rotated_latitude_longitude",
+        ):
+            key = f.construct_key(identity)
+            c = f.construct(identity)
+
+            self.assertTrue(
+                f.get_coordinate_reference(identity).equals(c, verbose=2)
+            )
+            self.assertEqual(
+                f.get_coordinate_reference(identity, key=True), key
+            )
+
         # Delete
         self.assertIsNone(f.del_coordinate_reference("qwerty", default=None))
 

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -2338,14 +2338,6 @@ class FieldTest(unittest.TestCase):
         )
 
         # Get
-        self.assertEqual(len(f.get_coordinate_reference()), 2)
-        self.assertEqual(
-            len(f.get_coordinate_reference("coordinatereference0")), 1
-        )
-        self.assertEqual(
-            len(f.get_coordinate_reference("coordinatereference1")), 1
-        )
-
         for identity in (
             "coordinatereference1",
             "key%coordinatereference0",
@@ -2361,6 +2353,12 @@ class FieldTest(unittest.TestCase):
             self.assertEqual(
                 f.get_coordinate_reference(identity, key=True), key
             )
+
+        with self.assertRaises(ValueError):
+            f.get_coordinate_reference()  # since has two CR constructs
+        g = f.copy()
+        g.del_coordinate_reference("coordinatereference1")
+        g.get_coordinate_reference()  # should work here as has only one CR
 
         # Delete
         self.assertIsNone(f.del_coordinate_reference("qwerty", default=None))


### PR DESCRIPTION
To close #236 and (if we want to keep it as a method, see suggestion below), in the process improve the testing and documentation of `Field.get_coordinate_reference`.

I have made the basic update to apply the construct access API change that was missed for v3.10.0 via cfdm v1.8.9.0, in 32a8787, but this PR remains a draft because I also want to flash out the corresponding API documentation but:
* I am [also unsure](https://github.com/NCAS-CMS/cf-python/issues/236#issuecomment-881358028) of the intended role of the `construct` keyword.
 * It is not entirely clear to me from the code (given the lack of summary line in the docstring/docs) the intention of the method `Field.get_coordinate_reference`, in particular how it differs to `cf.Field.coordinate_reference` (from `cf`) and `cf.Field.coordinate_references` (from `cfdm`), because obviously it isn't a straightforward alias to either of those.

@davidhassell would you mind clarifying? If there isn't a specific difference to make this method worthwhile, could we just make it an alias to `coordinate_reference`? Also, unless you can recall or detect some clear purpose for the `construct` parameter, I suggest we just drop it from the method. In any case, I am happy to scrap the PR as-is especially as there are few changes in the PR change set as it stands.