### PR TITLE
`Data.mask`: migrate to Dask

### DIFF
--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -6373,13 +6373,12 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         """
         mask_data_obj = self.copy()
 
-        dx = self._get_dask().copy()
+        dx = self._get_dask()
         mask = da.ma.getmaskarray(dx)
-        mask_data_obj[...] = mask
 
-        mask_data_obj.dtype = _dtype_bool
-        mask_data_obj._Units = _units_None
-        mask_data_obj._hardmask = True
+        mask_data_obj._set_dask(mask, reset_mask_hardness=True)
+        mask_data_obj.override_units(_units_None, inplace=True)
+        mask_data_obj.hardmask = True
 
         return mask_data_obj
 

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -6371,17 +6371,17 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         (12, 73, 96)
 
         """
+        mask_data_obj = self.copy()
+
         dx = self._get_dask().copy()
         mask = da.ma.getmaskarray(dx)
+        mask_data_obj[...] = mask
 
-        mask._Units = _units_None
-        mask._hardmask = True
+        mask_data_obj.dtype = _dtype_bool
+        mask_data_obj._Units = _units_None
+        mask_data_obj._hardmask = True
 
-        # Note pre-daskification this would return a mask object where would
-        # need to apply 'array' prop. to get the array itself, but now, as
-        # consistent with NumPy, will instead return the mask array directly.
-        # Therefore in test suite, previous `x.mask.array` becomes `x.mask`.
-        return mask
+        return mask_data_obj
 
     @staticmethod
     def mask_fpe(*arg):

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -6351,9 +6351,9 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
     @property
     def mask(self):
-        """The boolean missing data mask of the data array.
+        """The Boolean missing data mask of the data array.
 
-        The boolean mask has True where the data array has missing data
+        The Boolean mask has True where the data array has missing data
         and False otherwise.
 
         :Returns:
@@ -6368,7 +6368,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         >>> m.dtype
         dtype('bool')
         >>> m.shape
-        (12, 73, 96])
+        (12, 73, 96)
 
         """
         mask = self.copy()

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -6366,7 +6366,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         (12, 73, 96)
         >>> m = d.mask
         >>> m.dtype
-        bool
+        dtype('bool')
         >>> m.shape
         (12, 73, 96)
 

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -540,7 +540,7 @@ class DataTest(unittest.TestCase):
         # TODODASK: once test_Data_apply_masking is passing after daskification
         # of apply_masking, might make sense to combine this test with that?
 
-        # Test mask for a masked Data object (having some masked points)
+        # Test for a masked Data object (having some masked points)
         a = self.ma
         d = cf.Data(a, units="m")
         self.assertTrue((a == d.array).all())
@@ -551,15 +551,27 @@ class DataTest(unittest.TestCase):
         self.assertTrue(d.mask.hardmask)
         self.assertIn(True, d.mask.array)
 
-        # Test mask for a non-masked Data object
+        # Test for a non-masked Data object
         a2 = np.arange(-100, 200.0, dtype=float).reshape(3, 4, 5, 5)
         d2 = cf.Data(a2, units="m")
+        d2[...] = a2
         self.assertTrue((a2 == d2.array).all())
         self.assertEqual(d2.shape, d2.mask.shape)
         self.assertEqual(d2.mask.dtype, bool)
         self.assertEqual(d2.mask.Units, cf.Units(None))
         self.assertTrue(d2.mask.hardmask)
         self.assertNotIn(True, d2.mask.array)
+
+        # Test for a masked Data object of string type, including chunking
+        a3 = np.ma.array(["one", "two", "four"], dtype="S4")
+        a3[1] = np.ma.masked
+        d3 = cf.Data(a3, "m", chunks=(3,))
+        self.assertTrue((a3 == d3.array).all())
+        self.assertEqual(d3.shape, d3.mask.shape)
+        self.assertEqual(d3.mask.dtype, bool)
+        self.assertEqual(d3.mask.Units, cf.Units(None))
+        self.assertTrue(d3.mask.hardmask)
+        self.assertTrue(d3.mask.array[1], True)
 
     @unittest.skipIf(TEST_DASKIFIED_ONLY, "no attr. 'partition_configuration'")
     def test_Data_apply_masking(self):


### PR DESCRIPTION
Convert the `mask` managed attribute towards #182.