### PR TITLE
Manage warnings in `test_Data`

### DIFF
--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -85,56 +85,6 @@ class DataTest(unittest.TestCase):
     ones = ones
 
     test_only = []
-    #    test_only = ['NOTHING!!!!!']
-    # test_only = [
-    #    "test_Data___setitem__",
-    # ]
-    #        'test_Data_trigonometric_hyperbolic'
-    #        'test_Data_AUXILIARY_MASK',
-    #        'test_Data_datum',
-    #        'test_Data_ERROR',
-    #        'test_Data_array',
-    #        'test_Data_varray',
-    #        'test_Data_stats',
-    #        'test_Data_datetime_array',
-    #        'test_Data_cumsum',
-    #        'test_Data_dumpd_loadd_dumps',
-    #        'test_Data_root_mean_square',
-    #        'test_Data_mean_mean_absolute_value',
-    #        'test_Data_squeeze_insert_dimension',
-    #        'test_Data_months_years',
-    #        'test_Data_binary_mask',
-    #        'test_Data_CachedArray',
-    #        'test_Data_digitize',
-    #        'test_Data_outerproduct',
-    #        'test_Data_flatten',
-    #        'test_Data_transpose',
-    #        'test_Data__collapse_SHAPE',
-    #        'test_Data_range_mid_range',
-    #        'test_Data_median',
-    #        'test_Data_mean_of_upper_decile',
-    #        'test_Data__init__dtype_mask',
-    #    ]
-
-    #    test_only = ['test_Data_mean_mean_absolute_value']
-    #    test_only = ['test_Data_AUXILIARY_MASK']
-    #    test_only = ['test_Data_mean_of_upper_decile']
-    #    test_only = ['test_Data__collapse_SHAPE']
-    #    test_only = ['test_Data__collapse_UNWEIGHTED_MASKED']
-    #    test_only = ['test_Data__collapse_UNWEIGHTED_UNMASKED']
-    #    test_only = ['test_Data__collapse_WEIGHTED_UNMASKED']
-    #    test_only = ['test_Data__collapse_WEIGHTED_MASKED']
-    #    test_only = ['test_Data_ERROR']
-    #    test_only = ['test_Data_diff', 'test_Data_compressed']
-    #    test_only = ['test_Data__init__dtype_mask']
-    #    test_only = ['test_Data_section']
-    #    test_only = ['test_Data_sum_of_weights_sum_of_weights2']
-    #    test_only = ['test_Data_max_min_sum_sum_of_squares']
-    #    test_only = ['test_Data___setitem__']
-    #    test_only = ['test_Data_year_month_day_hour_minute_second']
-    #    test_only = ['test_Data_BINARY_AND_UNARY_OPERATORS']
-    #    test_only = ['test_Data_clip']
-    #    test_only = ['test_Data__init__dtype_mask']
 
     def setUp(self):
         # Suppress the warning output for some specific warnings which are

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -4,6 +4,7 @@ import inspect
 import itertools
 import os
 import unittest
+import warnings
 from functools import reduce
 from operator import mul
 
@@ -134,6 +135,23 @@ class DataTest(unittest.TestCase):
     #    test_only = ['test_Data_BINARY_AND_UNARY_OPERATORS']
     #    test_only = ['test_Data_clip']
     #    test_only = ['test_Data__init__dtype_mask']
+
+    def setUp(self):
+        # Suppress the warning output for some specific warnings which are
+        # expected due to the nature of the tests being performed.
+        expexted_warning_msgs = [
+            "divide by zero encountered in arctanh",
+            "invalid value encountered in arctanh",
+            "divide by zero encountered in log",
+            "invalid value encountered in log",
+            "invalid value encountered in arcsin",
+        ]
+        for expected_warning in expexted_warning_msgs:
+            warnings.filterwarnings(
+                "ignore",
+                category=RuntimeWarning,
+                message=expected_warning,
+            )
 
     def test_Data_equals(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -437,7 +437,9 @@ class DataTest(unittest.TestCase):
                 # that nothing is logged, but need to use workaround to prevent
                 # AssertionError on fact that nothing is logged here. When at
                 # Python =>3.10 this can be replaced by 'assertNoLogs' method.
-                logger.warn("Log warning to prevent test error on empty log.")
+                logger.warning(
+                    "Log warning to prevent test error on empty log."
+                )
 
                 self.assertFalse(d2.equals(d, verbose=verbosity_level))
                 self.assertIs(


### PR DESCRIPTION
Quick PR to suppress some specific expected warning messages which are presently clogging up the `test_Data` output, and address a lone deprecation warning at the same time.

Not strictly a Dask migration PR (just tidying the relevant test), and contains nothing controversial, so no review required.