### PR TITLE
LAMA to Dask: `func` -> built-in conversion for non-trig. methods

### DIFF
--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -10138,6 +10138,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
     @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")
+    @_inplace_enabled(default=False)
     def floor(self, inplace=False, i=False):
         """Return the floor of the data array.
 
@@ -10164,7 +10165,10 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         [-2. -2. -2. -1.  0.  1.  1.  1.  1.]
 
         """
-        return self.func(np.floor, inplace=inplace)
+        d = _inplace_enabled_define_and_cleanup(self)
+        dx = d._get_dask()
+        d._set_dask(da.floor(dx), reset_mask_hardness=False)
+        return d
 
     @_deprecated_kwarg_check("i")
     def outerproduct(self, e, inplace=False, i=False):

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -9219,7 +9219,8 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         if d.Units:
             d.Units = _units_1
 
-        d.func(np.exp, inplace=True)
+        dx = d._get_dask()
+        d._set_dask(da.exp(dx), reset_mask_hardness=False)
 
         return d
 

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -12315,6 +12315,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
     @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")
+    @_inplace_enabled(default=False)
     def trunc(self, inplace=False, i=False):
         """Return the truncated values of the data array.
 
@@ -12345,7 +12346,10 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         [-1. -1. -1. -1.  0.  1.  1.  1.  1.]
 
         """
-        return self.func(np.trunc, inplace=inplace)
+        d = _inplace_enabled_define_and_cleanup(self)
+        dx = d._get_dask()
+        d._set_dask(da.trunc(dx), reset_mask_hardness=False)
+        return d
 
     @classmethod
     def empty(

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -2824,6 +2824,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
     @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")
+    @_inplace_enabled(default=False)
     def ceil(self, inplace=False, i=False):
         """The ceiling of the data, element-wise.
 
@@ -2855,7 +2856,10 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         [-1. -1. -1. -1.  0.  1.  2.  2.  2.]
 
         """
-        return self.func(np.ceil, inplace=inplace)
+        d = _inplace_enabled_define_and_cleanup(self)
+        dx = d._get_dask()
+        d._set_dask(da.ceil(dx), reset_mask_hardness=False)
+        return d
 
     @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -11027,6 +11027,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
     @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")
+    @_inplace_enabled(default=False)
     def rint(self, inplace=False, i=False):
         """Round the data to the nearest integer, element-wise.
 
@@ -11055,7 +11056,10 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         [-2. -2. -1. -1.  0.  1.  1.  2.  2.]
 
         """
-        return self.func(np.rint, inplace=inplace)
+        d = _inplace_enabled_define_and_cleanup(self)
+        dx = d._get_dask()
+        d._set_dask(da.rint(dx), reset_mask_hardness=False)
+        return d
 
     def root_mean_square(
         self,

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -9217,7 +9217,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         if units and not units.isdimensionless:
             raise ValueError(
                 "Can't take exponential of dimensional "
-                "quantities: {!r}".format(units)
+                f"quantities: {units!r}"
             )
 
         if d.Units:
@@ -12050,7 +12050,9 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
         d._set_dask(dx, reset_mask_hardness=False)
 
-        d.override_units(_units_1, inplace=True)  # all logarithm outputs are unitless
+        d.override_units(
+            _units_1, inplace=True
+        )  # all logarithm outputs are unitless
 
         return d
 

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -12016,9 +12016,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
         return d
 
-    # TODOASK: daskified except in the case of arbitrary base (not e, 2 or 10)
-    # which requires `__itruediv__` to be daskified.
-    # @daskified(_DASKIFIED_VERBOSE)
+    @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     def log(self, base=None, inplace=False, i=False):
@@ -12038,16 +12036,21 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
         """
         d = _inplace_enabled_define_and_cleanup(self)
+        dx = d._get_dask()
 
         if base is None:
-            d.func(np.log, units=_units_1, inplace=True)
+            dx = da.log(dx)
         elif base == 10:
-            d.func(np.log10, units=_units_1, inplace=True)
+            dx = da.log10(dx)
         elif base == 2:
-            d.func(np.log2, units=_units_1, inplace=True)
+            dx = da.log2(dx)
         else:
-            d.func(np.log, units=_units_1, inplace=True)
-            d /= np.log(base)
+            dx = da.log(dx)
+            dx /= da.log(base)
+
+        d._set_dask(dx, reset_mask_hardness=False)
+
+        d._Units = _units_1  # all logarithm outputs are unitless
 
         return d
 

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -12050,7 +12050,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
         d._set_dask(dx, reset_mask_hardness=False)
 
-        d._Units = _units_1  # all logarithm outputs are unitless
+        d.override_units(_units_1, inplace=True)  # all logarithm outputs are unitless
 
         return d
 

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -11142,6 +11142,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
     @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")
+    @_inplace_enabled(default=False)
     def round(self, decimals=0, inplace=False, i=False):
         """Evenly round elements of the data array to the given number
         of decimals.
@@ -11185,7 +11186,10 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         [-0., -0., -0., -0.,  0.,  0.,  0.,  0.,  0.]
 
         """
-        return self.func(np.round, inplace=inplace, decimals=decimals)
+        d = _inplace_enabled_define_and_cleanup(self)
+        dx = d._get_dask()
+        d._set_dask(da.round(dx, decimals=decimals), reset_mask_hardness=False)
+        return d
 
     def stats(
         self,

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -3397,6 +3397,7 @@ class DataTest(unittest.TestCase):
         d = c.log(base=4)
         self.assertTrue((d.array == b).all())
         self.assertEqual(d.shape, b.shape)
+        self.assertEqual(d.Units, cf.Units("1"))
 
         # Text values outside of the restricted domain for a log
         a = np.array([0, -1, -2])

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -3397,9 +3397,11 @@ class DataTest(unittest.TestCase):
         d = c.log(base=4)
         self.assertTrue((d.array == b).all())
         self.assertEqual(d.shape, b.shape)
+
+        # Check units for general case
         self.assertEqual(d.Units, cf.Units("1"))
 
-        # Text values outside of the restricted domain for a log
+        # Text values outside of the restricted domain for a logarithm
         a = np.array([0, -1, -2])
         b = np.log(a)
         c = cf.Data(a)

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -3391,14 +3391,12 @@ class DataTest(unittest.TestCase):
         self.assertEqual(d.shape, b.shape)
 
         # Test an arbitrary base, using 4 (not a special managed case like 10)
-        # TODODASK: reinstate this assertion once mask property is
-        # daskified.
-        # a = np.array([[4, 16, 4**3.5], [0, 1, 0.25]])
-        # b = np.log(a) / np.log(4)  # the numpy way, using log rules from school
-        # c = cf.Data(a, "s")
-        # d = c.log(base=4)
-        # self.assertTrue((d.array == b).all())
-        # self.assertEqual(d.shape, b.shape)
+        a = np.array([[4, 16, 4 ** 3.5], [0, 1, 0.25]])
+        b = np.log(a) / np.log(4)  # the numpy way, using log rules from school
+        c = cf.Data(a, "s")
+        d = c.log(base=4)
+        self.assertTrue((d.array == b).all())
+        self.assertEqual(d.shape, b.shape)
 
         # Text values outside of the restricted domain for a log
         a = np.array([0, -1, -2])


### PR DESCRIPTION
Partially address #302, to tick all sub-issue boxes except the topmost\* and in doing so close #303, since `Data.log` is now fully migrated (and marked as such) because the `/=` operator it uses with a non-`e`/`10`/`2` based is applied in 'Dask space' rather than `cf` space.

##### Note
\* the topmost item,  '_the eight trigonometric and hyperbolic methods and their inverses which don't have restricted domains_', will be tackled as a separate PR to make it easier for the reviewer to check that the correct eight methods have been converted and in a consistent way, with commenting to explain why the other four such methods have been left as `func` calls. And since the code changes required on all of the methods listed in #302 are largely the same, such that any review feedback can be done as one on them all, and it would be more time-consuming to make seven separate PRs for each, I thought it best to split into just two PRs to cover the Issue (second PR for the trig. methods to follow).

