### PR TITLE
remove "-g" (include debug flags) compiler option

### DIFF
--- a/cf/umread_lib/c-lib/Makefile
+++ b/cf/umread_lib/c-lib/Makefile
@@ -1,7 +1,7 @@
 HEADERS=umfile.h umfileint.h bits/*.h
 
 LIBRARY=umfile.so
-CFLAGS=-Wall -fPIC -g
+CFLAGS=-Wall -fPIC
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)


### PR DESCRIPTION
This works around what seems to be some kind of compiler / linker bug.

In the conda environment we are using, containing:
```
$ gcc --version
gcc (GCC) 11.2.0
[...]

$ ld --version
GNU ld version 2.27-44.base.el7
[...]
```

I find that I can't create a shared library if `-g` has been used in the compilation:

```
$ cat foo.c
void foo() {}

$ gcc -c -g foo.c
$ ld -shared -o foo.so foo.o
ld: foo.o: unable to initialize decompress status for section .debug_info
ld: foo.o: unable to initialize decompress status for section .debug_info
foo.o: file not recognized: File format not recognized
```

without the `-g`, everything looks normal
```
$ rm foo.o
$ gcc -c foo.c
$ ld -shared -o foo.so foo.o
$ nm foo.so
0000000000201000 D __bss_start
0000000000200f50 d _DYNAMIC
0000000000201000 D _edata
0000000000201000 D _end
000000000000024d T foo
0000000000201000 d _GLOBAL_OFFSET_TABLE_
```

Hence removing `-g` from the compiler options to work around this.