### PR TITLE
Fix bug in `cf.Field.derivative` and `cf.relative_vorticity` when   wrapping with periodic coordinates

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -7,6 +7,8 @@ version NEXT
   parameter (https://github.com/NCAS-CMS/cf-python/issues/283)
 * Fix bug that raised error with subtraction of a `cf.TimeDuration`
   (https://github.com/NCAS-CMS/cf-python/issues/287)
+* Fix bug in `cf.Field.derivative` when wrapping with periodic
+  coordinates (https://github.com/NCAS-CMS/cf-python/issues/289)
 
 ----
 

--- a/cf/field.py
+++ b/cf/field.py
@@ -16733,7 +16733,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
             period = coord.period()
             if period is not None:
                 # Fix the boundary differences for cyclic periodic
-                # coordinates. Need to add extend the coordinates to
+                # coordinates. Need to extend the coordinates to
                 # include a dummy value at each end, grabbed from the
                 # other end, that maintains strict monotonicity.
                 c_data = coord.data

--- a/cf/field.py
+++ b/cf/field.py
@@ -16609,12 +16609,11 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
     ):
         """Return the derivative along the specified axis.
 
-        The derivative is calculated by centred finite differences along
-        the specified axis.
-
-        If the axis is cyclic then the boundary is wrapped around,
-        otherwise missing values are used at the boundary unless one-sided
-        finite differences are requested.
+        The derivative is calculated using centred finite differences
+        apart from at the boundaries (see the *one_sided_at_boundary*
+        parameter). If missing values are present then missing values
+        will be returned at all points where a centred finite
+        difference could not be calculated.
 
         :Parameters:
 
@@ -16632,22 +16631,57 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 autodetected.
 
             one_sided_at_boundary: `bool`, optional
-                If True then one-sided finite differences are used at the
-                boundary, otherwise missing values are used.
+                If True, and the field is not cyclic or *wrap* is
+                True, then one-sided finite differences are calculated
+                at the non-cyclic boundaries. By default missing
+                values are set at non-cyclic boundaries.
 
             {{inplace: `bool`, optional}}
-                If True then do the operation in-place and return `None`.
 
             {{i: deprecated at version 3.0.0}}
 
         :Returns:
 
             `Field` or `None`
-                TODO , or `None` if the operation was in-place.
+                The derivative of the field along the specified axis,
+                or `None` if the operation was in-place.
 
-        **Examples:**
+        **Examples**
 
-        TODO
+        >>> f = cf.example_field(0)
+        >>> print(f.dimension_coordinate('X').array)
+        [ 22.5  67.5 112.5 157.5 202.5 247.5 292.5 337.5]
+        >>> print(f.dimension_coordinate('X').cellsize.array)
+        [45. 45. 45. 45. 45. 45. 45. 45.]
+        >>> f[...] = [45, 90, 135, 180, 225, 270, 315, 360]
+        >>> f.iscyclic('X')
+        True
+        >>> print(f.array)
+        [[ 45.  90. 135. 180. 225. 270. 315. 360.]
+         [ 45.  90. 135. 180. 225. 270. 315. 360.]
+         [ 45.  90. 135. 180. 225. 270. 315. 360.]
+         [ 45.  90. 135. 180. 225. 270. 315. 360.]
+         [ 45.  90. 135. 180. 225. 270. 315. 360.]]
+        >>> print(f.derivative('X').array)
+        [[-3.  1.  1.  1.  1.  1.  1. -3.]
+         [-3.  1.  1.  1.  1.  1.  1. -3.]
+         [-3.  1.  1.  1.  1.  1.  1. -3.]
+         [-3.  1.  1.  1.  1.  1.  1. -3.]
+         [-3.  1.  1.  1.  1.  1.  1. -3.]]
+        >>> print(f.derivative('X', wrap=False).array)
+        [[-- 1.0 1.0 1.0 1.0 1.0 1.0 --]
+         [-- 1.0 1.0 1.0 1.0 1.0 1.0 --]
+         [-- 1.0 1.0 1.0 1.0 1.0 1.0 --]
+         [-- 1.0 1.0 1.0 1.0 1.0 1.0 --]
+         [-- 1.0 1.0 1.0 1.0 1.0 1.0 --]]
+        >>> print(
+        ...   f.derivative('X', wrap=False, one_sided_at_boundary=True).array
+        ... )
+        [[1. 1. 1. 1. 1. 1. 1. 1.]
+         [1. 1. 1. 1. 1. 1. 1. 1.]
+         [1. 1. 1. 1. 1. 1. 1. 1.]
+         [1. 1. 1. 1. 1. 1. 1. 1.]
+         [1. 1. 1. 1. 1. 1. 1. 1.]]
 
         """
         if cyclic:
@@ -16658,25 +16692,23 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 "Use the 'wrap' keyword instead",
             )  # pragma: no cover
 
-        #        try:
-        #            scipy_convolve1d
-        #        except NameError:
-        #            raise ImportError(
-        #                "Must install scipy to use the derivative method.")
-
         # Retrieve the axis
+        axis_in = axis
         axis = self.domain_axis(axis, key=True, default=None)
         if axis is None:
-            raise ValueError("Invalid axis specifier")
+            raise ValueError(f"Invalid axis specifier: {axis_in}")
 
         coord = self.dimension_coordinate(filter_by_axis=(axis,), default=None)
         if coord is None:
-            raise ValueError("Axis specified is not unique.")
+            raise ValueError(
+                f"No dimension coordinates for axis defined by {axis_in}"
+            )
 
         # Get the axis index
         axis_index = self.get_data_axes().index(axis)
 
-        # Automatically detect the cyclicity of the axis if cyclic is None
+        # Automatically detect the cyclicity of the axis if cyclic is
+        # None
         if wrap is None:
             wrap = self.iscyclic(axis)
 
@@ -16690,17 +16722,40 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
 
         f = _inplace_enabled_define_and_cleanup(self)
 
-        # Find the finite difference of the field
+        # Find the differences of the data
         f.convolution_filter(
             [1, 0, -1], axis=axis, mode=mode, update_bounds=False, inplace=True
         )
 
-        # Find the finite difference of the axis
-        d = coord.data.convolution_filter(
-            window=[1, 0, -1], axis=0, mode=mode, cval=numpy_nan
-        )
+        # Find the differences of the coordinates
+        d = None
+        if wrap and f.iscyclic(axis):
+            period = coord.period()
+            if period is not None:
+                # Fix the boundary differences for cyclic periodic
+                # coordinates. Need to add extend the coordinates to
+                # include a dummy value at each end, grabbed from the
+                # other end, that maintains strict monotonicity.
+                c_data = coord.data
+                d2 = self._Data.empty((c_data.size + 2,), units=c_data.Units)
+                if not coord.direction():
+                    period = -period
 
-        # Reshape the finite difference of the axis for broadcasting
+                d2[1:-1] = c_data
+                d2[0] = c_data[-1] - period
+                d2[-1] = c_data[0] + period
+
+                d = d2.convolution_filter(
+                    window=[1, 0, -1], axis=0, mode="constant"
+                )[1:-1]
+
+        if d is None:
+            d = coord.data.convolution_filter(
+                window=[1, 0, -1], axis=0, mode=mode, cval=numpy_nan
+            )
+
+        # Reshape the coordinate differences so that they broadcast to
+        # the data
         for _ in range(self.ndim - 1 - axis_index):
             d.insert_dimension(position=1, inplace=True)
 
@@ -16708,13 +16763,8 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
         f.data /= d
 
         # Update the standard name and long name
-        standard_name = f.get_property("standard_name", None)
-        long_name = f.get_property("long_name", None)
-        if standard_name is not None:
-            del f.standard_name
-            f.long_name = f"derivative of {standard_name}"
-        elif long_name is not None:
-            f.long_name = f"derivative of {long_name}"
+        f.set_property("long_name", f"{axis_in} derivative of {f.identity()}")
+        f.del_property("standard_name", None)
 
         return f
 


### PR DESCRIPTION
Fixes #289 