### PR TITLE
`data` batch docstring re-formatting: 'Examples:' -> 'Examples'

### DIFF
--- a/cf/data/abstract/compressedsubarray.py
+++ b/cf/data/abstract/compressedsubarray.py
@@ -78,7 +78,7 @@ class CompressedSubarray(abc.ABC):
         """The file on disk which contains the compressed array, or
         `None` of the array is in memory.
 
-        **Examples:**
+        **Examples**
 
          >>> self.file
          '/home/foo/bar.nc'
@@ -96,7 +96,7 @@ class CompressedSubarray(abc.ABC):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> f.close()
 
@@ -127,7 +127,7 @@ class CompressedSubarray(abc.ABC):
         """True if and only if the compressed array is on disk as
         opposed to in memory.
 
-        **Examples:**
+        **Examples**
 
         >>> a.on_disk()
         True

--- a/cf/data/abstract/filearray.py
+++ b/cf/data/abstract/filearray.py
@@ -36,7 +36,7 @@ class FileArray(Array):
     def dtype(self):
         """Data-type of the data elements.
 
-        **Examples:**
+        **Examples**
 
         >>> a.dtype
         dtype('float64')
@@ -50,7 +50,7 @@ class FileArray(Array):
     def ndim(self):
         """Number of array dimensions.
 
-        **Examples:**
+        **Examples**
 
         >>> a.shape
         (73, 96)
@@ -80,7 +80,7 @@ class FileArray(Array):
     def shape(self):
         """Tuple of array dimension sizes.
 
-        **Examples:**
+        **Examples**
 
         >>> a.shape
         (73, 96)
@@ -110,7 +110,7 @@ class FileArray(Array):
     def size(self):
         """Number of elements in the array.
 
-        **Examples:**
+        **Examples**
 
         >>> a.shape
         (73, 96)
@@ -140,7 +140,7 @@ class FileArray(Array):
     def filename(self):
         """The name of the file containing the array.
 
-        **Examples:**
+        **Examples**
 
         >>> a.filename()
         'file.nc'
@@ -157,7 +157,7 @@ class FileArray(Array):
             `numpy.ndarray`
                 An independent numpy array of the data.
 
-        **Examples:**
+        **Examples**
 
         >>> n = numpy.asanyarray(a)
         >>> isinstance(n, numpy.ndarray)
@@ -181,7 +181,7 @@ class FileArray(Array):
     def get_filename(self):
         """Return the name of the file containing the array.
 
-        **Examples:**
+        **Examples**
 
         >>> a.get_filename()
         'file.nc'

--- a/cf/data/cachedarray.py
+++ b/cf/data/cachedarray.py
@@ -29,7 +29,7 @@ class CachedArray(abstract.FileArray):
             array: numpy array
                 The array to be stored on disk in a temporary file.
 
-        **Examples:**
+        **Examples**
 
         >>> f = CachedArray(numpy.array([1, 2, 3, 4, 5]))
         >>> f = CachedArray(numpy.ma.array([1, 2, 3, 4, 5]))

--- a/cf/data/collapse_functions.py
+++ b/cf/data/collapse_functions.py
@@ -68,7 +68,7 @@ def psum(x, y):
 
         `numpy.ndarray`
 
-    **Examples:**
+    **Examples**
 
     >>> c = psum(a, b)
 

--- a/cf/data/creation.py
+++ b/cf/data/creation.py
@@ -48,7 +48,7 @@ def convert_to_builtin_type(x):
 
             TODO
 
-    **Examples:**
+    **Examples**
 
     >>> type(_convert_to_netCDF_datatype(numpy.bool_(True)))
     bool
@@ -407,7 +407,7 @@ def generate_axis_identifiers(n):
         `list`
             The new axis idenfifiers.
 
-    **Examples:**
+    **Examples**
 
     >>> generate_axis_identifiers(0)
     []

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -455,7 +455,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
             chunk: deprecated at version TODODASK
                 Use the *chunks* parameter instead.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data(5)
         >>> d = cf.Data([1,2,3], units='K')
@@ -834,7 +834,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
             `int`
                 The hash value.
 
-        **Examples:**
+        **Examples**
 
         >>> print(d.array)
         [[0 1 2 3]]
@@ -1045,7 +1045,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
             `Data`
                 The subspace of the data.
 
-        **Examples:**
+        **Examples**
 
         >>> import numpy
         >>> d = Data(numpy.arange(100, 190).reshape(1, 10, 9))
@@ -1239,7 +1239,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
         .. seealso:: `__getitem__`, `cf.masked`, `hardmask`, `where`
 
-        **Examples:**
+        **Examples**
 
         """
         indices, roll = parse_indices(
@@ -1523,7 +1523,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
             `dask.array.Array`
                 The removed dask array.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([1, 2, 3])
         >>> dx = d._del_dask()
@@ -1582,7 +1582,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
             `dask.array.Array`
                 The updated dask array.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([1, 2, 3])
         >>> dx = d._map_blocks(lambda x: x / 2)
@@ -2489,7 +2489,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
             `dict`
                 The serialization.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([[1, 2, 3]], 'm')
         >>> d.dumpd()
@@ -2672,7 +2672,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> d = Data([[1, 2, 3]], 'm')
         >>> e = Data([6, 7, 8, 9], 's')
@@ -2964,7 +2964,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
                 The ceiling of the data. If the operation was in-place
                 then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([-1.9, -1.5, -1.1, -1, 0, 1, 1.1, 1.5 , 1.9])
         >>> print(d.array)
@@ -3531,7 +3531,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `Data` or `None`, `Data` or `None`, `Units`
 
-        **Examples:**
+        **Examples**
 
         >>> d._combined_units(e, '__sub__')
         >>> d._combined_units(e, '__imul__')
@@ -3927,7 +3927,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
                 A new data object, or if the operation was in place, the
                 same data object.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([0, 1, 2, 3])
         >>> e = cf.Data([1, 1, 3, 4])
@@ -4323,7 +4323,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
             `Data`
                 The concatenated data.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([[1, 2], [3, 4]], 'km')
         >>> e = cf.Data([[5.0, 6.0]], 'metre')
@@ -4633,7 +4633,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
             `Data`
                 A new Data array.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([[1, 2, -3, -4, -5]])
 
@@ -5449,7 +5449,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `list`
 
-        **Examples:**
+        **Examples**
 
         """
 
@@ -5692,7 +5692,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `numpy array or `None`
 
-        **Examples:**
+        **Examples**
 
         """
         array_shape = array.shape
@@ -5990,7 +5990,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
         .. seealso `override_units`, `override_calendar`
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([1, 2, 3], units='m')
         >>> d.Units
@@ -6049,7 +6049,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
     def data(self):
         """The data as an object identity.
 
-        **Examples:**
+        **Examples**
 
         >>> d.data is d
         True
@@ -6062,7 +6062,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
     def dtype(self):
         """The `numpy` data-type of the data.
 
-        **Examples:**
+        **Examples**
 
         TODODASK
         >>> d = cf.Data([0.5, 1.5, 2.5])
@@ -6114,7 +6114,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         Deleting this attribute is equivalent to setting it to None, so
         this attribute is guaranteed to always exist.
 
-        **Examples:**
+        **Examples**
 
         >>> d.fill_value = 9999.0
         >>> d.fill_value
@@ -6157,7 +6157,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         .. seealso:: `harden_mask`, `soften_mask`, `where`,
                      `__setitem__`
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([1, 2, 3])
         >>> d.hardmask
@@ -6194,7 +6194,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
         `is_masked` causes all delayed operations to be executed.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([[1, 2, 3], [4, 5, 6]])
         >>> print(d.is_masked)
@@ -6229,7 +6229,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
     def isscalar(self):
         """True if the data array is a 0-d scalar array.
 
-        **Examples:**
+        **Examples**
 
         >>> d.ndim
         0
@@ -6256,7 +6256,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         If the number of bytes is unknown then it is calculated
         immediately by executing all delayed operations.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([[1, 1.5, 2]])
         >>> d.dtype
@@ -6286,7 +6286,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
     def ndim(self):
         """Number of dimensions in the data array.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([[1, 2, 3], [4, 5, 6]])
         >>> d.ndim
@@ -6322,7 +6322,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         If the shape of the data is unknown then it is calculated
         immediately by executing all delayed operations.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([[1, 2, 3], [4, 5, 6]])
         >>> d.shape
@@ -6358,7 +6358,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         If the size of the data is unknown then it is calculated
         immediately by executing all delayed operations.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([[1, 2, 3], [4, 5, 6]])
         >>> d.size
@@ -6533,7 +6533,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `Data`
 
-        **Examples:**
+        **Examples**
 
         >>> d.shape
         (12, 73, 96)
@@ -6590,7 +6590,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
                 The behaviour prior to the change, or the current
                 behaviour if no new value was specified.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([0., 1])
         >>> e = cf.Data([1., 2])
@@ -6700,7 +6700,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
                 The behaviour prior to the change, or the current
                 behaviour if no new values are specified.
 
-        **Examples:**
+        **Examples**
 
         Set treatment for all types of floating-point errors to
         ``'raise'`` and then reset to the previous behaviours:
@@ -6821,7 +6821,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `Data` or `None`
 
-        **Examples:**
+        **Examples**
 
         >>> print(d.array)
         [[0.5 0.7]
@@ -6886,7 +6886,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
     #
     #        `Data`
     #
-    #    **Examples:**
+    #    **Examples**
     #
     #        '''
     #        return cls(numpy_arctan2(y, x), units=_units_radians)
@@ -6910,7 +6910,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `Data` or `None`
 
-        **Examples:**
+        **Examples**
 
         >>> print(d.array)
         [[0.5 0.7]
@@ -6965,7 +6965,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `Data` or `None`
 
-        **Examples:**
+        **Examples**
 
         >>> print(d.array)
         [[0.5 0.7]
@@ -7020,7 +7020,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `Data` or `None`
 
-        **Examples:**
+        **Examples**
 
         >>> print(d.array)
         [[0.5 0.7]
@@ -7069,7 +7069,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `Data` or `None`
 
-        **Examples:**
+        **Examples**
 
         >>> print(d.array)
         [[0.5 0.7]
@@ -7124,7 +7124,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `Data` or `None`
 
-        **Examples:**
+        **Examples**
 
         >>> print(d.array)
         [[0.5 0.7]
@@ -7173,7 +7173,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
             `bool`
                 Whether or not all data array elements evaluate to True.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([[1, 3, 2]])
         >>> print(d.array)
@@ -7239,7 +7239,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `bool`
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([1000, 2500], 'metre')
         >>> e = cf.Data([1, 2.5], 'km')
@@ -7273,7 +7273,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
         .. seealso:: `all`, `allclose`, `isclose`
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([[0, 0, 0]])
         >>> d.any()
@@ -7385,7 +7385,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
                 The data with masked values. If the operation was in-place
                 then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> import numpy
         >>> d = Data(numpy.arange(12).reshape(3, 4), 'm')
@@ -7561,7 +7561,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
             `Data`
                 The resulting reconstructed Data object.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data(numpy.arange(120).reshape(2, 3, 4, 5))
         >>> x = d.section([1, 3])
@@ -7755,7 +7755,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
                 The calendar.
 
-        **Examples:**
+        **Examples**
 
         >>> d.set_calendar('julian')
         >>> d.get_calendar
@@ -7859,7 +7859,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
             `Data` or `None`
                 The collapsed array.
 
-        **Examples:**
+        **Examples**
 
         """
         # TODODASK: Placeholder for the real thing, that takes into
@@ -7903,7 +7903,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
                 The collapsed data, or `None` if the operation was
                 in-place.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([[-1, 2, 3], [9, -8, -12]], 'm')
         >>> d.maximum_absolute_value()
@@ -7958,7 +7958,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
         .. seealso:: `maximum`, `mean`, `mid_range`, `sum`, `sd`, `var`
 
-        **Examples:**
+        **Examples**
 
         """
         return self._collapse(
@@ -8001,7 +8001,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
                 The collapsed data, or `None` if the operation was
                 in-place.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([[-1, 2, 3], [9, -8, -12]], 'm')
         >>> d.minimum_absolute_value()
@@ -8094,7 +8094,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         .. seealso:: `maximum`, `minimum`, `mid_range`, `range`, `sum`, `sd`,
                      `var`
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([[1, 2, 4], [1, 4, 9]], 'm')
         >>> print(d.array)
@@ -8235,7 +8235,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
                 The collapsed data, or `None` if the operation was
                 in-place.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([[-1, 2, 3], [9, -8, -12]], 'm')
         >>> d.mean_absolute_value()
@@ -8324,7 +8324,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         .. seealso:: `maximum`, `minimum`, `mid_range`, `range`, `sum`, `sd`,
                      `var`
 
-        **Examples:**
+        **Examples**
 
         """
         if weights is None:
@@ -8403,7 +8403,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
             `Data`
                 The binary mask.
 
-        **Examples:**
+        **Examples**
 
         >>> print(d.mask.array)
         [[ True False  True False]]
@@ -8477,7 +8477,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
                 `None` is returned.
 
 
-        **Examples:**
+        **Examples**
 
         >>> g = f.clip(-90, 90)
         >>> g = f.clip(-90, 90, 'degrees_north')
@@ -8581,7 +8581,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> d.close()
 
@@ -8709,7 +8709,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `Data` or `None`
 
-        **Examples:**
+        **Examples**
 
         >>> d.Units
         <Units: degrees_east>
@@ -8753,7 +8753,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             ``int``
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data(numpy.arange(24).reshape(3, 4))
         >>> print(d.array)
@@ -9091,7 +9091,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
                 The uncompressed data, or `None` of the operation was
                 in-place.
 
-        **Examples:**
+        **Examples**
 
         >>> d.get_compression_type()
         'ragged contiguous'
@@ -9124,7 +9124,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         Returns a new object with the sorted unique elements in a one
         dimensional array.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([[4, 2, 1], [1, 2, 3]], 'metre')
         >>> d.unique()
@@ -9291,7 +9291,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
             `bool`
                 Whether or not the two instances are equal.
 
-        **Examples:**
+        **Examples**
 
         >>> d.equals(d)
         True
@@ -9392,7 +9392,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `Data` or `None`
 
-        **Examples:**
+        **Examples**
 
         """
         d = _inplace_enabled_define_and_cleanup(self)
@@ -9434,7 +9434,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `Data` or `None`
 
-        **Examples:**
+        **Examples**
 
         """
         d = _inplace_enabled_define_and_cleanup(self)
@@ -9475,7 +9475,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
                 The file names in normalized, absolute form. If the data
                 is are memory then an empty `set` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> f = cf.read('../file[123]')[0]
         >>> f.get_filenames()
@@ -9618,7 +9618,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
                 The expanded data, or `None` if the operation was
                 in-place.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data(numpy.arange(12).reshape(3, 4), 'm')
         >>> d[-1, -1] = cf.masked
@@ -9847,7 +9847,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
         .. seealso:: `hardmask`, `soften_mask`
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([1, 2, 3], hardmask=False)
         >>> d.hardmask
@@ -9942,7 +9942,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
         .. seealso:: `hardmask`, `harden_mask`
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([1, 2, 3])
         >>> d.hardmask
@@ -9984,7 +9984,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
             `Data` or `None`
                 The filled data, or `None` if the operation was in-place.
 
-        **Examples:**
+        **Examples**
 
         >>> d = {{package}}.Data([[1, 2, 3]])
         >>> print(d.filled().array)
@@ -10038,7 +10038,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
                 The first element of the data
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([[1, 2], [3, 4]])
         >>> d.first_element()
@@ -10079,7 +10079,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
                 The second element of the data
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([[1, 2], [3, 4]])
         >>> d.second_element()
@@ -10120,7 +10120,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
                 The last element of the data
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([[1, 2], [3, 4]])
         >>> d.last_element()
@@ -10153,7 +10153,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
             generator
                 An iterator over elements of the data array.
 
-        **Examples:**
+        **Examples**
 
         >>> print(d.array)
         [[1 -- 3]]
@@ -10338,7 +10338,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `Data` or `None`
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([-1.9, -1.5, -1.1, -1, 0, 1, 1.1, 1.5 , 1.9])
         >>> print(d.array)
@@ -10377,7 +10377,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `Data` or `None`
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([1, 2, 3], 'metre')
         >>> o = d.outerproduct([4, 5, 6, 7])
@@ -10516,7 +10516,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `Data` or `None`
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data(1012.0, 'hPa')
         >>> d.override_units('km')
@@ -10560,7 +10560,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `Data` or `None`
 
-        **Examples:**
+        **Examples**
 
         """
         d = _inplace_enabled_define_and_cleanup(self)
@@ -10578,7 +10578,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> d.to_disk()
 
@@ -10614,7 +10614,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> d.to_memory()
         >>> d.to_memory(regardless=True)
@@ -10648,7 +10648,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
         :Returns:
 
-        **Examples:**
+        **Examples**
 
         >>> d.in_memory
 
@@ -10719,7 +10719,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
                 A copy of the specified element of the array as a suitable
                 Python scalar.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data(2)
         >>> d.datum()
@@ -10836,7 +10836,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `Data` or `None`
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([0., 1])
         >>> e = cf.Data([1., 2])
@@ -11005,7 +11005,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
             `Data`
                 The new data array having all elements masked.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data.masked_all((96, 73))
 
@@ -11052,7 +11052,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
             `Data` or `None`
                 The collapsed array.
 
-        **Examples:**
+        **Examples**
 
         """
         return self._collapse(
@@ -11090,7 +11090,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `Data` or `None`
 
-        **Examples:**
+        **Examples**
 
         >>> d.flip()
         >>> d.flip(1)
@@ -11244,7 +11244,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
              `bool`
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([1000, 2500], 'metre')
         >>> e = cf.Data([1, 2.5], 'km')
@@ -11313,7 +11313,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
                 The rounded data. If the operation was in-place then
                 `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([-1.9, -1.5, -1.1, -1, 0, 1, 1.1, 1.5 , 1.9])
         >>> print(d.array)
@@ -11391,7 +11391,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         .. seealso:: `maximum`, `minimum`, `mid_range`, `range`, `sum`, `sd`,
                      `var`
 
-        **Examples:**
+        **Examples**
 
         """
         return self._collapse(
@@ -11439,7 +11439,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `Data` or `None`
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([-1.81, -1.41, -1.01, -0.91, 0.09, 1.09, 1.19, 1.59, 1.99])
         >>> print(d.array)
@@ -11570,7 +11570,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
             `dict`
                 The statistics.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([[0, 1, 2], [3, -99, 5]], mask=[[0, 0, 0], [0, 1, 0]])
         >>> print(d.array)
@@ -11684,7 +11684,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
             `Data` or `None`
                 The data with swapped axis positions.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([[[1, 2, 3], [4, 5, 6]]])
         >>> d
@@ -11735,7 +11735,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `bool`
 
-        **Examples:**
+        **Examples**
 
         >>> print(d.fits_in_memory(8))
         False
@@ -11760,7 +11760,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `bool`
 
-        **Examples:**
+        **Examples**
 
         >>> print(d.fits_one_chunk_in_memory(8))
         False
@@ -12074,7 +12074,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `Data` or `None`
 
-        **Examples:**
+        **Examples**
 
         >>> d.Units
         <Units: degrees_north>
@@ -12135,7 +12135,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `Data` or `None`
 
-        **Examples:**
+        **Examples**
 
         >>> d.Units
         <Units: degrees_north>
@@ -12194,7 +12194,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `Data` or `None`
 
-        **Examples:**
+        **Examples**
 
         >>> d.Units
         <Units: degrees_north>
@@ -12256,7 +12256,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `Data` or `None`
 
-        **Examples:**
+        **Examples**
 
         >>> d.Units
         <Units: degrees_north>
@@ -12363,7 +12363,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
             `Data` or `None`
                 The squeezed data array.
 
-        **Examples:**
+        **Examples**
 
         >>> v.shape
         (1,)
@@ -12463,7 +12463,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `Data` or `None`
 
-        **Examples:**
+        **Examples**
 
         >>> d.Units
         <Units: degrees_north>
@@ -12509,7 +12509,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
             `list`
                 The possibly nested list of array elements.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([1, 2])
         >>> d.tolist()
@@ -12551,7 +12551,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `Data` or `None`
 
-        **Examples:**
+        **Examples**
 
         >>> d.shape
         (19, 73, 96)
@@ -12617,7 +12617,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `Data` or `None`
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([-1.9, -1.5, -1.1, -1, 0, 1, 1.1, 1.5 , 1.9])
         >>> print(d.array)
@@ -12899,7 +12899,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `Data` or `None`
 
-        **Examples:**
+        **Examples**
 
         >>> d.Units
         <Units: radians>
@@ -12990,7 +12990,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
             `Data` or `None`
                 The collapsed array.
 
-        **Examples:**
+        **Examples**
 
         """
         return self._collapse(
@@ -13090,7 +13090,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
             `Data` or `None`
                 The collapsed array.
 
-        **Examples:**
+        **Examples**
 
         """
         return self._collapse(
@@ -13136,7 +13136,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
                 The collapsed data, or `None` if the operation was
                 in-place.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([[-1, 2, 3], [9, -8, -12]], 'm')
         >>> d.sum_of_squares()
@@ -13195,7 +13195,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
             `Data` or `None`
                 The collapsed array.
 
-        **Examples:**
+        **Examples**
 
         """
         if weights is None:
@@ -13258,7 +13258,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
             `Data` or `None`
                 The collapsed array.
 
-        **Examples:**
+        **Examples**
 
         """
         if weights is None:
@@ -13422,7 +13422,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             `Data` or `None`
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([1, 1, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4])
         >>> e = cf.Data([1, 2, 3, 4])
@@ -13490,7 +13490,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
             `Data` or `None`
                 The collapsed array.
 
-        **Examples:**
+        **Examples**
 
         """
         units = self.Units
@@ -13557,7 +13557,7 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
                 The dictionary of m dimensional sections of the Data
                 object.
 
-        **Examples:**
+        **Examples**
 
         Section a Data object into 2D slices:
 
@@ -13680,7 +13680,7 @@ def _size_of_index(index, size=None):
         `int`
             The length of the sequence resulting from applying the index.
 
-    **Examples:**
+    **Examples**
 
     >>> _size_of_index(slice(None, None, -2), 10)
     5
@@ -13719,7 +13719,7 @@ def _overlapping_partitions(partitions, indices, axes, master_flip):
         numpy array
             A numpy array of cf.Partition objects.
 
-    **Examples:**
+    **Examples**
 
     >>> type(f.Data)
     <class 'cf.data.Data'>

--- a/cf/data/filledarray.py
+++ b/cf/data/filledarray.py
@@ -88,7 +88,7 @@ class FilledArray(abstract.Array):
     def dtype(self):
         """Data-type of the data elements.
 
-        **Examples:**
+        **Examples**
 
         >>> a.dtype
         dtype('float64')
@@ -102,7 +102,7 @@ class FilledArray(abstract.Array):
     def ndim(self):
         """Number of array dimensions.
 
-        **Examples:**
+        **Examples**
 
         >>> a.shape
         (73, 96)
@@ -132,7 +132,7 @@ class FilledArray(abstract.Array):
     def shape(self):
         """Tuple of array dimension sizes.
 
-        **Examples:**
+        **Examples**
 
         >>> a.shape
         (73, 96)
@@ -162,7 +162,7 @@ class FilledArray(abstract.Array):
     def size(self):
         """Number of elements in the array.
 
-        **Examples:**
+        **Examples**
 
         >>> a.shape
         (73, 96)

--- a/cf/data/functions.py
+++ b/cf/data/functions.py
@@ -30,7 +30,7 @@ def _open_netcdf_file(filename, mode, fmt="NETCDF4"):  # set_auto_mask=True):
         `netCDF4.Dataset`
             A netCDF4.Dataset instance for the netCDF file.
 
-    **Examples:**
+    **Examples**
 
     >>> nc1 = _open_netcdf_file('file.nc')
     >>> nc1

--- a/cf/data/mixin/deprecations.py
+++ b/cf/data/mixin/deprecations.py
@@ -50,7 +50,7 @@ class DataClassDeprecationsMixin:
     def ispartitioned(self):
         """True if the data array is partitioned.
 
-        **Examples:**
+        **Examples**
 
         >>> d._pmsize
         1
@@ -83,7 +83,7 @@ class DataClassDeprecationsMixin:
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> d.chunk()
         >>> d.chunk(100000)
@@ -100,7 +100,7 @@ class DataClassDeprecationsMixin:
 
         TODODASK
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data([[1, 2, 3], [4, 5, 6]])
         >>> print(d.ismasked)
@@ -121,7 +121,7 @@ class DataClassDeprecationsMixin:
 
         .. seealso:: `array`, `datetime_array`
 
-        **Examples:**
+        **Examples**
 
         >>> a = d.varray
         >>> type(a)
@@ -150,7 +150,7 @@ class DataClassDeprecationsMixin:
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> d.add_partitions(    )
 
@@ -165,7 +165,7 @@ class DataClassDeprecationsMixin:
 
             `dict`
 
-        **Examples:**
+        **Examples**
 
         """
         _DEPRECATION_ERROR_METHOD("TODODASK - consider using 'chunks' instead")

--- a/cf/data/netcdfarray.py
+++ b/cf/data/netcdfarray.py
@@ -85,7 +85,7 @@ class NetCDFArray(cfdm.NetCDFArray, abstract.FileArray):
 
                 .. versionadded:: 3.4.0
 
-        **Examples:**
+        **Examples**
 
         >>> import netCDF4
         >>> nc = netCDF4.Dataset('file.nc', 'r')
@@ -142,7 +142,7 @@ class NetCDFArray(cfdm.NetCDFArray, abstract.FileArray):
 #
 #        `None`
 #
-#    **Examples:**
+#    **Examples**
 #
 #    >>> f.close()
 #
@@ -157,7 +157,7 @@ class NetCDFArray(cfdm.NetCDFArray, abstract.FileArray):
 #
 #        `netCDF4.Dataset`
 #
-#    **Examples:**
+#    **Examples**
 #
 #    >>> f.open()
 #    <netCDF4.Dataset at 0x115a4d0>

--- a/cf/data/partition.py
+++ b/cf/data/partition.py
@@ -96,7 +96,7 @@ def _remove_temporary_files(filename=None):
 
         `None`
 
-    **Examples:**
+    **Examples**
 
     >>> _remove_temporary_files()
 
@@ -241,7 +241,7 @@ class Partition:
                 The units of the partition's subarray. DO NOT UPDATE
                 INPLACE.
 
-        **Examples:**
+        **Examples**
 
         >>> p = Partition(subarray   = numpy.arange(20).reshape(2,5,1),
         ...               location   = [(0, 6), (1, 3), (4, 5)],
@@ -352,7 +352,7 @@ class Partition:
     #        `dict`
     #            A dictionary of the instance's attributes
     #
-    #    **Examples:**
+    #    **Examples**
     #
     #        '''
     #        return dict([(attr, getattr(self, attr))
@@ -465,7 +465,7 @@ class Partition:
 
             `None`
 
-        **:Examples:**
+        **:Examples**
 
         >>> p._configure_auxiliary_mask([mask_component1, mask_component2])
 
@@ -506,7 +506,7 @@ class Partition:
                 A tuple of slice objects or, if the master data array is a
                 scalar array, an empty tuple.
 
-        **Examples:**
+        **Examples**
 
         >>> p.location
         [(0, 5), (2, 9)]
@@ -526,7 +526,7 @@ class Partition:
         """True if and only if the partition's subarray is in memory as
         opposed to on disk.
 
-        **Examples:**
+        **Examples**
 
         >>> p.in_memory
         False
@@ -542,7 +542,7 @@ class Partition:
     #
     #    .. seealso:: `array`, `in_memory`, `on_disk`, `to_shared_memory`
     #
-    #    **Examples:**
+    #    **Examples**
     #
     #    >>> p.in_shared_memory
     #    True
@@ -561,7 +561,7 @@ class Partition:
         .. seealso:: `array`, `in_memory`, `in_shared_memory`, `on_disk`,
                      `to_disk`
 
-        **Examples:**
+        **Examples**
 
         >>> p.in_cached_file
         False
@@ -574,7 +574,7 @@ class Partition:
         """True if and only if the partition's subarray is on disk as
         opposed to in memory.
 
-        **Examples:**
+        **Examples**
 
         >>> p.on_disk
         True
@@ -590,7 +590,7 @@ class Partition:
         """True if and only if the partition's subarray is on disk as
         opposed to in memory.
 
-        **Examples:**
+        **Examples**
 
         >>> p.on_disk
         True
@@ -611,7 +611,7 @@ class Partition:
         """True if and only if the partition's data array is a scalar
         array.
 
-        **Examples:**
+        **Examples**
 
         >>> p.axes
         []
@@ -657,7 +657,7 @@ class Partition:
         """Number of elements in the partition's data array (not its
         subarray).
 
-        **Examples:**
+        **Examples**
 
         >>> p.shape
         (73, 48)
@@ -691,7 +691,7 @@ class Partition:
     #
     #    True if and only if the partition's subarray is in an external file.
     #
-    #    **Examples:**
+    #    **Examples**
     #
     #    >>> p.subarray_in_external_file
     #    False
@@ -715,7 +715,7 @@ class Partition:
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> p.axes
         ['dim0', 'dim1']
@@ -770,7 +770,7 @@ class Partition:
 
             None
 
-        **Examples:**
+        **Examples**
 
         >>> p.array(...)
         >>> p.close()
@@ -951,7 +951,7 @@ class Partition:
 
                 A deep copy.
 
-        **Examples:**
+        **Examples**
 
         >>> q = p.copy()
 
@@ -1231,7 +1231,7 @@ class Partition:
     def isdt(self):
         """True if the subarray contains date-time objects.
 
-        **Examples:**
+        **Examples**
 
         >>> p.Units.isreftime
         True
@@ -1250,7 +1250,7 @@ class Partition:
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> p.file_close()
 
@@ -1271,7 +1271,7 @@ class Partition:
     #        generator
     #            An iterator that yields the partition itself.
     #
-    #    **Examples:**
+    #    **Examples**
     #
     #    >>> type(p.flat())
     #    <generator object flat at 0x519a0a0>
@@ -1297,7 +1297,7 @@ class Partition:
     #        generator
     #            An iterator over indices of the partition's data array.
     #
-    #    **Examples:**
+    #    **Examples**
     #
     #    >>> p.shape
     #    [2, 1, 3]
@@ -1330,7 +1330,7 @@ class Partition:
 
             None
 
-        **Examples:**
+        **Examples**
 
         >>> f.inspect()
 
@@ -1347,7 +1347,7 @@ class Partition:
                 An iterator over indices of the master array which are
                 spanned by the data array.
 
-        **Examples:**
+        **Examples**
 
         >>> p.location
         [(3, 5), (0, 1), (0, 3)]
@@ -1382,7 +1382,7 @@ class Partition:
 
             None
 
-        **Examples:**
+        **Examples**
 
         >>> p.new_part(indices, dim2position, master_flip)
 
@@ -1673,7 +1673,7 @@ class Partition:
                 partition's shape as a list. Otherwise return `None`,
                 `None`.
 
-        **Examples:**
+        **Examples**
 
         >>> indices = (slice(None), slice(5, 1, -2), [1, 3, 4, 8])
         >>> p.overlaps(indices)
@@ -1773,7 +1773,7 @@ class Partition:
             `bool`
                 True if the subarray was moved to disk, False otherwise.
 
-        **Examples:**
+        **Examples**
 
         >>> p.to_disk()
         >>> p.to_disk(reopen=False)
@@ -1850,7 +1850,7 @@ class Partition:
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> p.revert()
 
@@ -1884,7 +1884,7 @@ class Partition:
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> p.update_inplace_from(q)
 

--- a/cf/data/partitionmatrix.py
+++ b/cf/data/partitionmatrix.py
@@ -56,7 +56,7 @@ class PartitionMatrix:
                 array. If the partition matrix is a scalar array then it
                 is an empty list. DO NOT UPDATE INPLACE.
 
-        **Examples:**
+        **Examples**
 
         >>> pm = PartitionMatrix(
         ...          numpy.array(Partition(
@@ -88,7 +88,7 @@ class PartitionMatrix:
 
         Returns either a partition or a partition matrix.
 
-        **Examples:**
+        **Examples**
 
         >>> pm.shape
         (5, 3)
@@ -134,7 +134,7 @@ class PartitionMatrix:
         integer) is given then there must be one index per partition
         matrix dimension.
 
-        **Examples:**
+        **Examples**
 
         >>> pm.shape
         (3,)
@@ -196,7 +196,7 @@ class PartitionMatrix:
     def flat(self):
         """A flat iterator over the partitions in the partition matrix.
 
-        **Examples:**
+        **Examples**
 
         >>> pm.shape
         [2, 2]
@@ -227,7 +227,7 @@ class PartitionMatrix:
         Not to be confused with the number of dimensions of the master
         data array.
 
-        **Examples:**
+        **Examples**
 
         >>> pm.shape
         (8, 4)
@@ -249,7 +249,7 @@ class PartitionMatrix:
         Not to be confused with the sizes of the master data array's
         dimensions.
 
-        **Examples:**
+        **Examples**
 
         >>> pm.ndim
         2
@@ -273,7 +273,7 @@ class PartitionMatrix:
         Not to be confused with the number of elements in the master data
         array.
 
-        **Examples:**
+        **Examples**
 
         >>> pm.shape
         (8, 4)
@@ -488,7 +488,7 @@ class PartitionMatrix:
 
                 The deep copy.
 
-        **Examples:**
+        **Examples**
 
         >>> pm.copy()
 
@@ -530,7 +530,7 @@ class PartitionMatrix:
 
             `PartitionMatrix`
 
-        **Examples:**
+        **Examples**
 
         >>> pm.shape
         (2, 3)
@@ -555,7 +555,7 @@ class PartitionMatrix:
             `numpy.ndenumerate`
                 An iterator over the array coordinates and values.
 
-        **Examples:**
+        **Examples**
 
         >>> pm.shape
         (2, 3)
@@ -629,7 +629,7 @@ class PartitionMatrix:
 
             `PartitionMatrix`
 
-        **Examples:**
+        **Examples**
 
         >>> pm.shape
         (2, 3, 4, 5)
@@ -666,7 +666,7 @@ class PartitionMatrix:
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> pm.set_location_map(['dim1', 'dim0'])
         >>> pm.set_location_map([])
@@ -740,7 +740,7 @@ class PartitionMatrix:
 
             `PartitionMatrix`
 
-        **Examples:**
+        **Examples**
 
         >>> pm.shape
         (1, 2, 1, 2)
@@ -789,7 +789,7 @@ class PartitionMatrix:
 
             `PartitionMatrix`
 
-        **Examples:**
+        **Examples**
 
         >>> pm.ndim
         3

--- a/cf/data/umarray.py
+++ b/cf/data/umarray.py
@@ -64,7 +64,7 @@ class UMArray(abstract.FileArray):
 
             byte_ordering: `str`, optional
 
-        **Examples:**
+        **Examples**
 
         >>> a = UMFileArray(file='file.pp', header_offset=3156,
         ...                 data_offset=3420,
@@ -270,7 +270,7 @@ class UMArray(abstract.FileArray):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> f.close()
 
@@ -284,7 +284,7 @@ class UMArray(abstract.FileArray):
 
             `umfile_lib.File`
 
-        **Examples:**
+        **Examples**
 
         >>> f.open()
 

--- a/cf/data/utils.py
+++ b/cf/data/utils.py
@@ -31,7 +31,7 @@ def _is_numeric_dtype(array):
             `bool`
                 Whether or not the array holds numeric elements.
 
-    **Examples:**
+    **Examples**
 
     >>> a = np.array([0, 1, 2])
     >>> cf.data.utils._is_numeric_dtype(a)
@@ -377,7 +377,7 @@ def new_axis_identifier(existing_axes=(), basename="dim"):
         `str`
             The new axis idenfifier.
 
-    **Examples:**
+    **Examples**
 
     >>> cf.data.utils.new_axis_identifier()
     'dim0'


### PR DESCRIPTION
As for NCAS-CMS#182 over on cfdm, but note that this is **only across the data module**, i.e:

```console
$ pwd
<path to cf repo>/cf-python/cf/data
$ find . -type f | xargs sed -i 's/Examples:/Examples/g'
```

in line with our approach to managing development of mostly `data` modules on `lama-to-dask` and all other modules on `master`. I am about to open a corresponding PR on `master` to cover all non-`data` modules.

@davidhassell I have opened this PR so the batch update gets done at the first available point, but please prioritise merging of your currently-open PRs before this - it is trivial to manage code updates and to resolve merge conflicts here, much less so (probably) on your PRs.
