### PR TITLE
`test_Data` workflow with skips to monitor Dask migration

### DIFF
--- a/.github/workflows/dask-migration-testing.yml
+++ b/.github/workflows/dask-migration-testing.yml
@@ -1,0 +1,113 @@
+# A GitHub Action to run test_Data.py only for the 'lama-to-dask' branch
+name: Test `cf.Data` during the replacement of LAMA with Dask
+
+on:
+  push:
+    branches:
+      - lama-to-dask
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+    branches:
+      - lama-to-dask
+
+jobs:
+  test-suite-job-0:
+
+    # Set-up the build matrix. We run on different distros and Python versions.
+    strategy:
+      matrix:
+        # Skip older ubuntu-16.04 & macos-10.15 to save usage resource
+        os: [ubuntu-latest, macos-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9]
+
+    # Run on new and old(er) versions of the distros we support (Linux, Mac OS)
+    runs-on: ${{ matrix.os }}
+
+    # The sequence of tasks that will be executed as part of this job:
+    steps:
+
+    - name: Checkout cf-python
+      uses: actions/checkout@v2
+      with:
+        path: main
+
+    # Provide a notification message
+    - name: Notify about setup
+      run: echo Now setting up the environment for the cf-python test suite...
+
+    - name: Checkout the current cfdm master to use as the dependency
+      uses: actions/checkout@v2
+      with:
+        repository: NCAS-CMS/cfdm
+        path: cfdm
+
+    # Prepare to run the test-suite on different versions of Python 3:
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    # Setup conda, which is the simplest way to access all dependencies,
+    # especially as some are C-based so otherwise difficult to setup.
+    - name: Setup Miniconda
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        auto-update-conda: true
+        miniconda-version: 'latest'
+        activate-environment: cf-latest
+        python-version: ${{ matrix.python-version }}
+        channels: ncas, conda-forge
+
+    # Ensure shell is configured with conda activated:
+    - name: Check conda config
+      shell: bash -l {0}
+      run: |
+        conda info
+        conda list
+        conda config --show-sources
+        conda config --show
+    # Install cf-python dependencies, excluding cfdm, pre-testing
+    # We do so with conda which was setup in a previous step.
+    - name: Install dependencies
+      shell: bash -l {0}
+      run: |
+        conda install -c ncas -c conda-forge udunits2=2.2.25
+        conda install -c conda-forge mpich esmpy
+        conda install scipy matplotlib dask
+        pip install pycodestyle
+    # Install cfdm from master branch, then the cf-python development version
+    # We do so with conda which was setup in a previous step.
+    - name: Install development cfdm and cf-python
+      shell: bash -l {0}
+      run: |
+        cd ${{ github.workspace }}/cfdm
+        pip install -e .
+        cd ${{ github.workspace }}/main
+        pip install -e .
+    # Make UMRead library
+    - name: Make UMRead
+      shell: bash -l {0}
+      run: |
+        cd ${{ github.workspace }}/main/cf/umread_lib/c-lib
+        make
+    # Install the coverage library
+    # We do so with conda which was setup in a previous step.
+    - name: Install coverage
+      shell: bash -l {0}
+      run: |
+        conda install coverage
+    # Provide another notification message
+    - name: Notify about starting testing
+      run: echo Setup complete. Now starting to run the cf-python test suite...
+
+    # Finally run test_Data.py!
+    - name: Run the test_Data test module
+      shell: bash -l {0}
+      run: |
+        cd ${{ github.workspace }}/main/cf/test
+        python test_Data.py
+
+    # End with a message indicating the suite has completed its run
+    - name: Notify about a completed run
+      run: |
+        echo The test_Data module has run and you can inspect the results.

--- a/.github/workflows/dask-migration-testing.yml
+++ b/.github/workflows/dask-migration-testing.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         # Skip older ubuntu-16.04 & macos-10.15 to save usage resource
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     # Run on new and old(er) versions of the distros we support (Linux, Mac OS)
     runs-on: ${{ matrix.os }}

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -31,6 +31,12 @@ ma[0, 3, :, 3] = np.ma.masked
 ma[1, 2, 3, :] = np.ma.masked
 
 
+# If True, all tests that will not pass temporarily due to the LAMA-to-Dask
+# migration will be skipped. These skips will be incrementally removed as the
+# migration progresses. TODODASK: ensure all skips are removed once complete.
+TEST_DASKIFIED_ONLY = True
+
+
 def reshape_array(a, axes):
     new_order = [i for i in range(a.ndim) if i not in axes]
     new_order.extend(axes)
@@ -119,6 +125,7 @@ class DataTest(unittest.TestCase):
     #    test_only = ['test_Data_clip']
     #    test_only = ['test_Data__init__dtype_mask']
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "hits unexpected kwarg 'ndim'")
     def test_Data_halo(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -201,6 +208,7 @@ class DataTest(unittest.TestCase):
     #     [ 8  8  9 10 -- --]
     #     [ 8  8  9 10 -- --]]
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_apply_masking(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -258,6 +266,7 @@ class DataTest(unittest.TestCase):
                 self.assertTrue((b == e.array).all())
                 self.assertTrue((b.mask == e.mask.array).all())
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_convolution_filter(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -292,6 +301,7 @@ class DataTest(unittest.TestCase):
                     self.assertTrue((e.array == b).all())
         # --- End: for
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attr. 'partition_configuration'")
     def test_Data_diff(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -335,6 +345,7 @@ class DataTest(unittest.TestCase):
                         self.assertTrue((a_diff.mask == d_diff.mask).all())
         # --- End: for
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute '_ndim'")
     def test_Data_compressed(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -373,6 +384,7 @@ class DataTest(unittest.TestCase):
                 d = cf.Data(self.ma, "km")
                 self.assertTrue((self.ma.compressed() == d.compressed()).all())
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute '_shape'")
     def test_Data_stats(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -383,6 +395,7 @@ class DataTest(unittest.TestCase):
         _ = d.stats(all=True)
         _ = d.stats(mean_of_upper_decile=True, range=False)
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute '_shape'")
     def test_Data__init__dtype_mask(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -459,6 +472,7 @@ class DataTest(unittest.TestCase):
         self.assertTrue((d.array == a).all())
         self.assertTrue((d.mask.array == np.ma.getmaskarray(a)).all())
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_digitize(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -497,6 +511,7 @@ class DataTest(unittest.TestCase):
                             f = d.digitize(bins, upper=upper)
                             self.assertTrue(e.equals(f, verbose=2))
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute '_ndim'")
     def test_Data_cumsum(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -523,6 +538,7 @@ class DataTest(unittest.TestCase):
                     e = d.cumsum(axis=i, masked_as_zero=False)
                     self.assertTrue(cf.functions._numpy_allclose(e.array, b))
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute '_ndim'")
     def test_Data_flatten(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -562,6 +578,7 @@ class DataTest(unittest.TestCase):
                     self.assertEqual(e.ndim, d.ndim - len(axes) + 1)
                     self.assertEqual(e.size, d.size)
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'partitions'")
     def test_Data_CachedArray(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -594,6 +611,7 @@ class DataTest(unittest.TestCase):
 
         cf.free_memory_factor(original_FMF)
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attr. 'partition_configuration'")
     def test_Data_cached_arithmetic_units(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -629,6 +647,7 @@ class DataTest(unittest.TestCase):
         # Reset
         cf.constants.CONSTANTS["FM_THRESHOLD"] = fmt
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute '_auxiliary_mask'")
     def test_Data_AUXILIARY_MASK(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -728,6 +747,7 @@ class DataTest(unittest.TestCase):
                 self.assertEqual(f.shape, fm.shape)
                 self.assertTrue((f._auxiliary_mask_return().array == fm).all())
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data___contains__(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -745,6 +765,7 @@ class DataTest(unittest.TestCase):
                 self.assertIn(value, d)
                 self.assertIn(np.array([[[2]]]), d)
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_asdata(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -782,6 +803,7 @@ class DataTest(unittest.TestCase):
                     )
                 )
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_squeeze_insert_dimension(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -886,6 +908,7 @@ class DataTest(unittest.TestCase):
             self.assertTrue((d.array == a).all())
             self.assertTrue((d.array.mask == a.mask).all())
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_outerproduct(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -914,6 +937,7 @@ class DataTest(unittest.TestCase):
                 self.assertIsNone(d.outerproduct(e, inplace=True))
                 self.assertEqual(d.shape, (40, 30, 5), d.shape)
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_all(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -929,6 +953,7 @@ class DataTest(unittest.TestCase):
                 d[...] = cf.masked
                 self.assertTrue(d.all())
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_any(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -944,6 +969,7 @@ class DataTest(unittest.TestCase):
                 d[...] = cf.masked
                 self.assertFalse(d.any())
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_array(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -977,6 +1003,7 @@ class DataTest(unittest.TestCase):
                 a = d.array
                 self.assertTrue((a == np.array([[2.5]])).all())
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_binary_mask(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -997,6 +1024,7 @@ class DataTest(unittest.TestCase):
                 self.assertEqual(b.dtype, np.dtype("int32"))
                 self.assertTrue((b.array == a).all())
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_clip(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -1023,6 +1051,7 @@ class DataTest(unittest.TestCase):
                 d.clip(c0 * 100, c1 * 100, units="10m", inplace=True)
                 self.assertTrue(d.allclose(ac, rtol=1e-05, atol=1e-08))
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attr. 'partition_configuration'")
     def test_Data_months_years(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -1096,6 +1125,7 @@ class DataTest(unittest.TestCase):
         )
         d *= 31
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "'NoneType' object is not callable")
     def test_Data_datetime_array(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -1152,6 +1182,7 @@ class DataTest(unittest.TestCase):
                 ).all()
             )
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data__asdatetime__asreftime__isdatetime(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -1178,6 +1209,7 @@ class DataTest(unittest.TestCase):
                 self.assertEqual(d.dtype, np.dtype(float))
                 self.assertFalse(d._isdatetime())
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_ceil(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -1195,6 +1227,7 @@ class DataTest(unittest.TestCase):
                     self.assertEqual(d.shape, c.shape)
                     self.assertTrue((d.array == c).all())
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_floor(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -1212,6 +1245,7 @@ class DataTest(unittest.TestCase):
                     self.assertEqual(d.shape, c.shape)
                     self.assertTrue((d.array == c).all())
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_trunc(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -1229,6 +1263,7 @@ class DataTest(unittest.TestCase):
                     self.assertEqual(d.shape, c.shape)
                     self.assertTrue((d.array == c).all())
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_rint(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -1251,6 +1286,7 @@ class DataTest(unittest.TestCase):
                     self.assertEqual(d.shape, c.shape)
                     self.assertTrue((d.array == c).all())
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_round(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -1270,6 +1306,7 @@ class DataTest(unittest.TestCase):
                     self.assertEqual(d.shape, c.shape)
                     self.assertTrue((d.array == c).all())
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_datum(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -1315,6 +1352,7 @@ class DataTest(unittest.TestCase):
                 self.assertIs(d.datum([0, -1]), cf.masked)
                 self.assertIs(d.datum(-1, -1), cf.masked)
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_flip(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -1364,6 +1402,7 @@ class DataTest(unittest.TestCase):
         self.assertEqual(e[0].maximum(), 3 * 4 * 5)
         self.assertEqual(e[-1].maximum(), 4 * 5)
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_max(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -1388,6 +1427,7 @@ class DataTest(unittest.TestCase):
                         cf.Data(0.005, "km"),
                     )
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_min(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -1412,6 +1452,7 @@ class DataTest(unittest.TestCase):
                         cf.Data(0.002, "km"),
                     )
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_ndindex(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -1429,6 +1470,7 @@ class DataTest(unittest.TestCase):
 
         cf.chunksize(self.original_chunksize)
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_roll(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -1459,6 +1501,7 @@ class DataTest(unittest.TestCase):
                 self.assertEqual(f.shape, d.shape)
                 self.assertTrue(f.equals(d, verbose=2))
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_swapaxes(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -1479,6 +1522,7 @@ class DataTest(unittest.TestCase):
                         self.assertEqual(b.shape, e.shape, message)
                         self.assertTrue((b == e.array).all(), message)
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_transpose(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -1502,6 +1546,7 @@ class DataTest(unittest.TestCase):
                         self.assertEqual(d.shape, a.shape, message)
                         self.assertTrue((d.array == a).all(), message)
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_unique(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -1517,6 +1562,9 @@ class DataTest(unittest.TestCase):
                     (d.unique() == cf.Data([1, 2, 4], "metre")).all()
                 )
 
+    @unittest.skipIf(
+        TEST_DASKIFIED_ONLY, "hits 'TODODASK - use harden_mask/soften_mask'"
+    )
     def test_Data_varray(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -1548,6 +1596,7 @@ class DataTest(unittest.TestCase):
                 v[0, 0, 0, 0] = 0
                 self.assertTrue((v == b).all())
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attr. 'partition_configuration'")
     def test_Data_year_month_day_hour_minute_second(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -1572,6 +1621,7 @@ class DataTest(unittest.TestCase):
 
         cf.chunksize(self.original_chunksize)
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_BINARY_AND_UNARY_OPERATORS(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -1864,6 +1914,7 @@ class DataTest(unittest.TestCase):
 
         cf.chunksize(self.original_chunksize)
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_BROADCASTING(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -1937,6 +1988,7 @@ class DataTest(unittest.TestCase):
         cf.Data.mask_fpe(oldm)
         cf.Data.seterr(**olds)
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute '_shape'")
     def test_Data__len__(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -1996,6 +2048,7 @@ class DataTest(unittest.TestCase):
         with self.assertRaises(Exception):
             _ = round(cf.Data([1, 2]))
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_argmax(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -2016,6 +2069,7 @@ class DataTest(unittest.TestCase):
                     )
                 )
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "hits 'NoneType' is not iterable")
     def test_Data__collapse_SHAPE(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -2106,6 +2160,7 @@ class DataTest(unittest.TestCase):
             )
         # --- End: for
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_max_min_sum_sum_of_squares(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -2169,6 +2224,7 @@ class DataTest(unittest.TestCase):
 
         cf.chunksize(self.original_chunksize)
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_median(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -2222,6 +2278,7 @@ class DataTest(unittest.TestCase):
                             "\ne={}, \nb={}".format(axes, e.array, b),
                         )
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_percentile(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -2251,6 +2308,7 @@ class DataTest(unittest.TestCase):
         # TODO: add loop to check get same shape and close enough data
         # for every possible axes combo (as with test_Data_median above).
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_mean_of_upper_decile(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -2318,6 +2376,7 @@ class DataTest(unittest.TestCase):
                             "\ne={}, \nb={}".format(axes, e.array, b),
                         )
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_range_mid_range(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -2383,6 +2442,7 @@ class DataTest(unittest.TestCase):
                                 "\ne={}, \nb={}".format(h, axes, e.array, b),
                             )
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_integral(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -2441,6 +2501,7 @@ class DataTest(unittest.TestCase):
                             ),
                         )
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_sum_of_weights_sum_of_weights2(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -2559,6 +2620,7 @@ class DataTest(unittest.TestCase):
                                 ),
                             )
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_mean_mean_absolute_value(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -2654,6 +2716,7 @@ class DataTest(unittest.TestCase):
 
         cf.chunksize(self.original_chunksize)
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_root_mean_square(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -2731,6 +2794,7 @@ class DataTest(unittest.TestCase):
                         ),
                     )
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_sample_size(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -2762,6 +2826,7 @@ class DataTest(unittest.TestCase):
                         "axis={}, \ne={}, \nb={}".format(axes, e.array, b),
                     )
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_sd_var(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -2935,6 +3000,7 @@ class DataTest(unittest.TestCase):
 
         cf.chunksize(self.original_chunksize)
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_dumpd_loadd_dumps(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -2950,6 +3016,7 @@ class DataTest(unittest.TestCase):
                 d.to_disk()
                 self.assertTrue(d.equals(cf.Data(loadd=dumpd), verbose=2))
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "hits unexpected kwarg 'select'")
     def test_Data_section(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -2967,6 +3034,7 @@ class DataTest(unittest.TestCase):
                 e = cf.Data.reconstruct_sectioned_data(x)
                 self.assertTrue(e.equals(d))
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attr. 'partition_configuration'")
     def test_Data_count(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -2983,6 +3051,7 @@ class DataTest(unittest.TestCase):
                 self.assertEqual(d.count(), d.size)
                 self.assertEqual(d.count_masked(), 0)
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_exp(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -3009,6 +3078,7 @@ class DataTest(unittest.TestCase):
         with self.assertRaises(Exception):
             _ = d.exp()
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attribute 'chunk_sizes'")
     def test_Data_trigonometric_hyperbolic(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -3119,6 +3189,9 @@ class DataTest(unittest.TestCase):
         #             self.assertTrue((e.array == c).all())
         #             self.assertTrue((d1.mask.array == c.mask).all())
 
+    @unittest.skipIf(
+        TEST_DASKIFIED_ONLY, "hits 'TODODASK - use harden_mask/soften_mask'"
+    )
     def test_Data_filled(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -3170,6 +3243,7 @@ class DataTest(unittest.TestCase):
         d = cf.Data(["a", "b", "c"], mask=[1, 0, 0])
         self.assertTrue((d.filled().array == ["", "b", "c"]).all())
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "units-related problem")
     def test_Data_del_units(self):
         d = cf.Data(1)
         with self.assertRaises(ValueError):
@@ -3207,6 +3281,7 @@ class DataTest(unittest.TestCase):
         d = cf.Data(1, "days since 2000-1-1", calendar="noleap")
         self.assertTrue(d.del_calendar(), "noleap")
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "units-related problem")
     def test_Data_has_units(self):
         d = cf.Data(1)
         self.assertFalse(d.has_units())
@@ -3215,6 +3290,7 @@ class DataTest(unittest.TestCase):
         d = cf.Data(1, "m")
         self.assertTrue(d.has_units())
 
+    @unittest.skipIf(TEST_DASKIFIED_ONLY, "units-related problem")
     def test_Data_has_calendar(self):
         d = cf.Data(1)
         self.assertFalse(d.has_calendar())


### PR DESCRIPTION
I am about to put up some more interesting PRs to make headway with 'Daskifying' the data-related methods in turn for #182, but before I start doing that in earnest I want to ensure we can track the migration progress in terms of the tests that pass, notably for (self-)review to:

* indicate progress for a given PR by highlighting extra tests that pass due to a given change; and
* ensure tests that do pass due to progress previously made aren't broken by any proposed changes in a new PR.

So in this PR I have:

* added skips to tests in `test_Data`  that can be switched on or off by a new flag `TEST_DASKIFIED_ONLY`;
* added a new workflow specifically specifically for the LAMA-to-dask migration work to trigger Github Actions to run jobs that run the `test_Data` module and not the whole test suite, because the first goal is to get the data modules working, where metadata tests will fail on data issues until that is complete.