### PR TITLE
Fix subtraction of `TimeDuration` of, and from, `Data`

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -5,6 +5,8 @@ version NEXT
 
 * Fix `cf.aggregate` failures when using the ``dimension`` keyword
   parameter (https://github.com/NCAS-CMS/cf-python/issues/283)
+* Fix bug that raised error with subtraction of a `cf.TimeDuration`
+  (https://github.com/NCAS-CMS/cf-python/issues/287)
 
 ----
 

--- a/cf/test/test_TimeDuration.py
+++ b/cf/test/test_TimeDuration.py
@@ -474,6 +474,24 @@ class TimeDurationTest(unittest.TestCase):
         self.assertEqual(cf.M(8) / 3, cf.M(8 / 3))
         self.assertEqual(cf.M(8) // 3, cf.M(2))
 
+        # Test arithmetic involving Data as well as datetimes:
+        da = cf.Data([2], units="days since 2000-01-01")
+        dt = cf.TimeDuration(14, "day")
+        t0 = da + dt
+        t1 = dt + da
+        self.assertEqual(
+            t0,
+            cf.dt(2000, 1, 17, calendar="gregorian"),
+        )
+        self.assertEqual(t0, t1)
+        t2 = dt - da
+        t3 = da - dt
+        self.assertEqual(
+            t2,
+            cf.dt(1999, 12, 20, calendar="gregorian"),
+        )
+        self.assertEqual(t2, t3)
+
     def test_Timeduration__days_in_month(self):
         self.assertEqual(cf.TimeDuration.days_in_month(1900, 2), 28)
         self.assertEqual(cf.TimeDuration.days_in_month(1999, 2), 28)

--- a/cf/timeduration.py
+++ b/cf/timeduration.py
@@ -546,6 +546,13 @@ class TimeDuration:
         if isinstance(other, (self.__class__, int, float)):
             return self._binary_operation(other, "__sub__")
 
+        if hasattr(other, "timetuple"):
+            # other is a date-time object
+            try:
+                return self._datetime_arithmetic(other, __sub__)
+            except TypeError:
+                return NotImplemented
+
         if isinstance(other, Data):
             return self._data_arithmetic(other, "__sub__")
 
@@ -717,17 +724,7 @@ class TimeDuration:
         .. versionadded:: 1.4
 
         """
-        if isinstance(other, (self.__class__, int, float)):
-            return self._binary_operation(other, "__rsub__")
-
-        if hasattr(other, "timetuple"):
-            # other is a date-time object
-            try:
-                return self._datetime_arithmetic(other, __sub__)
-            except TypeError:
-                return NotImplemented
-
-        return NotImplemented
+        return -self + other
 
     def __mod__(self, other):
         """The binary arithmetic operation ``%``


### PR DESCRIPTION
Close #287 and add a test to capture it that bug, as well as a similar bug with a different traceback emering if the inverse is tried i..e the data subtracted from the timeduration (which I guess makes sense and should work, though isn't a very natural operation), namely (this report results from adding the new test lines to the `master` branch:

```python
test_TimeDuration (__main__.TimeDurationTest) ... ok
test_TimeDuration_arithmetic (__main__.TimeDurationTest) ... ERROR
test_TimeDuration_bounds (__main__.TimeDurationTest) ... ok
test_TimeDuration_interval (__main__.TimeDurationTest) ... ok
test_TimeDuration_iso (__main__.TimeDurationTest) ... ok
test_Timeduration__days_in_month (__main__.TimeDurationTest) ... ok

======================================================================
ERROR: test_TimeDuration_arithmetic (__main__.TimeDurationTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_TimeDuration.py", line 487, in test_TimeDuration_arithmetic
    t2 = dt - da
  File "/home/sadie/cf-python/cf/timeduration.py", line 550, in __sub__
    return self._data_arithmetic(other, "__sub__")
  File "/home/sadie/cf-python/cf/timeduration.py", line 894, in _data_arithmetic
    return Data(dt, units=other.Units)
  File "/home/sadie/cf-python/cf/data/data.py", line 665, in __init__
    map(str, (x.year, x.month, x.day))
AttributeError: 'NotImplementedType' object has no attribute 'year'

----------------------------------------------------------------------
```

where commenting our the `t2 = dt - da` line and anything referring to `t2` reveals the error Dan reported (for the full traceback it is:)

```python
test_TimeDuration (__main__.TimeDurationTest) ... ok
test_TimeDuration_arithmetic (__main__.TimeDurationTest) ... ERROR
test_TimeDuration_bounds (__main__.TimeDurationTest) ... ok
test_TimeDuration_interval (__main__.TimeDurationTest) ... ok
test_TimeDuration_iso (__main__.TimeDurationTest) ... ok
test_Timeduration__days_in_month (__main__.TimeDurationTest) ... ok

======================================================================
ERROR: test_TimeDuration_arithmetic (__main__.TimeDurationTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_TimeDuration.py", line 488, in test_TimeDuration_arithmetic
    t3 = da - dt
TypeError: unsupported operand type(s) for -: 'Data' and 'TimeDuration'

----------------------------------------------------------------------

```

## Fix suggestion

@davidhassell my suggestion is to change the implementation of `__rsub__` to that shown, especially given the equivalently simple implementations of `__radd__` and `__rmul__`, though because those are commutative and `sub` isn't, I would like to check that the idea is OK - perhaps relating to the non-commutativity `__rsub__` must be done differently? If so, happy to change the approach, but something about the current implementation certainly isn't working and needs to be fixed and/or changed, and my suggestion does work at least...