### PR TITLE
CI: drop Python 3.7 & add 3.10 for `lama-to-dask` workflow

### DIFF
--- a/.github/workflows/dask-migration-testing.yml
+++ b/.github/workflows/dask-migration-testing.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         # Skip older ubuntu-16.04 & macos-10.15 to save usage resource
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.9, 3.10]
+        python-version: [3.8, 3.9, "3.10"]
 
     # Run on new and old(er) versions of the distros we support (Linux, Mac OS)
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/dask-migration-testing.yml
+++ b/.github/workflows/dask-migration-testing.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         # Skip older ubuntu-16.04 & macos-10.15 to save usage resource
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9]
 
     # Run on new and old(er) versions of the distros we support (Linux, Mac OS)
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/dask-migration-testing.yml
+++ b/.github/workflows/dask-migration-testing.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         # Skip older ubuntu-16.04 & macos-10.15 to save usage resource
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
 
     # Run on new and old(er) versions of the distros we support (Linux, Mac OS)
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
For context, see https://github.com/NCAS-CMS/cf-python/pull/313#issuecomment-1033476035 and related comments in that thread. Also adding Python 3.10 whilst I am amending the workflow matrix, as that is now available and it is a good idea to start testing with it.

Trivial change but opening as a PR instead of committing directly to the branch in order to check the remaining jobs pass. (`lama` was changed to Llama somehow when writing the commit message here and it can stay for amusement value / because I can't be bothered to rebase to re-word).