### PR TITLE
Update deprecated `distutils.version` to `packaging.version`

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -7,6 +7,7 @@ version 3.13.0
   ``um`` keyword has been set, but without the ``'version'`` key
   (https://github.com/NCAS-CMS/cf-python/issues/306)
 * Changed dependency: ``1.9.0.2<=cfdm<1.9.1.0``
+* New dependency: ``packaging>=20.0``
 
 ----
 

--- a/cf/__init__.py
+++ b/cf/__init__.py
@@ -96,13 +96,13 @@ except ImportError as error1:
 
 __cf_version__ = cfdm.core.__cf_version__
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 import importlib.util
 import platform
 
 # Check the version of Python
 _minimum_vn = "3.7.0"
-if LooseVersion(platform.python_version()) < LooseVersion(_minimum_vn):
+if Version(platform.python_version()) < Version(_minimum_vn):
     raise ValueError(
         f"Bad python version: cf requires python version {_minimum_vn} "
         f"or later. Got {platform.python_version()}"
@@ -141,7 +141,7 @@ except ImportError as error1:
 
 # Check the version of psutil
 _minimum_vn = "0.6.0"
-if LooseVersion(psutil.__version__) < LooseVersion(_minimum_vn):
+if Version(psutil.__version__) < Version(_minimum_vn):
     raise RuntimeError(
         f"Bad psutil version: cf requires psutil>={_minimum_vn}. "
         f"Got {psutil.__version__} at {psutil.__file__}"
@@ -149,7 +149,7 @@ if LooseVersion(psutil.__version__) < LooseVersion(_minimum_vn):
 
 # Check the version of netCDF4
 _minimum_vn = "1.5.4"
-if LooseVersion(netCDF4.__version__) < LooseVersion(_minimum_vn):
+if Version(netCDF4.__version__) < Version(_minimum_vn):
     raise RuntimeError(
         f"Bad netCDF4 version: cf requires netCDF4>={_minimum_vn}. "
         f"Got {netCDF4.__version__} at {netCDF4.__file__}"
@@ -157,7 +157,7 @@ if LooseVersion(netCDF4.__version__) < LooseVersion(_minimum_vn):
 
 # Check the version of cftime
 _minimum_vn = "1.5.0"
-if LooseVersion(cftime.__version__) < LooseVersion(_minimum_vn):
+if Version(cftime.__version__) < Version(_minimum_vn):
     raise RuntimeError(
         f"Bad cftime version: cf requires cftime>={_minimum_vn}. "
         f"Got {cftime.__version__} at {cftime.__file__}"
@@ -165,7 +165,7 @@ if LooseVersion(cftime.__version__) < LooseVersion(_minimum_vn):
 
 # Check the version of numpy
 _minimum_vn = "1.15"
-if LooseVersion(numpy.__version__) < LooseVersion(_minimum_vn):
+if Version(numpy.__version__) < Version(_minimum_vn):
     raise RuntimeError(
         f"Bad numpy version: cf requires numpy>={_minimum_vn}. "
         f"Got {numpy.__version__} at {numpy.__file__}"
@@ -173,7 +173,7 @@ if LooseVersion(numpy.__version__) < LooseVersion(_minimum_vn):
 
 # Check the version of cfunits
 _minimum_vn = "3.3.4"
-if LooseVersion(cfunits.__version__) < LooseVersion(_minimum_vn):
+if Version(cfunits.__version__) < Version(_minimum_vn):
     raise RuntimeError(
         f"Bad cfunits version: cf requires cfunits>={_minimum_vn}. "
         f"Got {cfunits.__version__} at {cfunits.__file__}"
@@ -182,8 +182,8 @@ if LooseVersion(cfunits.__version__) < LooseVersion(_minimum_vn):
 # Check the version of cfdm
 _minimum_vn = "1.9.0.2"
 _maximum_vn = "1.9.1.0"
-_cfdm_version = LooseVersion(cfdm.__version__)
-if not LooseVersion(_minimum_vn) <= _cfdm_version < LooseVersion(_maximum_vn):
+_cfdm_version = Version(cfdm.__version__)
+if not Version(_minimum_vn) <= _cfdm_version < Version(_maximum_vn):
     raise RuntimeError(
         f"Bad cfdm version: cf requires {_minimum_vn}<=cfdm<{_maximum_vn}. "
         f"Got {_cfdm_version} at {cfdm.__file__}"

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -197,6 +197,8 @@ Required
 
 * `psutil <https://pypi.org/project/psutil/>`_, version 0.6.0 or newer.
 
+* `packaging <https://pypi.org/project/packaging/>`_, version 20.0 or newer.
+
 .. _UNIDATA-UDUNITS-2-library:
 
 * `UNIDATA UDUNITS-2 library

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ numpy>=1.15
 cfdm>=1.9.0.2, <1.9.1.0
 psutil>=0.6.0
 cfunits>=3.3.4
+packaging>=20.0


### PR DESCRIPTION
When running test modules e.g. `test_Data` under `pytest` (as can be done via `$ pytest <test module>` even though we don't strictly use `pytest` but `unittest`), I get multiple deprecation warnings on several uses of `distutils.version.LooseVersion`, all in `cf/__init__.py`:

```console
DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    g["version"][version] = LooseVersion(version)
```

I have updated these here to `packaging.version.Version`; it actually wasn't at all clear in any of the relevant documentation as to which class from that module would be the appropriate replacement, but from doing a full-GitHub search on relevant keywords I found the following comments ([this](https://github.com/pydata/xarray/pull/6096#issue-1086346755) and [this](https://github.com/pydata/xarray/pull/6096#issuecomment-1000339097)) and corresponding PR to xarray, along with a few other similar PRs on major libraries, to confirm that `Version` is the best one to go with.

Unfortunately `packaging` isn't a built-in, so this change prompted by the deprecation warning does necessitate another dependency, which I have added to the requirements list and documentation of those.

@davidhassell can I check with you that it is OK to add this new dependency? (I am not too pleased that an entire new dependency is required to upgrade deprecated API usage, but this is what the warning prompts us to use. If you can think of an alternative approach, do let me know...)
