### PR TITLE
CI: create `test_file.nc` before step to run test suite

### DIFF
--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -111,6 +111,16 @@ jobs:
     - name: Notify about starting testing
       run: echo Setup complete. Now starting to run the cf-python test suite...
 
+    # Create a file needed for testing. A separate step is required for this
+    # so the file can be registered and recognised first. Locally, the file
+    # is created and used on-the-fly by the 'run_tests_and_coverage' script.
+    - name: Create test_file.nc
+      shell: bash -l {0}
+      run: |
+        cd ${{ github.workspace }}/main/cf/test
+        python create_test_files.py
+        ls -la
+
     # Finally run the test suite and generate a coverage report!
     - name: Run test suite and generate a coverage report
       shell: bash -l {0}

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -119,6 +119,7 @@ jobs:
       run: |
         cd ${{ github.workspace }}/main/cf/test
         python create_test_files.py
+        python setup_create_field.py
         ls -la
 
     # Finally run the test suite and generate a coverage report!

--- a/.github/workflows/test-source-dist.yml
+++ b/.github/workflows/test-source-dist.yml
@@ -94,6 +94,17 @@ jobs:
     - name: Notify about starting the sdist test
       run: echo Setup complete. Now creating and testing the source dist...
 
+    # Create a file needed for testing. A separate step is required for this
+    # so the file can be registered and recognised first. Locally, the file
+    # is created and used on-the-fly by the 'run_tests_and_coverage' script.
+    - name: Create test_file.nc
+      shell: bash -l {0}
+      run: |
+        cd ${{ github.workspace }}/main/cf/test
+        python create_test_files.py
+        python setup_create_field.py
+        ls -la
+
     - name: Create the source distribution and store the version as an env var
       shell: bash -l {0}
       run: |

--- a/.github/workflows/test-source-dist.yml
+++ b/.github/workflows/test-source-dist.yml
@@ -77,7 +77,8 @@ jobs:
         pip install pycodestyle
 
     # Install cfdm from the cfdm development master branch, then all other
-    # dependencies, but not cf-python itself (only want to test sdist build).
+    # dependencies, where we also install cf-python itself but only in order
+    # to generate the test_file.nc file for testing, not as the cf to test.
     # We do so with conda which was setup in a previous step.
     - name: Install development cfdm.
       shell: bash -l {0}
@@ -89,6 +90,9 @@ jobs:
         # spec (next) in the conda env rather than globally to the PYTHONPATH:
         conda install pip
         pip install -r requirements.txt
+        # Installing cf now but only to be able to run setup_create_field.py
+        # next, in order to generate the test_file.nc required to test on
+        pip install -e .
 
     # Provide another notification message
     - name: Notify about starting the sdist test


### PR DESCRIPTION
A netCDF file for testing on, `test_file.nc` is written out and used by the `run_test.py` script that runs the full test suite, and locally this works fine, but for the Actions jobs it is not being recognised, at least within the `test_Field` module:

```bash
Running tests from /home/runner/work/cf-python/cf-python/main/cf/test

    class FieldTest(unittest.TestCase):
  File "/home/runner/work/cf-python/cf-python/main/cf/test/test_Field.py", line 80, in FieldTest
    f = cf.read(filename)[0]
  File "/home/runner/work/cf-python/cf-python/cfdm/cfdm/decorators.py", line 171, in verbose_override_wrapper
    return method_with_verbose_kwarg(*args, **kwargs)
  File "/home/runner/work/cf-python/cf-python/main/cf/read_write/read.py", line 699, in read
    open(file_glob, "rb")
FileNotFoundError: [Errno 2] No such file or directory: '/home/runner/work/cf-python/cf-python/main/cf/test/test_file.nc'
```

This PR aims to fix this so that the required file is generated by the Actions jobs and available for use by that script (as wrapped by the coverage-checking script), as opposed to committing it permanently to the repo which is a simple solution but is not preferred for various reasons.

Some trial-and-error is anticipated to get this working.