### PR TITLE
Fix bug in previously-daskified `Data.flip`

### DIFF
--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -10957,7 +10957,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
             return d
 
         index = [
-            slice(None, None, -1) if i in axes else slice(None) for i in iaxes
+            slice(None, None, -1) if i in iaxes else slice(None) for i in iaxes
         ]
 
         dx = d._get_dask()

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -10945,7 +10945,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         """
         d = _inplace_enabled_define_and_cleanup(self)
 
-        if axes is not None and not axes and axes != 0:
+        if axes is not None and not axes and axes != 0:  # i.e. empty sequence
             return d
 
         if axes is None:
@@ -10957,7 +10957,8 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
             return d
 
         index = [
-            slice(None, None, -1) if i in iaxes else slice(None) for i in iaxes
+            slice(None, None, -1) if i in iaxes else slice(None)
+            for i in range(len(d._axes))
         ]
 
         dx = d._get_dask()

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -10958,7 +10958,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
         index = [
             slice(None, None, -1) if i in iaxes else slice(None)
-            for i in range(len(d._axes))
+            for i in range(d.ndim)
         ]
 
         dx = d._get_dask()

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -1794,7 +1794,6 @@ class DataTest(unittest.TestCase):
         self.assertIs(d.datum([0, -1]), cf.masked)
         self.assertIs(d.datum(-1, -1), cf.masked)
 
-    @unittest.skipIf(TEST_DASKIFIED_ONLY, "TypeError: 'int' is not iterable")
     def test_Data_flip(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return
@@ -1816,10 +1815,8 @@ class DataTest(unittest.TestCase):
         self.assertTrue((d.array == array).all())
 
         array = np.arange(3 * 4 * 5).reshape(3, 4, 5) + 1
-        d = cf.Data(array.copy(), "metre", chunk=False)
-        d.chunk(total=[0], omit_axes=[1, 2])
+        d = cf.Data(array.copy(), "metre", chunks=-1)
 
-        self.assertEqual(d._pmshape, (3,))
         self.assertEqual(d[0].shape, (1, 4, 5))
         self.assertEqual(d[-1].shape, (1, 4, 5))
         self.assertEqual(d[0].maximum(), 4 * 5)
@@ -1827,7 +1824,6 @@ class DataTest(unittest.TestCase):
 
         for i in (2, 1):
             e = d.flip(i)
-            self.assertEqual(e._pmshape, (3,))
             self.assertEqual(e[0].shape, (1, 4, 5))
             self.assertEqual(e[-1].shape, (1, 4, 5))
             self.assertEqual(e[0].maximum(), 4 * 5)
@@ -1835,7 +1831,6 @@ class DataTest(unittest.TestCase):
 
         i = 0
         e = d.flip(i)
-        self.assertEqual(e._pmshape, (3,))
         self.assertEqual(e[0].shape, (1, 4, 5))
         self.assertEqual(e[-1].shape, (1, 4, 5))
         self.assertEqual(e[0].maximum(), 3 * 4 * 5)


### PR DESCRIPTION
Fix a bug in `Data.flip`, exposed with the following example, which was lifted from the start of the `test_Data_BINARY_AND_UNARY_OPERATORS` test, which is where the bug was noticed:

```py
a = np.arange(3 * 4 * 5).reshape(3, 4, 5) + 1.0
a0 = a[(slice(None, None, -1),) * a.ndim]
d = cf.Data(a0)

d.flip()
```

which, on the present `lama-to-dask` branch, runs into:

```pycon
~/cf-python/cf/data/data.py in <listcomp>(.0)
  10958 
  10959         index = [
> 10960             slice(None, None, -1) if i in axes else slice(None) for i in iaxes
  10961         ]
  10962 

TypeError: argument of type 'NoneType' is not iterable
```

though it is not just a case of converting the `axes` into a sequence if an integer value was provided (both are permitted as values for that keyword), since there is a further issue in the logic for the creation of the indices list `index` by that list comprehension that is, for example, revealed in the failing unit test once it has been unskipped (and with some old syntax converted so it runs to pass/fail rather than error) since that test method appears to have been missed to be reinstate despite `flip` being marked as migrated for #182.


#### Suggested solution context

With a simple adjustment to ensure `axes` is a sequence, namely using:

```python
        if isinstance(axes, int):
            axes = [axes,]
        index = [
            slice(None, None, -1) if i in axes else slice(None)
            for i in iaxes
        ]
```

the indices were (as far as the initial unit test failure):

```
test_Data_flip (__main__.DataTest) ...
RESULTING INDEX IS [slice(None, None, -1)] IAXES (0,) AXES [0]
RESULTING INDEX IS [slice(None, None, -1)] IAXES (1,) AXES [1]
RESULTING INDEX IS [slice(None, None, -1), slice(None, None, -1)] IAXES (0, 1) AXES [0, 1]
FAIL
```

which don't look appropriate, where the printed variables result from the following print calls:

```diff
diff --git a/cf/data/data.py b/cf/data/data.py
index 5cc6368de..b58b1a550 100644
--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -10964,11 +10964,12 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
+        print("RESULTING INDEX IS", index, "IAXES", iaxes, "AXES", axes)
         dx = d._get_dask()
         dx = dx[tuple(index)]
         d._set_dask(dx, reset_mask_hardness=False)
```

With the change to the list comprehension suggested in this PR, arrived at by taking [a look at the current/LAMA code defining `Data.flip` `master`](https://github.com/NCAS-CMS/cf-python/blob/9c037bb54a4db14a9392a8030098ae597811253b/cf/data/data.py#L12688-L12709), the unit test passes and a resulting print-out of the `index` variable with the `axes` used in each test case, as above, is instead something which looks right, namely:

```
test_Data_flip (__main__.DataTest) ...
RESULTING INDEX IS [slice(None, None, -1), slice(None, None, None)] IAXES (0,) AXES 0
RESULTING INDEX IS [slice(None, None, None), slice(None, None, -1)] IAXES (1,) AXES 1
RESULTING INDEX IS [slice(None, None, -1), slice(None, None, -1)] IAXES (0, 1) AXES [0, 1]
RESULTING INDEX IS [slice(None, None, None), slice(None, None, None), slice(None, None, -1)] IAXES (2,) AXES 2
RESULTING INDEX IS [slice(None, None, None), slice(None, None, -1), slice(None, None, None)] IAXES (1,) AXES 1
RESULTING INDEX IS [slice(None, None, -1), slice(None, None, None), slice(None, None, None)] IAXES (0,) AXES 0``
```