### PR TITLE
LAMA to Dask: func -> built-in conversion for trig. methods

### DIFF
--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -12025,7 +12025,10 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         if d.Units.equivalent(_units_radians):
             d.Units = _units_radians
 
-        d.func(np.tanh, units=_units_1, inplace=True)
+        dx = d._get_dask()
+        d._set_dask(da.tanh(dx), reset_mask_hardness=False)
+
+        d.override_units(_units_1, inplace=True)
 
         return d
 

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -8585,7 +8585,10 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         if d.Units.equivalent(_units_radians):
             d.Units = _units_radians
 
-        d.func(np.cos, units=_units_1, inplace=True)
+        dx = d._get_dask()
+        d._set_dask(da.cos(dx), reset_mask_hardness=False)
+
+        d.override_units(_units_1, inplace=True)
 
         return d
 

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -6891,7 +6891,10 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         """
         d = _inplace_enabled_define_and_cleanup(self)
 
-        d.func(np.arcsinh, units=_units_radians, inplace=True)
+        dx = d._get_dask()
+        d._set_dask(da.arcsinh(dx), reset_mask_hardness=False)
+
+        d.override_units(_units_radians, inplace=True)
 
         return d
 

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -11963,7 +11963,10 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         if d.Units.equivalent(_units_radians):
             d.Units = _units_radians
 
-        d.func(np.cosh, units=_units_1, inplace=True)
+        dx = d._get_dask()
+        d._set_dask(da.cosh(dx), reset_mask_hardness=False)
+
+        d.override_units(_units_1, inplace=True)
 
         return d
 

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -6696,7 +6696,10 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         """
         d = _inplace_enabled_define_and_cleanup(self)
 
-        d.func(np.arctan, units=_units_radians, inplace=True)
+        dx = d._get_dask()
+        d._set_dask(da.arctan(dx), reset_mask_hardness=False)
+
+        d.override_units(_units_radians, inplace=True)
 
         return d
 

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -6787,7 +6787,9 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         """
         d = _inplace_enabled_define_and_cleanup(self)
 
-        # preserve_invalid necessary because arctanh has a restricted domain
+        # Data.func is used instead of the Dask built-in in this case because
+        # arctanh has a restricted domain therefore it is necessary to use our
+        # custom logic implemented via the `preserve_invalid` keyword to func.
         d.func(
             np.arctanh,
             units=_units_radians,
@@ -6840,7 +6842,9 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         """
         d = _inplace_enabled_define_and_cleanup(self)
 
-        # preserve_invalid necessary because arcsin has a restricted domain
+        # Data.func is used instead of the Dask built-in in this case because
+        # arcsin has a restricted domain therefore it is necessary to use our
+        # custom logic implemented via the `preserve_invalid` keyword to func.
         d.func(
             np.arcsin,
             units=_units_radians,
@@ -6942,7 +6946,9 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         """
         d = _inplace_enabled_define_and_cleanup(self)
 
-        # preserve_invalid necessary because arccos has a restricted domain
+        # Data.func is used instead of the Dask built-in in this case because
+        # arccos has a restricted domain therefore it is necessary to use our
+        # custom logic implemented via the `preserve_invalid` keyword to func.
         d.func(
             np.arccos,
             units=_units_radians,
@@ -6995,7 +7001,9 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         """
         d = _inplace_enabled_define_and_cleanup(self)
 
-        # preserve_invalid necessary because arccosh has a restricted domain
+        # Data.func is used instead of the Dask built-in in this case because
+        # arccosh has a restricted domain therefore it is necessary to use our
+        # custom logic implemented via the `preserve_invalid` keyword to func.
         d.func(
             np.arccosh,
             units=_units_radians,

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -11904,7 +11904,11 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         if d.Units.equivalent(_units_radians):
             d.Units = _units_radians
 
-        d.func(np.sinh, units=_units_1, inplace=True)
+        dx = d._get_dask()
+        d._set_dask(da.sinh(dx), reset_mask_hardness=False)
+
+        d.override_units(_units_1, inplace=True)
+
         return d
 
     @daskified(_DASKIFIED_VERBOSE)

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -12229,7 +12229,10 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         if d.Units.equivalent(_units_radians):
             d.Units = _units_radians
 
-        d.func(np.tan, units=_units_1, inplace=True)
+        dx = d._get_dask()
+        d._set_dask(da.tan(dx), reset_mask_hardness=False)
+
+        d.override_units(_units_1, inplace=True)
 
         return d
 

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -11840,7 +11840,10 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         if d.Units.equivalent(_units_radians):
             d.Units = _units_radians
 
-        d.func(np.sin, units=_units_1, inplace=True)
+        dx = d._get_dask()
+        d._set_dask(da.sin(dx), reset_mask_hardness=False)
+
+        d.override_units(_units_1, inplace=True)
 
         return d
 


### PR DESCRIPTION
Close #302 by addressing the final item, namely to convert 'the eight trigonometric and hyperbolic methods and their inverses which don't have restricted domains' and also, for completeness, adding comments to the other four such methods to indicate why they haven't been converted in this way.