### PR TITLE
Batch docstring formatting update: 'Examples:' -> 'Examples'

### DIFF
--- a/cf/abstract/constructlist.py
+++ b/cf/abstract/constructlist.py
@@ -118,7 +118,7 @@ class ConstructList(list, Container, cfdm.Container):
             `{{class}}`
                 The concatenation of the list and another sequence.
 
-        **Examples:**
+        **Examples**
 
         >>> h = f + g
         >>> f += g
@@ -153,7 +153,7 @@ class ConstructList(list, Container, cfdm.Container):
             `{{class}}`
                 The list added to itself *n* times.
 
-        **Examples:**
+        **Examples**
 
         >>> h = f * 2
         >>> f *= 2
@@ -187,7 +187,7 @@ class ConstructList(list, Container, cfdm.Container):
             `{{class}}`
                 Slice of the list from *i* to *j*.
 
-        **Examples:**
+        **Examples**
 
         >>> g = f[0:1]
         >>> g = f[1:-4]
@@ -208,7 +208,7 @@ class ConstructList(list, Container, cfdm.Container):
                 element is returned. If *index* is a slice then a new
                 {{class}} is returned, which may be empty.
 
-        **Examples:**
+        **Examples**
 
         >>> g = f[0]
         >>> g = f[-1:-4:-1]
@@ -258,7 +258,7 @@ class ConstructList(list, Container, cfdm.Container):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> f.close()
 
@@ -276,7 +276,7 @@ class ConstructList(list, Container, cfdm.Container):
 
         .. seealso:: `list.count`
 
-        **Examples:**
+        **Examples**
 
         >>> f = cf.{{class}}([a, b, c, a])
         >>> f.count(a)
@@ -375,7 +375,7 @@ class ConstructList(list, Container, cfdm.Container):
 
                 The deep copy.
 
-        **Examples:**
+        **Examples**
 
         >>> g = f.copy()
         >>> g is f
@@ -480,7 +480,7 @@ class ConstructList(list, Container, cfdm.Container):
             `bool`
                 Whether the two lists are equal.
 
-        **Examples:**
+        **Examples**
 
         >>> fl.equals(fl)
         True
@@ -670,7 +670,7 @@ class ConstructList(list, Container, cfdm.Container):
             `{{class}}`
                 The matching constructs.
 
-        **Examples:**
+        **Examples**
 
         See `{{package}}.{{class}}.match_by_identity`
 

--- a/cf/aggregate.py
+++ b/cf/aggregate.py
@@ -1000,7 +1000,7 @@ class _Meta:
                 A structural signature of each coordinate reference
                 object.
 
-        **Examples:**
+        **Examples**
 
         >>> sig = coordinate_reference_signatures(refs)
 
@@ -1293,7 +1293,7 @@ class _Meta:
 
             `tuple` or `None`
 
-        **Examples:**
+        **Examples**
 
         >>> m.find_coordrefs('dim0')
         >>> m.find_coordrefs('aux1')
@@ -1586,7 +1586,7 @@ def aggregate(
         `FieldList`
             The aggregated field constructs.
 
-    **Examples:**
+    **Examples**
 
     The following six fields comprise eastward wind at two different times
     and for three different atmospheric heights for each time:
@@ -2781,7 +2781,7 @@ def _ok_coordinate_arrays(meta, axis, overlap, contiguous, verbose=None):
 
         `bool`
 
-    **Examples:**
+    **Examples**
 
     >>> if not _ok_coordinate_arrays(meta, 'latitude', True, False):
     ...     print("Don't aggregate")

--- a/cf/bounds.py
+++ b/cf/bounds.py
@@ -91,7 +91,7 @@ class Bounds(mixin.Coordinate, mixin.PropertiesData, cfdm.Bounds):
              `bool`
                  Whether or not the cells are contiguous.
 
-         **Examples:**
+         **Examples**
 
          >>> c.has_bounds()
          False
@@ -269,7 +269,7 @@ class Bounds(mixin.Coordinate, mixin.PropertiesData, cfdm.Bounds):
 
                 The identity.
 
-        **Examples:**
+        **Examples**
 
         >>> b.inherited_properties()
         {'foo': 'bar',

--- a/cf/cellmeasure.py
+++ b/cf/cellmeasure.py
@@ -108,7 +108,7 @@ class CellMeasure(mixin.PropertiesData, cfdm.CellMeasure):
 
                 The identity.
 
-        **Examples:**
+        **Examples**
 
         >>> c.measure
         'area'

--- a/cf/cellmethod.py
+++ b/cf/cellmethod.py
@@ -82,7 +82,7 @@ class CellMethod(cfdm.CellMethod):
 
             `list`
 
-        **Examples:**
+        **Examples**
 
         >>> c = CellMethod.create('lat: mean (interval: 1 hour)')
 
@@ -232,7 +232,7 @@ class CellMethod(cfdm.CellMethod):
 
         .. seealso:: `over`
 
-        **Examples:**
+        **Examples**
 
         >>> c
         >>> c
@@ -265,7 +265,7 @@ class CellMethod(cfdm.CellMethod):
 
         .. seealso:: `over`
 
-        **Examples:**
+        **Examples**
 
         >>> c
         >>> c
@@ -298,7 +298,7 @@ class CellMethod(cfdm.CellMethod):
 
         .. seealso:: `within`
 
-        **Examples:**
+        **Examples**
 
         >>> c
         >>> c
@@ -342,7 +342,7 @@ class CellMethod(cfdm.CellMethod):
 
         Describes how the cell values have been determined or derived.
 
-        **Examples:**
+        **Examples**
 
         >>> c
         <CF CellMethod: time: minimum>
@@ -370,7 +370,7 @@ class CellMethod(cfdm.CellMethod):
     def intervals(self):
         """The cell method's interval qualifier(s).
 
-        **Examples:**
+        **Examples**
 
         >>> c
         <CF CellMethod: time: minimum>
@@ -532,7 +532,7 @@ class CellMethod(cfdm.CellMethod):
             `bool`
                 Whether or not the two instances are equivalent.
 
-        **Examples:**
+        **Examples**
 
         >>> a = cf.example_field(1)
         >>> a.cell_methods()

--- a/cf/cfdatetime.py
+++ b/cf/cfdatetime.py
@@ -92,7 +92,7 @@ def dt(
         `cftime.datetime`
             The new date-time object.
 
-    **Examples:**
+    **Examples**
 
     >>> d = cf.dt(2003)
     >>> d
@@ -197,7 +197,7 @@ def dt_vector(
         `numpy.ndarray`
             1-d array of date-time objects.
 
-    **Examples:**
+    **Examples**
 
     TODO
 
@@ -317,7 +317,7 @@ def st2dt(array, units_in=None, dummy0=None, dummy1=None):
             An array of `cftime.datetime` objects with the same shape
             as *array*.
 
-    **Examples:**
+    **Examples**
 
     """
     func = partial(st2datetime, calendar=units_in._calendar)

--- a/cf/cfimplementation.py
+++ b/cf/cfimplementation.py
@@ -114,7 +114,7 @@ def implementation():
         `CFImplementation`
             A container for the CF data model implementation.
 
-    **Examples:**
+    **Examples**
 
     >>> i = cf.implementation()
     >>> i

--- a/cf/constructlist.py
+++ b/cf/constructlist.py
@@ -118,7 +118,7 @@ class ConstructList(list, Container, cfdm.Container):
             `{{class}}`
                 The concatenation of the list and another sequence.
 
-        **Examples:**
+        **Examples**
 
         >>> h = f + g
         >>> f += g
@@ -153,7 +153,7 @@ class ConstructList(list, Container, cfdm.Container):
             `{{class}}`
                 The list added to itself *n* times.
 
-        **Examples:**
+        **Examples**
 
         >>> h = f * 2
         >>> f *= 2
@@ -187,7 +187,7 @@ class ConstructList(list, Container, cfdm.Container):
             `{{class}}`
                 Slice of the list from *i* to *j*.
 
-        **Examples:**
+        **Examples**
 
         >>> g = f[0:1]
         >>> g = f[1:-4]
@@ -208,7 +208,7 @@ class ConstructList(list, Container, cfdm.Container):
                 construct element is returned. If *index* is a slice
                 then a new {{class}} is returned, which may be empty.
 
-        **Examples:**
+        **Examples**
 
         >>> g = f[0]
         >>> g = f[-1:-4:-1]
@@ -261,7 +261,7 @@ class ConstructList(list, Container, cfdm.Container):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> f.close()
 
@@ -279,7 +279,7 @@ class ConstructList(list, Container, cfdm.Container):
 
         .. seealso:: `list.count`
 
-        **Examples:**
+        **Examples**
 
         >>> f = cf.{{class}}([a, b, c, a])
         >>> f.count(a)
@@ -380,7 +380,7 @@ class ConstructList(list, Container, cfdm.Container):
             `{{class}}`
                 The deep copy.
 
-        **Examples:**
+        **Examples**
 
         >>> g = f.copy()
         >>> g is f
@@ -486,7 +486,7 @@ class ConstructList(list, Container, cfdm.Container):
             `bool`
                 Whether the two lists are equal.
 
-        **Examples:**
+        **Examples**
 
         >>> fl.equals(fl)
         True
@@ -664,7 +664,7 @@ class ConstructList(list, Container, cfdm.Container):
             `{{class}}`
                 The matching constructs.
 
-        **Examples:**
+        **Examples**
 
         See `{{package}}.{{class}}.match_by_identity`
 

--- a/cf/constructs.py
+++ b/cf/constructs.py
@@ -126,7 +126,7 @@ class Constructs(cfdm.Constructs):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> c.close()
 

--- a/cf/coordinatereference.py
+++ b/cf/coordinatereference.py
@@ -211,7 +211,7 @@ class CoordinateReference(cfdm.CoordinateReference):
         """Returns False since coordinate reference constructs do not
         have cell bounds.
 
-        **Examples:**
+        **Examples**
 
         >>> c.has_bounds()
         False
@@ -264,7 +264,7 @@ class CoordinateReference(cfdm.CoordinateReference):
             `Units` or `None`
                 The canonical units, or `None` if there are not any.
 
-        **Examples:**
+        **Examples**
 
         >>> cf.CoordinateReference.canonical_units('perspective_point_height')
         <Units: m>
@@ -282,7 +282,7 @@ class CoordinateReference(cfdm.CoordinateReference):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> c.close()
 
@@ -303,7 +303,7 @@ class CoordinateReference(cfdm.CoordinateReference):
 
                 The default value, or 0.0 if one is not available.
 
-        **Examples:**
+        **Examples**
 
         >>> cf.CoordinateReference.default_value('ptop')
         0.0
@@ -340,7 +340,7 @@ class CoordinateReference(cfdm.CoordinateReference):
             out: `bool`
                 Whether or not the two objects are equivalent.
 
-        **Examples:**
+        **Examples**
 
         >>> a = cf.example_field(6)
         >>> b = cf.example_field(7)
@@ -544,7 +544,7 @@ class CoordinateReference(cfdm.CoordinateReference):
                 Whether or not the coordinate reference matches one of the
                 given identities.
 
-        **Examples:**
+        **Examples**
 
         >>> c.match_by_identity('time')
 
@@ -619,7 +619,7 @@ class CoordinateReference(cfdm.CoordinateReference):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> r = cf.CoordinateReference('atmosphere_hybrid_height_coordinate',
         ...                             a='ncvar:ak',

--- a/cf/dimensioncoordinate.py
+++ b/cf/dimensioncoordinate.py
@@ -97,7 +97,7 @@ class DimensionCoordinate(
             `bool`
                 Whether or not the coordinate is increasing.
 
-        **Examples:**
+        **Examples**
 
         >>> c.array
         array([  0  30  60])
@@ -154,7 +154,7 @@ class DimensionCoordinate(
     #        `Data`
     #            The size for each cell.
     #
-    #    **Examples:**
+    #    **Examples**
     #
     #    >>> print(c.bounds)
     #    <CF Bounds: latitude(3, 2) degrees_north>
@@ -207,7 +207,7 @@ class DimensionCoordinate(
             `bool`
                 Whether or not the coordinate is decreasing.
 
-        **Examples:**
+        **Examples**
 
         >>> c.decreasing
         False
@@ -236,7 +236,7 @@ class DimensionCoordinate(
             `bool`
                 Whether or not the coordinate is increasing.
 
-        **Examples:**
+        **Examples**
 
         >>> c.decreasing
         False
@@ -252,7 +252,7 @@ class DimensionCoordinate(
     #
     #    .. seealso:: `bounds`, `upper_bounds`
     #
-    #    **Examples:**
+    #    **Examples**
     #
     #    >>> print(c.bounds.array)
     #    [[ 5  3]
@@ -285,7 +285,7 @@ class DimensionCoordinate(
     #
     #    .. seealso:: `bounds`, `lower_bounds`
     #
-    #    **Examples:**
+    #    **Examples**
     #
     #    >>> print(c.bounds.array)
     #    [[ 5  3]
@@ -327,7 +327,7 @@ class DimensionCoordinate(
             `bool`
                 Whether or not the coordinate is increasing.
 
-        **Examples:**
+        **Examples**
 
         >>> c.array
         array([  0  30  60])
@@ -499,7 +499,7 @@ class DimensionCoordinate(
             `Bounds`
                 The newly-created coordinate cell bounds object.
 
-        **Examples:**
+        **Examples**
 
         >>> c.create_bounds()
         >>> c.create_bounds(bound=-9000.0)
@@ -710,7 +710,7 @@ class DimensionCoordinate(
             `Bounds`
                 The bounds.
 
-        **Examples:**
+        **Examples**
 
         >>> b = Bounds(data=cfdm.Data(range(10).reshape(5, 2)))
         >>> c.set_bounds(b)
@@ -760,7 +760,7 @@ class DimensionCoordinate(
     #
     #       `bool`
     #
-    #    **Examples:**
+    #    **Examples**
     #
     #    >>> f.autocyclic()
     #

--- a/cf/domain.py
+++ b/cf/domain.py
@@ -136,7 +136,7 @@ class Domain(mixin.FieldDomain, mixin.Properties, cfdm.Domain):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> d.close()
 
@@ -186,7 +186,7 @@ class Domain(mixin.FieldDomain, mixin.Properties, cfdm.Domain):
     #                prior to the new setting, or the current cyclic domain
     #                axes if no axis was specified.
     #
-    #        **Examples:**
+    #        **Examples**
     #
     #        >>> f.cyclic()
     #        set()
@@ -269,7 +269,7 @@ class Domain(mixin.FieldDomain, mixin.Properties, cfdm.Domain):
     #            `DomainAxis` or `str`
     #                The selected domain axis construct, or its key.
     #
-    #        **Examples:**
+    #        **Examples**
     #
     #        """
     #        c = self.domain_axes(identity)
@@ -337,7 +337,7 @@ class Domain(mixin.FieldDomain, mixin.Properties, cfdm.Domain):
                 The domain with flipped axes, or `None` if the operation
                 was in-place.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.example_field(0).domain
         >>> print(d)
@@ -406,7 +406,7 @@ class Domain(mixin.FieldDomain, mixin.Properties, cfdm.Domain):
                 The value of the *default* parameter, if an exception
                 has not been raised.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.example_domain(0)
         >>> print(d.get_data(None))
@@ -478,7 +478,7 @@ class Domain(mixin.FieldDomain, mixin.Properties, cfdm.Domain):
             `tuple`
                 The keys of the domain axis constructs spanned by the data.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.example_field(7).domain
         >>> print(d)
@@ -552,7 +552,7 @@ class Domain(mixin.FieldDomain, mixin.Properties, cfdm.Domain):
 
                 The identity.
 
-        **Examples:**
+        **Examples**
 
         >>> f.properties()
         {'foo': 'bar',
@@ -648,7 +648,7 @@ class Domain(mixin.FieldDomain, mixin.Properties, cfdm.Domain):
             `list`
                 The identities.
 
-        **Examples:**
+        **Examples**
 
         >>> d = {{package}}.Domain()
         >>> d.set_properties({'foo': 'bar',
@@ -749,7 +749,7 @@ class Domain(mixin.FieldDomain, mixin.Properties, cfdm.Domain):
                 A dictionary of indices, keyed by the domain axis
                 construct identifiers to which they apply.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.example_field(0).domain
         >>> print(d)
@@ -917,7 +917,7 @@ class Domain(mixin.FieldDomain, mixin.Properties, cfdm.Domain):
                 Whether or not the domain construct contains the specfied
                 metadata constructs.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.example_field(0).domain
         >>> print(d)
@@ -1022,7 +1022,7 @@ class Domain(mixin.FieldDomain, mixin.Properties, cfdm.Domain):
             `Field`
                 The rolled field.
 
-        **Examples:**
+        **Examples**
 
         Roll the data of the "X" axis one elements to the right:
 
@@ -1140,7 +1140,7 @@ class Domain(mixin.FieldDomain, mixin.Properties, cfdm.Domain):
                 whether or not it is possible to create specified
                 subspace.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.example_field(0).domain
         >>> print(d)
@@ -1307,7 +1307,7 @@ class Domain(mixin.FieldDomain, mixin.Properties, cfdm.Domain):
                 The domain construct with transposed constructs, or `None`
                 if the operation was in-place.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.example_field(7).domain
         >>> print(d)

--- a/cf/domainaxis.py
+++ b/cf/domainaxis.py
@@ -150,7 +150,7 @@ class DomainAxis(cfdm.DomainAxis):
 
         .. seealso:: `del_size`, `get_size`, `has_size`, `set_size`
 
-        **Examples:**
+        **Examples**
 
         >>> d.size = 96
         >>> d.size
@@ -182,7 +182,7 @@ class DomainAxis(cfdm.DomainAxis):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> d.inspect()
 

--- a/cf/field.py
+++ b/cf/field.py
@@ -394,7 +394,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
 
         .. seealso:: `indices`, `squeeze`, `subspace`, `where`
 
-        **Examples:**
+        **Examples**
 
         >>> f.shape
         (12, 73, 96)
@@ -620,7 +620,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
             `dict`
                 A description of the domain.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f)
         Axes           : time(3) = [1979-05-01 12:00:00, ..., 1979-05-03 12:00:00] gregorian
@@ -944,7 +944,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 The new field, or the same field if the operation was an
                 in place augmented arithmetic assignment.
 
-        **Examples:**
+        **Examples**
 
         >>> h = f._binary_operation(g, '__add__')
         >>> h = f._binary_operation(g, '__ge__')
@@ -1886,7 +1886,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 The new field, or the same field if the operation was an
                 in place augmented arithmetic assignment.
 
-        **Examples:**
+        **Examples**
 
         >>> h = f._binary_operation(g, '__add__')
         >>> h = f._binary_operation(g, '__ge__')
@@ -2415,7 +2415,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
             `Field`
                 The conformed version of *other*.
 
-        **Examples:**
+        **Examples**
 
         >>> h = f._conform_for_assignment(g)
 
@@ -2645,7 +2645,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
             `Field`
                 The conformed version of *other*.
 
-        **Examples:**
+        **Examples**
 
         >>> h = f._conform_for_data_broadcasting(g)
 
@@ -4076,7 +4076,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
 
         .. seealso:: `featureType`
 
-        **Examples:**
+        **Examples**
 
         >>> f.featureType
         'timeSeries'
@@ -4098,7 +4098,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
         Stores the `flag_values`, `flag_meanings` and `flag_masks` CF
         properties in an internally consistent manner.
 
-        **Examples:**
+        **Examples**
 
         >>> f.Flags
         <CF Flags: flag_values=[0 1 2], flag_masks=[0 2 2], flag_meanings=['low' 'medium' 'high']>
@@ -4132,7 +4132,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
 
         .. seealso:: `array`, `data`, `datetime_array`
 
-        **Examples:**
+        **Examples**
 
         >>> f.data
         <CF Data(5): [0, ... 4] kg m-1 s-2>
@@ -4167,7 +4167,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
         Stored as a 1-d numpy array but may be set as any array-like
         object.
 
-        **Examples:**
+        **Examples**
 
         >>> f.flag_values = ['a', 'b', 'c']
         >>> f.flag_values
@@ -4222,7 +4222,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
 
         Stored as a 1-d numpy array but may be set as array-like object.
 
-        **Examples:**
+        **Examples**
 
         >>> f.flag_masks = numpy.array([1, 2, 4], dtype='int8')
         >>> f.flag_masks
@@ -4281,7 +4281,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
         Stored as a 1-d numpy string array but may be set as a space
         delimited string or any array-like object.
 
-        **Examples:**
+        **Examples**
 
         >>> f.flag_meanings = 'low medium      high'
         >>> f.flag_meanings
@@ -4343,7 +4343,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
         The name of the conventions followed by the field. See
         http://cfconventions.org/latest.html for details.
 
-        **Examples:**
+        **Examples**
 
         >>> f.Conventions = 'CF-1.6'
         >>> f.Conventions
@@ -4376,7 +4376,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
 
         .. versionadded:: 2.0
 
-        **Examples:**
+        **Examples**
 
         >>> f.featureType = 'trajectoryProfile'
         >>> f.featureType
@@ -4406,7 +4406,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
         Specifies where the original data was produced. See
         http://cfconventions.org/latest.html for details.
 
-        **Examples:**
+        **Examples**
 
         >>> f.institution = 'University of Reading'
         >>> f.institution
@@ -4437,7 +4437,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
         methods used to produce it. See
         http://cfconventions.org/latest.html for details.
 
-        **Examples:**
+        **Examples**
 
         >>> f.references = 'some references'
         >>> f.references
@@ -4469,7 +4469,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
         values are the stated multiple of one standard error. See
         http://cfconventions.org/latest.html for details.
 
-        **Examples:**
+        **Examples**
 
         >>> f.standard_error_multiplier = 2.0
         >>> f.standard_error_multiplier
@@ -4503,7 +4503,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
         observation'`` or ``'radiosonde'``). See
         http://cfconventions.org/latest.html for details.
 
-        **Examples:**
+        **Examples**
 
         >>> f.source = 'radiosonde'
         >>> f.source
@@ -4534,7 +4534,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
         read, or is to be written to. See
         http://cfconventions.org/latest.html for details.
 
-        **Examples:**
+        **Examples**
 
         >>> f.title = 'model data'
         >>> f.title
@@ -4610,7 +4610,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 A field construct containing the horizontal cell
                 areas.
 
-        **Examples:**
+        **Examples**
 
         >>> a = f.cell_area()
         >>> a = f.cell_area(radius=cf.Data(3389.5, 'km'))
@@ -4678,7 +4678,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
             `Data`
                 The radius of the sphere, in units of metres.
 
-        **Examples:**
+        **Examples**
 
         >>> f.radius()
         <CF Data(): 6371178.98 m>
@@ -4970,7 +4970,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 field with corresponding values of axis identifiers of the
                 of other field.
 
-        **Examples:**
+        **Examples**
 
         >>> f.map_axes(g)
         {'dim0': 'dim1',
@@ -4999,7 +4999,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> f.close()
 
@@ -5028,7 +5028,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
             `bool`
                 True if the selected axis is cyclic, otherwise False.
 
-        **Examples:**
+        **Examples**
 
         >>> f.iscyclic('X')
         True
@@ -5415,7 +5415,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 broadcastable form; or if *components* is True, orthogonal
                 weights in a dictionary.
 
-        **Examples:**
+        **Examples**
 
         >>> f
         <CF Field: air_temperature(time(12), latitude(145), longitude(192)) K>
@@ -6060,7 +6060,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 If *return_bins* is True then also return the bins in
                 their 2-d form.
 
-        **Examples:**
+        **Examples**
 
         >>> f = cf.example_field(0)
         >>> f
@@ -6555,7 +6555,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
             `Field`
                 The field construct containing the binned values.
 
-        **Examples:**
+        **Examples**
 
         Find the range of values that lie in each bin:
 
@@ -6953,7 +6953,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
             `bool`
                 `True` if the construct exists, otherwise `False`.
 
-        **Examples:**
+        **Examples**
 
         >>> f = cf.example_field(0)
         >>> print(f)
@@ -8449,7 +8449,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                  *regroup* parameter is True then a `numpy` array is
                  returned.
 
-        **Examples:**
+        **Examples**
 
         There are further worked examples in
         https://ncas-cms.github.io/cf-python/analysis.html#statistical-collapses
@@ -9552,7 +9552,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
 
                 `dict` or `None`
 
-            **Examples:**
+            **Examples**
 
             >>> print(weights)
             None
@@ -10538,7 +10538,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 The field construct with expanded data, or `None` if the
                 operation was in-place.
 
-        **Examples:**
+        **Examples**
 
         >>> f = cf.example_field(0)
         >>> print(f)
@@ -10680,7 +10680,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
             `tuple`
                 The indices meeting the conditions.
 
-        **Examples:**
+        **Examples**
 
         >>> q = cf.example_field(0)
         >>> print(q)
@@ -11331,7 +11331,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 otherwise return a new `Field` instance containing the new
                 data.
 
-        **Examples:**
+        **Examples**
 
         >>> f = cf.Field()
         >>> f.set_data([1, 2, 3])
@@ -11507,7 +11507,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
             `Field`
                 The domain mask.
 
-        **Examples:**
+        **Examples**
 
         Create a domain mask which is masked at all between between -30
         and 30 degrees of latitude:
@@ -11760,7 +11760,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 Whether or not the field construct contains the specified
                 metadata constructs.
 
-        **Examples:**
+        **Examples**
 
             TODO
 
@@ -12094,7 +12094,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 The field construct of moving window values, or `None`
                 if the operation was in-place.
 
-        **Examples:**
+        **Examples**
 
         >>> f = cf.example_field(0)
         >>> print(f)
@@ -12437,7 +12437,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 The convolved field construct, or `None` if the operation
                 was in-place.
 
-        **Examples:**
+        **Examples**
 
         >>> f = cf.example_field(2)
         >>> print(f)
@@ -12683,7 +12683,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
             `Field`
                 The new field construct.
 
-        **Examples:**
+        **Examples**
 
         TODO
 
@@ -12771,7 +12771,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 The field construct with the cumulatively summed axis, or
                 `None` if the operation was in-place.
 
-        **Examples:**
+        **Examples**
         >>> f = cf.example_field(2)
         >>> print(f)
         Field: air_potential_temperature (ncvar%air_potential_temperature)
@@ -12894,7 +12894,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 The field construct with flipped axes, or `None` if
                 the operation was in-place.
 
-        **Examples:**
+        **Examples**
 
         >>> g = f.flip()
         >>> g = f.flip('time')
@@ -12950,7 +12950,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
 
         :Returns:
 
-        **Examples:**
+        **Examples**
 
         >>> g = f.argmax('T')
 
@@ -13073,7 +13073,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 The field construct with squeezed data, or `None` if the
                 operation was in-place.
 
-                **Examples:**
+                **Examples**
 
         >>> g = f.squeeze()
         >>> g = f.squeeze('time')
@@ -13130,7 +13130,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 positions. If the operation was in-place then `None` is
                 returned.
 
-        **Examples:**
+        **Examples**
 
         >>> f.shape
         (1, 2, 3)
@@ -13232,7 +13232,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 The field construct with transposed data, or `None` if the
                 operation was in-place.
 
-        **Examples:**
+        **Examples**
 
         >>> f.ndim
         3
@@ -13303,7 +13303,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 The field construct with size-1 axes inserted in its data,
                 or `None` if the operation was in-place.
 
-        **Examples:**
+        **Examples**
 
         >>> g = f.unsqueeze()
         >>> f.unsqueeze(['dim2'], inplace=True)
@@ -13391,7 +13391,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
 
                 {{Returns construct}}
 
-        **Examples:**
+        **Examples**
 
         """
         return self._construct(
@@ -13457,7 +13457,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
 
                 {{Returns construct}}
 
-        **Examples:**
+        **Examples**
 
         """
         return self._construct(
@@ -13490,7 +13490,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 The position in the field construct's data of the
                 selected domain axis construct.
 
-        **Examples:**
+        **Examples**
 
         >>> f
         <CF Field: air_temperature(time(12), latitude(64), longitude(128)) K>
@@ -13523,7 +13523,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
             `dict`
                 The canonical name for the domain axis construct.
 
-        **Examples:**
+        **Examples**
 
         >>> f.axis_names()
         {'domainaxis0': 'atmosphere_hybrid_height_coordinate',
@@ -13571,7 +13571,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
             `int`
                 The size of the selected domain axis
 
-        **Examples:**
+        **Examples**
 
         >>> f
         <CF Field: eastward_wind(time(3), air_pressure(5), latitude(110), longitude(106)) m s-1>
@@ -13626,7 +13626,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 The keys of the domain axis constructs spanned by the
                 data.
 
-        **Examples:**
+        **Examples**
 
         >>> f.set_data_axes(['domainaxis0', 'domainaxis1'])
         >>> f.get_data_axes()
@@ -13995,7 +13995,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 The expanded field construct, or `None` if the operation
                 was in-place.
 
-        **Examples:**
+        **Examples**
 
         >>> f = cf.example_field(0)
         >>> print(f)
@@ -14268,7 +14268,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
             `Field`
                 The percentiles of the original data.
 
-        **Examples:**
+        **Examples**
 
         >>> f = cf.example_field(0)
         >>> print(f)
@@ -14832,7 +14832,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
             `Field`
                 The rolled field.
 
-        **Examples:**
+        **Examples**
 
         Roll the data of the "X" axis one elements to the right:
 
@@ -15060,7 +15060,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 A new field construct with an updated data array, or
                 `None` if the operation was in-place.
 
-        **Examples:**
+        **Examples**
 
         Set data array values to 15 everywhere:
 
@@ -15331,7 +15331,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 whether or not it is possible to create specified
                 subspace.
 
-        **Examples:**
+        **Examples**
 
         There are further worked examples
         :ref:`in the tutorial <Subspacing-by-metadata>`.
@@ -15389,7 +15389,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
             `FieldList`
                 The sections of the field construct.
 
-        **Examples:**
+        **Examples**
 
         Section a field into 2-d longitude/time slices, checking the
         units:
@@ -15737,7 +15737,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 operation was in-place, or the regridding operator if
                 *return_operator* is True.
 
-        **Examples:**
+        **Examples**
 
         Regrid field construct ``f`` conservatively onto a grid
         contained in field construct ``g``:
@@ -16503,7 +16503,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 operation was in-place, or the regridding operator if
                 *return_operator* is True.
 
-        **Examples:**
+        **Examples**
 
         Regrid the time axes of field ``f`` conservatively onto a grid
         contained in field ``g``:

--- a/cf/fieldlist.py
+++ b/cf/fieldlist.py
@@ -87,7 +87,7 @@ class FieldList(mixin.FieldDomainList, ConstructList):
             `FieldList`
                 The matching field constructs.
 
-        **Examples:**
+        **Examples**
 
         >>> f = cf.read("file.nc")
         >>> f
@@ -151,7 +151,7 @@ class FieldList(mixin.FieldDomainList, ConstructList):
             `FieldList`
                 The matching field constructs.
 
-        **Examples:**
+        **Examples**
 
         >>> gl = fl.select_by_units('metres')
         >>> gl = fl.select_by_units('m')
@@ -195,7 +195,7 @@ class FieldList(mixin.FieldDomainList, ConstructList):
             `Field`
                 The unique matching field construct.
 
-        **Examples:**
+        **Examples**
 
         >>> fl
         [<CF Field: specific_humidity(latitude(73), longitude(96)) 1>,

--- a/cf/flags.py
+++ b/cf/flags.py
@@ -66,7 +66,7 @@ class Flags:
             `int`
                 The hash value.
 
-        **Examples:**
+        **Examples**
 
         >>> hash(f)
         -956218661958673979
@@ -99,7 +99,7 @@ class Flags:
         Stored as a 1-d numpy array but may be set as any array-like
         object.
 
-        **Examples:**
+        **Examples**
 
         >>> f.flag_values = ['a', 'b', 'c']
         >>> f.flag_values
@@ -144,7 +144,7 @@ class Flags:
 
         Stored as a 1-d numpy array but may be set as array-like object.
 
-        **Examples:**
+        **Examples**
 
         >>> f.flag_masks = numpy.array([1, 2, 4], dtype='int8')
         >>> f.flag_masks
@@ -186,7 +186,7 @@ class Flags:
         Stored as a 1-d numpy string array but may be set as a space
         delimited string or any array-like object.
 
-        **Examples:**
+        **Examples**
 
         >>> f.flag_meanings = 'low medium      high'
         >>> f.flag_meanings
@@ -256,7 +256,7 @@ class Flags:
 
                 The deep copy.
 
-        **Examples:**
+        **Examples**
 
         >>> f.copy()
 
@@ -334,7 +334,7 @@ class Flags:
             `bool`
                 Whether or not the two instances are equal.
 
-        **Examples:**
+        **Examples**
 
         >>> f
         <CF Flags: flag_values=[1 0 2], flag_masks=[2 0 2], flag_meanings=['medium' 'low' 'high']>
@@ -428,7 +428,7 @@ class Flags:
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> f
         <CF Flags: flag_values=[2 0 1], flag_masks=[2 0 2], flag_meanings=['high' 'low' 'medium']>

--- a/cf/functions.py
+++ b/cf/functions.py
@@ -130,7 +130,7 @@ if _linux:
             `float`
                 The amount of available physical memory in bytes.
 
-        **Examples:**
+        **Examples**
 
         >>> _free_memory()
         96496240.0
@@ -177,7 +177,7 @@ else:
             `float`
                 The amount of available physical memory in bytes.
 
-        **Examples:**
+        **Examples**
 
         >>> _free_memory()
         96496240.0
@@ -311,7 +311,7 @@ def configuration(
             of the project-wide constants prior to the change, or the
             current names and values if no new values are specified.
 
-    **Examples:**
+    **Examples**
 
     >>> cf.configuration()  # view full global configuration of constants
     {'rtol': 2.220446049250313e-16,
@@ -521,7 +521,7 @@ def free_memory():
         `float`
             The amount of free memory in bytes.
 
-    **Examples:**
+    **Examples**
 
     >>> import numpy
     >>> print('Free memory =', cf.free_memory()/2**30, 'GiB')
@@ -636,7 +636,7 @@ class regrid_logging(ConstantAccess):
             The value prior to the change, or the current value if no
             new value was specified.
 
-    **Examples:**
+    **Examples**
 
     >>> cf.regrid_logging()
     False
@@ -702,7 +702,7 @@ class collapse_parallel_mode(ConstantAccess):
             The value prior to the change, or the current value if no
             new value was specified.
 
-    **Examples:**
+    **Examples**
 
     >>> cf.collapse_parallel_mode()
     0
@@ -763,7 +763,7 @@ class relaxed_identities(ConstantAccess):
             The value prior to the change, or the current value if no
             new value was specified.
 
-    **Examples:**
+    **Examples**
 
     >>> org = cf.relaxed_identities()
     >>> org
@@ -895,7 +895,7 @@ class tempdir(ConstantAccess):
             The directory prior to the change, or the current
             directory if no new value was specified.
 
-    **Examples:**
+    **Examples**
 
     >>> cf.tempdir()
     '/tmp'
@@ -964,7 +964,7 @@ class of_fraction(ConstantAccess):
             The value prior to the change, or the current value if no
             new value was specified.
 
-    **Examples:**
+    **Examples**
 
     >>> cf.of_fraction()
     0.5
@@ -1169,7 +1169,7 @@ class bounds_combination_mode(ConstantAccess):
             The value prior to the change, or the current value if no
             new value was specified.
 
-    **Examples:**
+    **Examples**
 
     >>> old = cf.bounds_combination_mode()
     >>> print(old)
@@ -1274,7 +1274,7 @@ def fm_threshold():
         `float`
             The amount of memory in bytes.
 
-    **Examples:**
+    **Examples**
 
     >>> cf.fm_threshold()
     10000000000.0
@@ -1426,7 +1426,7 @@ def FM_THRESHOLD(*new_fm_threshold):
 #             The value prior to the change, or the current value if no
 #             new value was specified.
 #
-#     **Examples:**
+#     **Examples**
 #
 #     >>> org = cf.IGNORE_IDENTITIES()
 #     >>> print(org)
@@ -1468,7 +1468,7 @@ def dump(x, **kwargs):
 
         None
 
-    **Examples:**
+    **Examples**
 
     >>> x = 3.14159
     >>> cf.dump(x)
@@ -1514,7 +1514,7 @@ if _linux:
                 Whether or not the number of open files exceeds the
                 threshold.
 
-        **Examples:**
+        **Examples**
 
         In this example, the number of open files is 75% of the maximum
         possible number of concurrently open files:
@@ -1556,7 +1556,7 @@ else:
                 Whether or not the number of open files exceeds the
                 threshold.
 
-        **Examples:**
+        **Examples**
 
         In this example, the number of open files is 75% of the maximum
         possible number of concurrently open files:
@@ -1601,7 +1601,7 @@ def close_files(file_format=None):
 
         None
 
-    **Examples:**
+    **Examples**
 
     >>> cf.close_files()
     >>> cf.close_files('netCDF')
@@ -1648,7 +1648,7 @@ def close_one_file(file_format=None):
 
         `None`
 
-    **Examples:**
+    **Examples**
 
     >>> cf.close_one_file()
     >>> cf.close_one_file('netCDF')
@@ -1706,7 +1706,7 @@ def open_files(file_format=None):
             is the dictionary that would have been returned if the
             *file_format* parameter was set.
 
-    **Examples:**
+    **Examples**
 
     >>> cf.open_files()
     {'netCDF': {'file1.nc': <netCDF4.Dataset at 0x187b6d0>}}
@@ -1782,7 +1782,7 @@ def _numpy_allclose(a, b, rtol=None, atol=None, verbose=None):
         `bool`
             Returns True if the arrays are equal, otherwise False.
 
-    **Examples:**
+    **Examples**
 
     >>> cf._numpy_allclose([1, 2], [1, 2])
     True
@@ -1896,7 +1896,7 @@ def parse_indices(
 
         `list` [, `dict`]
 
-    **Examples:**
+    **Examples**
 
     >>> cf.parse_indices((5, 8), ([1, 2, 4, 6],))
     [array([1, 2, 4, 6]), slice(0, 8, 1)]
@@ -2325,7 +2325,7 @@ def equivalent(x, y, rtol=None, atol=None, traceback=False):
         `bool`
             Whether or not the two objects are equivalent.
 
-    **Examples:**
+    **Examples**
 
     >>> f
     <CF Field: rainfall_rate(latitude(10), longitude(20)) kg m2 s-1>
@@ -2436,7 +2436,7 @@ def load_stash2standard_name(table=None, delimiter="!", merge=True):
         `dict`
             The new STASH to standard name conversion table.
 
-    **Examples:**
+    **Examples**
 
     >>> cf.load_stash2standard_name()
     >>> cf.load_stash2standard_name('my_table.txt')
@@ -2584,7 +2584,7 @@ def flat(x):
         generator
             An iterator over flattened sequence.
 
-    **Examples:**
+    **Examples**
 
     >>> cf.flat([1, [2, [3, 4]]])
     <generator object flat at 0x3649cd0>
@@ -2670,7 +2670,7 @@ def abspath(filename):
             The normalized absolutised version of *filename*, or
             `None`.
 
-    **Examples:**
+    **Examples**
 
     >>> import os
     >>> os.getcwd()
@@ -2717,7 +2717,7 @@ def relpath(filename, start=None):
         `str`
             The relative path.
 
-    **Examples:**
+    **Examples**
 
     >>> cf.relpath('/data/archive/file.nc')
     '../file.nc'
@@ -2755,7 +2755,7 @@ def dirname(filename):
         `str`
             The directory name.
 
-    **Examples:**
+    **Examples**
 
     >>> cf.dirname('/data/archive/file.nc')
     '/data/archive'
@@ -2792,7 +2792,7 @@ def pathjoin(path1, path2):
         `str`
             The joined paths.
 
-    **Examples:**
+    **Examples**
 
     >>> cf.pathjoin('/data/archive', '../archive/file.nc')
     '/data/archive/../archive/file.nc'
@@ -2832,7 +2832,7 @@ def hash_array(array):
         `int`
             The hash value.
 
-    **Examples:**
+    **Examples**
 
     >>> print(array)
     [[0 1 2 3]]
@@ -2927,7 +2927,7 @@ def broadcast_array(array, shape):
 
         `numpy.ndarray`
 
-    **Examples:**
+    **Examples**
 
 
     >>> a = numpy.arange(8).reshape(2, 4)
@@ -3012,7 +3012,7 @@ def allclose(x, y, rtol=None, atol=None):
         `bool`
             Returns True if the arrays are equal, otherwise False.
 
-    **Examples:**
+    **Examples**
 
     """
     if rtol is None:
@@ -3099,7 +3099,7 @@ def _section(
             The list of m dimensional sections of the Field or the
             dictionary of m dimensional sections of the Data object.
 
-    **Examples:**
+    **Examples**
 
     Section a field into 2D longitude/time slices, checking the units:
 
@@ -3257,7 +3257,7 @@ def environment(display=True, paths=True):
             environment is printed and `None` is returned. Otherwise
             the description is returned as a string.
 
-    **Examples:**
+    **Examples**
 
     >>> cf.environment()
     Platform: Linux-5.4.0-58-generic-x86_64-with-debian-bullseye-sid
@@ -3338,7 +3338,7 @@ def default_netCDF_fillvals():
         `dict`
             The fill values, keyed by `numpy` data type strings
 
-    **Examples:**
+    **Examples**
 
     >>> cf.default_netCDF_fillvals()
     {'S1': '\x00',

--- a/cf/maths.py
+++ b/cf/maths.py
@@ -267,7 +267,7 @@ def histogram(*digitized):
         `Field`
             The field construct containing the histogram.
 
-    **Examples:**
+    **Examples**
 
     Create a one-dimensional histogram based on 10 equally-sized bins
     that exactly span the data range:

--- a/cf/mixin/coordinate.py
+++ b/cf/mixin/coordinate.py
@@ -31,7 +31,7 @@ class Coordinate:
 
         .. seealso:: `T`, `X`, `~cf.Coordinate.Y`, `Z`
 
-        **Examples:**
+        **Examples**
 
         >>> c.X
         True
@@ -69,7 +69,7 @@ class Coordinate:
 
         .. seealso:: `ctype`, `X`, `~cf.Coordinate.Y`, `Z`
 
-        **Examples:**
+        **Examples**
 
         >>> c = cf.{{class}}()
         >>> c.Units = cf.Units('seconds since 1992-10-08')
@@ -107,7 +107,7 @@ class Coordinate:
 
         .. seealso:: `ctype`, `T`, `~cf.Coordinate.Y`, `Z`
 
-        **Examples:**
+        **Examples**
 
         >>> f = cf.example_field(0)
         >>> print(f)
@@ -171,7 +171,7 @@ class Coordinate:
 
         .. seealso:: `ctype`, `T`, `X`, `Z`
 
-        **Examples:**
+        **Examples**
 
         >>> c.Units
         <CF Units: degree_north>
@@ -230,7 +230,7 @@ class Coordinate:
 
         .. seealso:: `ctype`, `T`, `X`, `~cf.Coordinate.Y`
 
-        **Examples:**
+        **Examples**
 
         >>> c.Units
         <CF Units: Pa>
@@ -310,7 +310,7 @@ class Coordinate:
         values `'X'` and `'Y'` being used to identify horizontal
         coordinates).
 
-        **Examples:**
+        **Examples**
 
         >>> c.axis = 'Y'
         >>> c.axis
@@ -348,7 +348,7 @@ class Coordinate:
         the surface as 0 and the depth of 1000 meters as 1000 then the
         `postive` property will have the value `'down'`.
 
-        **Examples:**
+        **Examples**
 
         >>> c.positive = 'up'
         >>> c.positive
@@ -403,7 +403,7 @@ class Coordinate:
 
             TODO
 
-        **Examples:**
+        **Examples**
 
         TODO
 
@@ -495,7 +495,7 @@ class Coordinate:
 
                 The identity.
 
-        **Examples:**
+        **Examples**
 
         >>> f.properties()
         {'foo': 'bar',
@@ -587,7 +587,7 @@ class Coordinate:
             `list`
                 The identities.
 
-        **Examples:**
+        **Examples**
 
         >>> f.properties()
         {'foo': 'bar',

--- a/cf/mixin/fielddomain.py
+++ b/cf/mixin/fielddomain.py
@@ -73,7 +73,7 @@ class FieldDomain:
 
             `set`
 
-        **Examples:**
+        **Examples**
 
         >>> f._coordinate_reference_axes('coordinatereference0')
 
@@ -109,7 +109,7 @@ class FieldDomain:
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> f._conform_coordinate_references('auxiliarycoordinate1')
         >>> f._conform_coordinate_references('auxiliarycoordinate1',
@@ -794,7 +794,7 @@ class FieldDomain:
 
                 The shifts corresponding to each rolled axis.
 
-        **Examples:**
+        **Examples**
 
         """
         if isinstance(shift, Integral):
@@ -960,7 +960,7 @@ class FieldDomain:
     def rank(self):
         """The number of axes in the domain.
 
-        **Examples:**
+        **Examples**
 
         TODO
 
@@ -1049,7 +1049,7 @@ class FieldDomain:
 
             `dict`
 
-        **Examples:**
+        **Examples**
 
         >>> f.iscyclic('X')
         True
@@ -1340,7 +1340,7 @@ class FieldDomain:
 
                         The removed coordinate reference construct.
 
-                **Examples:**
+                **Examples**
 
                 >>> f.del_coordinate_reference('rotated_latitude_longitude')
                 <CF CoordinateReference: rotated_latitude_longitude>
@@ -1477,7 +1477,7 @@ class FieldDomain:
             `DomainAxis`
                 The removed domain axis construct.
 
-        **Examples:**
+        **Examples**
 
         >>> f = cf.example_field(0)
         >>> g = f[0]
@@ -1590,7 +1590,7 @@ class FieldDomain:
 
                 {{Returns construct}}
 
-        **Examples:**
+        **Examples**
 
         """
         return self._construct(
@@ -1653,7 +1653,7 @@ class FieldDomain:
 
                 {{Returns construct}}
 
-        **Examples:**
+        **Examples**
 
         """
         return self._construct(
@@ -1719,7 +1719,7 @@ class FieldDomain:
 
                 {{Returns construct}}
 
-        **Examples:**
+        **Examples**
 
         """
         return self._construct(
@@ -1785,7 +1785,7 @@ class FieldDomain:
 
                 {{Returns construct}}
 
-        **Examples:**
+        **Examples**
 
         """
         return self._construct(
@@ -1853,7 +1853,7 @@ class FieldDomain:
 
                 {{Returns construct}}
 
-        **Examples:**
+        **Examples**
 
         """
         return self._construct(
@@ -1917,7 +1917,7 @@ class FieldDomain:
                         constructs used by the selected coordinate reference
                         construct.
 
-                **Examples:**
+                **Examples**
 
                 >>> f.coordinate_reference_domain_axes('coordinatereference0')
                 {'domainaxis0', 'domainaxis1', 'domainaxis2'}
@@ -1987,7 +1987,7 @@ class FieldDomain:
                 cyclic prior to the new setting, or the current cyclic
                 domain axes if no axis was specified.
 
-        **Examples:**
+        **Examples**
 
         >>> f.cyclic()
         set()
@@ -2111,7 +2111,7 @@ class FieldDomain:
 
                 {{Returns construct}}
 
-        **Examples:**
+        **Examples**
 
         """
         return self._construct(
@@ -2168,7 +2168,7 @@ class FieldDomain:
             `bool`
                 Whether or not the domain axis is increasing.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.dimension_coordinate('X').array)
         array([  0  30  60])
@@ -2207,7 +2207,7 @@ class FieldDomain:
                 A dictionary whose key/value pairs are domain axis
                 keys and their directions.
 
-        **Examples:**
+        **Examples**
 
         >>> d.directions()
         {'domainaxis1': True, 'domainaxis1': False}
@@ -2276,7 +2276,7 @@ class FieldDomain:
 
                 {{Returns construct}}
 
-        **Examples:**
+        **Examples**
 
         """
         return self._construct(
@@ -2354,7 +2354,7 @@ class FieldDomain:
                 {{Returns construct}}
 
 
-        **Examples:**
+        **Examples**
 
         """
         return self._construct(
@@ -2434,7 +2434,7 @@ class FieldDomain:
                 The selected coordinate reference construct, or its
                 key.
 
-        **Examples:**
+        **Examples**
 
         """
         if construct is None:
@@ -2488,7 +2488,7 @@ class FieldDomain:
             `bool`
                 `True` if the construct exists, otherwise `False`.
 
-        **Examples:**
+        **Examples**
 
         >>> f = cf.example_field(0)
         >>> print(f)
@@ -2537,7 +2537,7 @@ class FieldDomain:
             `bool`
                 True if the selected axis is cyclic, otherwise False.
 
-        **Examples:**
+        **Examples**
 
         >>> f.iscyclic('X')
         True
@@ -2597,7 +2597,7 @@ class FieldDomain:
             `bool`
                 Whether or not at least one of the conditions are met.
 
-        **Examples:**
+        **Examples**
 
         >>> f.match_by_rank(3, 4)
 
@@ -2685,7 +2685,7 @@ class FieldDomain:
 
                 The construct that was replaced.
 
-        **Examples:**
+        **Examples**
 
         >>> f.replace_construct('X', new=X_construct)
 
@@ -2801,7 +2801,7 @@ class FieldDomain:
             `str`
                 The construct identifier for the construct.
 
-        **Examples:**
+        **Examples**
 
         >>> key = f.set_construct(c)
         >>> key = f.set_construct(c, copy=False)
@@ -3123,7 +3123,7 @@ def _create_auxiliary_mask_component(mask_shape, ind, compress):
         `Data`
             The mask array.
 
-    **Examples:**
+    **Examples**
 
     >>> f = cf.{{class}}()
     >>> d = _create_auxiliary_mask_component(

--- a/cf/mixin/fielddomainlist.py
+++ b/cf/mixin/fielddomainlist.py
@@ -133,7 +133,7 @@ class FieldDomainList:
             `bool`
                 The matching field constructs.
 
-        **Examples:**
+        **Examples**
 
             TODO
 
@@ -204,7 +204,7 @@ class FieldDomainList:
             `{{class}}`
                 The matching constructs.
 
-        **Examples:**
+        **Examples**
 
         >>> fl = cf.{{class}}([cf.example_field(0), cf.example_field(1)])
         >>> fl
@@ -280,7 +280,7 @@ class FieldDomainList:
             `{{class}}`
                 The matching constructs.
 
-        **Examples:**
+        **Examples**
 
         See `cf.{{class}}.select_by_identity`
 
@@ -324,7 +324,7 @@ class FieldDomainList:
             `bool`
                 The matching field constructs.
 
-        **Examples:**
+        **Examples**
 
             TODO
 

--- a/cf/mixin/properties.py
+++ b/cf/mixin/properties.py
@@ -122,7 +122,7 @@ class Properties(Container):
 
         .. seealso:: `identity`, `identities`
 
-        **Examples:**
+        **Examples**
 
         >>> f = {{package}}.{{class}}()
         >>> f.id = "foo"
@@ -161,7 +161,7 @@ class Properties(Container):
         The calendar used for encoding time data. See
         http://cfconventions.org/latest.html for details.
 
-        **Examples:**
+        **Examples**
 
         >>> f.calendar = 'noleap'
         >>> f.calendar
@@ -193,7 +193,7 @@ class Properties(Container):
         Miscellaneous information about the data or methods used to
         produce it. See http://cfconventions.org/latest.html for details.
 
-        **Examples:**
+        **Examples**
 
         >>> f.comment = 'This simulation was done on an HP-35 calculator'
         >>> f.comment
@@ -225,7 +225,7 @@ class Properties(Container):
         A list of the applications that have modified the original
         data. See http://cfconventions.org/latest.html for details.
 
-        **Examples:**
+        **Examples**
 
         >>> f.history = 'created on 2012/10/01'
         >>> f.history
@@ -258,7 +258,7 @@ class Properties(Container):
         user defined calendar. See http://cfconventions.org/latest.html
         for details.
 
-        **Examples:**
+        **Examples**
 
         >>> f.leap_month = 2
         >>> f.leap_month
@@ -292,7 +292,7 @@ class Properties(Container):
         of four are also leap years. See
         http://cfconventions.org/latest.html for details.
 
-        **Examples:**
+        **Examples**
 
         >>> f.leap_year = 1984
         >>> f.leap_year
@@ -325,7 +325,7 @@ class Properties(Container):
         is not standardized. See http://cfconventions.org/latest.html for
         details.
 
-        **Examples:**
+        **Examples**
 
         >>> f.long_name = 'zonal_wind'
         >>> f.long_name
@@ -360,7 +360,7 @@ class Properties(Container):
 
         Stored as a tuple but may be set as any array-like object.
 
-        **Examples:**
+        **Examples**
 
         >>> f.month_lengths = numpy.array(
         ...     [34, 31, 32, 30, 29, 27, 28, 28, 28, 32, 32, 34])
@@ -396,7 +396,7 @@ class Properties(Container):
         (http://cfconventions.org/standard-names.html). See
         http://cfconventions.org/latest.html for details.
 
-        **Examples:**
+        **Examples**
 
         >>> f.standard_name = 'time'
         >>> f.standard_name
@@ -430,7 +430,7 @@ class Properties(Container):
         (http://www.unidata.ucar.edu/software/udunits). See
         http://cfconventions.org/latest.html for details.
 
-        **Examples:**
+        **Examples**
 
         >>> f.units = 'K'
         >>> f.units
@@ -462,7 +462,7 @@ class Properties(Container):
         The largest valid value of the data. See
         http://cfconventions.org/latest.html for details.
 
-        **Examples:**
+        **Examples**
 
         >>> f.valid_max = 100.0
         >>> f.valid_max
@@ -494,7 +494,7 @@ class Properties(Container):
         The smallest valid value of the data. See
         http://cfconventions.org/latest.html for details.
 
-        **Examples:**
+        **Examples**
 
         >>> f.valid_min = 8.0
         >>> f.valid_min
@@ -528,7 +528,7 @@ class Properties(Container):
 
         Stored as a tuple but may be set as any array-like object.
 
-        **Examples:**
+        **Examples**
 
         >>> f.valid_range = numpy.array([100., 400.])
         >>> f.valid_range
@@ -585,7 +585,7 @@ class Properties(Container):
                 The value of the named property or the default value, if
                 set.
 
-        **Examples:**
+        **Examples**
 
         >>> f = cf.{{class}}()
         >>> f.set_property('project', 'CMIP7')
@@ -637,7 +637,7 @@ class Properties(Container):
              `bool`
                 `True` if the property has been set, otherwise `False`.
 
-        **Examples:**
+        **Examples**
 
         >>> f = cf.{{class}}()
         >>> f.set_property('project', 'CMIP7')
@@ -688,7 +688,7 @@ class Properties(Container):
 
                 The removed property.
 
-        **Examples:**
+        **Examples**
 
         >>> f = cf.{{class}}()
         >>> f.set_property('project', 'CMIP7')
@@ -769,7 +769,7 @@ class Properties(Container):
             `bool`
                 Whether or not at least one of the conditions are met.
 
-        **Examples:**
+        **Examples**
 
         >>> f.match_by_identity('time')
 
@@ -822,7 +822,7 @@ class Properties(Container):
             `bool`
                 Whether or not at least one of the conditions are met.
 
-        **Examples:**
+        **Examples**
 
         >>> f.nc_get_variable()
         'time'
@@ -912,7 +912,7 @@ class Properties(Container):
             `bool`
                 Whether or not the conditions are met.
 
-        **Examples:**
+        **Examples**
 
         >>> f.match_by_property(standard_name='longitude')
 
@@ -972,7 +972,7 @@ class Properties(Container):
             `dict`
                 The properties.
 
-        **Examples:**
+        **Examples**
 
         >>> f.properties()
         {}
@@ -1030,7 +1030,7 @@ class Properties(Container):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> f.properties()
         {}
@@ -1083,7 +1083,7 @@ class Properties(Container):
 
              `None`
 
-        **Examples:**
+        **Examples**
 
         >>> f = cf.{{class}}()
         >>> f.set_property('project', 'CMIP7')

--- a/cf/mixin/propertiesdata.py
+++ b/cf/mixin/propertiesdata.py
@@ -76,7 +76,7 @@ class PropertiesData(Properties):
 
             `Data`
 
-        **Examples:**
+        **Examples**
 
         >>> f.data
         <CF Data(12): [14, ..., 56] km)
@@ -556,7 +556,7 @@ class PropertiesData(Properties):
                 A new construct, or the same construct if the operation
                 was in-place.
 
-        **Examples:**
+        **Examples**
 
         >>> w = u._binary_operation(u, '__add__')
         >>> w = u._binary_operation(v, '__lt__')
@@ -684,7 +684,7 @@ class PropertiesData(Properties):
     #
     #        `None`
     #
-    #    **Examples:**
+    #    **Examples**
     #
     #    >>> f._change_axis_names({'0': 'dim1', '1': 'dim2'})
     #
@@ -868,7 +868,7 @@ class PropertiesData(Properties):
                 A new construct, or the same construct if the operation
                 was in-place.
 
-        **Examples:**
+        **Examples**
 
         >>> print(v.array)
         [1 2 -3 -4 -5]
@@ -987,7 +987,7 @@ class PropertiesData(Properties):
 
         .. seealso:: `X`, `Y`, `Z`
 
-        **Examples:**
+        **Examples**
 
         >>> c.T
         False
@@ -1001,7 +1001,7 @@ class PropertiesData(Properties):
 
         .. seealso:: `T`, `Y`, `Z`
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.X)
         False
@@ -1015,7 +1015,7 @@ class PropertiesData(Properties):
 
         .. seealso:: `T`, `X`, `Z`
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.Y)
         False
@@ -1029,7 +1029,7 @@ class PropertiesData(Properties):
 
         .. seealso:: `T`, `X`, `Y`
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.Z)
         False
@@ -1044,7 +1044,7 @@ class PropertiesData(Properties):
         The binary mask's data comprises dimensionless 32-bit integers
         that are 0 where the data has missing values and 1 otherwise.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.mask.array)
         [[ True  False  True False]]
@@ -1151,7 +1151,7 @@ class PropertiesData(Properties):
         consistent manner. These are mirrored by the `units` and
         `calendar` CF properties respectively.
 
-        **Examples:**
+        **Examples**
 
         >>> f.Units
         <Units: K>
@@ -1211,7 +1211,7 @@ class PropertiesData(Properties):
 
         .. seealso:: `month`, `day`, `hour`, `minute`, `second`
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.datetime_array)
         [0450-11-15 00:00:00  0450-12-16 12:30:00  0451-01-16 12:00:45]
@@ -1229,7 +1229,7 @@ class PropertiesData(Properties):
 
         .. seealso:: `year`, `day`, `hour`, `minute`, `second`
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.datetime_array)
         [0450-11-15 00:00:00  0450-12-16 12:30:00  0451-01-16 12:00:45]
@@ -1247,7 +1247,7 @@ class PropertiesData(Properties):
 
         .. seealso:: `year`, `month`, `hour`, `minute`, `second`
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.datetime_array)
         [0450-11-15 00:00:00  0450-12-16 12:30:00  0451-01-16 12:00:45]
@@ -1265,7 +1265,7 @@ class PropertiesData(Properties):
 
         .. seealso:: `year`, `month`, `day`, `minute`, `second`
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.datetime_array)
         [0450-11-15 00:00:00  0450-12-16 12:30:00  0451-01-16 12:00:45]
@@ -1283,7 +1283,7 @@ class PropertiesData(Properties):
 
         .. seealso:: `year`, `month`, `day`, `hour`, `second`
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.datetime_array)
         [0450-11-15 00:00:00  0450-12-16 12:30:00  0451-01-16 12:00:45]
@@ -1301,7 +1301,7 @@ class PropertiesData(Properties):
 
         .. seealso:: `year`, `month`, `day`, `hour`, `minute`
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.datetime_array)
         [0450-11-15 00:00:00  0450-12-16 12:30:00  0451-01-16 12:00:45]
@@ -1319,7 +1319,7 @@ class PropertiesData(Properties):
 
         .. seealso:: `binary_mask`
 
-        **Examples:**
+        **Examples**
 
         >>> f.shape
         (12, 73, 96)
@@ -1365,7 +1365,7 @@ class PropertiesData(Properties):
         before the data are scaled. See
         http://cfconventions.org/latest.html for details.
 
-        **Examples:**
+        **Examples**
 
         >>> f.add_offset = -4.0
         >>> f.add_offset
@@ -1401,7 +1401,7 @@ class PropertiesData(Properties):
         The calendar used for encoding time data. See
         http://cfconventions.org/latest.html for details.
 
-        **Examples:**
+        **Examples**
 
         >>> f.calendar = 'noleap'
         >>> f.calendar
@@ -1465,7 +1465,7 @@ class PropertiesData(Properties):
         .. seealso:: `fill_value`, `missing_value`,
                      `cf.default_netCDF_fillvals`
 
-        **Examples:**
+        **Examples**
 
         >>> f._FillValue = -1.0e30
         >>> f._FillValue
@@ -1509,7 +1509,7 @@ class PropertiesData(Properties):
         .. seealso:: `_FillValue`, `fill_value`,
                      `cf.default_netCDF_fillvals`
 
-        **Examples:**
+        **Examples**
 
         >>> f.missing_value = 1.0e30
         >>> f.missing_value
@@ -1544,7 +1544,7 @@ class PropertiesData(Properties):
         properties are present, the offset is subtracted before the data
         are scaled. See http://cfconventions.org/latest.html for details.
 
-        **Examples:**
+        **Examples**
 
         >>> f.scale_factor = 10.0
         >>> f.scale_factor
@@ -1579,7 +1579,7 @@ class PropertiesData(Properties):
         (http://www.unidata.ucar.edu/software/udunits). See
         http://cfconventions.org/latest.html for details.
 
-        **Examples:**
+        **Examples**
 
         >>> f.units = 'K'
         >>> f.units
@@ -1659,7 +1659,7 @@ class PropertiesData(Properties):
             `{{class}}` or `None`
                 TODO
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.array)
         [ 0.  1.]
@@ -1708,7 +1708,7 @@ class PropertiesData(Properties):
             `Data`
                 The maximum of the data array.
 
-        **Examples:**
+        **Examples**
 
         >>> f.data
         <CF Data(12, 64, 128): [[[236.512756, ..., 256.93371]]] K>
@@ -1736,7 +1736,7 @@ class PropertiesData(Properties):
             `Data`
                 The unweighted mean the data array.
 
-        **Examples:**
+        **Examples**
 
         >>> f.data
         <CF Data(12, 73, 96): [[[236.512756348, ..., 256.93371582]]] K>
@@ -1765,7 +1765,7 @@ class PropertiesData(Properties):
                 The unweighted average of the maximum and minimum of the
                 data array.
 
-        **Examples:**
+        **Examples**
 
         >>> f.data
         <CF Data(12, 73, 96): [[[236.512756348, ..., 256.93371582]]] K>
@@ -1793,7 +1793,7 @@ class PropertiesData(Properties):
             `Data`
                 The minimum of the data array.
 
-        **Examples:**
+        **Examples**
 
         >>> f.data
         <CF Data(12, 73, 96): [[[236.512756348, ..., 256.93371582]]] K>
@@ -1834,7 +1834,7 @@ class PropertiesData(Properties):
                 no *value* was specified. `None` is always returned if the
                 period had not been set previously.
 
-        **Examples:**
+        **Examples**
 
         >>> print(c.period())
         None
@@ -1910,7 +1910,7 @@ class PropertiesData(Properties):
                 The absolute difference between the maximum and minimum of
                 the data array.
 
-        **Examples:**
+        **Examples**
 
         >>> f.data
         <CF Data(12, 73, 96): [[[236.512756348, ..., 256.93371582]]] K>
@@ -1937,7 +1937,7 @@ class PropertiesData(Properties):
             `Data`
                 The number of non-missing data elements in the data array.
 
-        **Examples:**
+        **Examples**
 
         >>> f.data
         <CF Data(12, 73, 96): [[[236.512756348, ..., 256.93371582]]] K>
@@ -1964,7 +1964,7 @@ class PropertiesData(Properties):
             `Data`
                 The unweighted standard deviation of the data array.
 
-        **Examples:**
+        **Examples**
 
         >>> f.data
         <CF Data(12, 73, 96): [[[236.512756348, ..., 256.93371582]]] K>
@@ -1996,7 +1996,7 @@ class PropertiesData(Properties):
             `Data`
                 The sum of the data array.
 
-        **Examples:**
+        **Examples**
 
         >>> f.data
         <CF Data(12, 73, 96): [[[236.512756348, ..., 256.93371582]]] K>
@@ -2034,7 +2034,7 @@ class PropertiesData(Properties):
                 The construct with data with swapped axis positions. If
                 the operation was in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> f.shape
         (1, 2, 3)
@@ -2067,7 +2067,7 @@ class PropertiesData(Properties):
             `Data`
                 The unweighted variance of the data array.
 
-        **Examples:**
+        **Examples**
 
         >>> f.data
         <CF Data(12, 73, 96): [[[236.512756348, ..., 256.93371582]]] K>
@@ -2115,7 +2115,7 @@ class PropertiesData(Properties):
           along each dimension (similar to the way vector subscripts work
           in Fortran), rather than by their elements.
 
-        **Examples:**
+        **Examples**
 
         TODO
 
@@ -2128,7 +2128,7 @@ class PropertiesData(Properties):
     #
     #    .. seealso:: `data`, `has_data`, `ndim`, `size`
     #
-    #    **Examples:**
+    #    **Examples**
     #
     #    >>> f.shape
     #    (73, 96)
@@ -2157,7 +2157,7 @@ class PropertiesData(Properties):
     #
     #    .. seealso:: `data`, `has_data`, `isscalar`, `shape`
     #
-    #    **Examples:**
+    #    **Examples**
     #
     #    >>> f.has_data()
     #    True
@@ -2181,7 +2181,7 @@ class PropertiesData(Properties):
     #
     #    .. seealso:: `data`, `has_data`, `ndim`, `shape`
     #
-    #    **Examples:**
+    #    **Examples**
     #
     #    >>> f.shape
     #    (73, 96)
@@ -2221,7 +2221,7 @@ class PropertiesData(Properties):
 
         .. seealso:: `array`, `varray`
 
-        **Examples:**
+        **Examples**
 
         >>> f.units
         'days since 2000-01-01'
@@ -2268,7 +2268,7 @@ class PropertiesData(Properties):
         reinstated default data type may be different to the data type
         prior to `dtype` being set.
 
-        **Examples:**
+        **Examples**
 
         >>> f.dtype
         dtype('float64')
@@ -2333,7 +2333,7 @@ class PropertiesData(Properties):
 
         .. seealso:: `where`, `subspace`, `__setitem__`
 
-        **Examples:**
+        **Examples**
 
         >>> f.hardmask = False
         >>> f.hardmask
@@ -2372,7 +2372,7 @@ class PropertiesData(Properties):
 
         .. seealso:: `data`, `datetime_array`, `varray`
 
-        **Examples:**
+        **Examples**
 
         >>> f.data
         <CF Data(5): [0, ... 4] kg m-1 s-2>
@@ -2406,7 +2406,7 @@ class PropertiesData(Properties):
 
         .. seealso:: `array`, `data`, `datetime_array`
 
-        **Examples:**
+        **Examples**
 
         >>> f.data
         <CF Data(5): [0, ... 4] kg m-1 s-2>
@@ -2438,7 +2438,7 @@ class PropertiesData(Properties):
 
         .. seealso:: `has_data`, `ndim`
 
-        **Examples:**
+        **Examples**
 
         >>> f.ndim
         0
@@ -2486,7 +2486,7 @@ class PropertiesData(Properties):
                 The construct with the ceiling of the data. If the
                 operation was in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.array)
         [-1.9 -1.5 -1.1 -1.   0.   1.   1.1  1.5  1.9]
@@ -2557,7 +2557,7 @@ class PropertiesData(Properties):
                 The construct with clipped data. If the operation was
                 in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> g = f.clip(-90, 90)
         >>> g = f.clip(-90, 90, 'degrees_north')
@@ -2584,7 +2584,7 @@ class PropertiesData(Properties):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> f.close()
 
@@ -2665,7 +2665,7 @@ class PropertiesData(Properties):
     #        of data values. If the operation was in-place then `None` is
     #        returned.
     #
-    #    **Examples:**
+    #    **Examples**
     #
     #    TODO
     #
@@ -2710,7 +2710,7 @@ class PropertiesData(Properties):
                 The construct with the cosine of data values. If the
                 operation was in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> f.Units
         <Units: degrees_east>
@@ -2749,7 +2749,7 @@ class PropertiesData(Properties):
             `int`
                 The number of non-masked elements.
 
-        **Examples:**
+        **Examples**
 
         >>> n = f.count()
 
@@ -2768,7 +2768,7 @@ class PropertiesData(Properties):
             `int`
                 The number of masked elements.
 
-        **Examples:**
+        **Examples**
 
         >>> n = f.count_masked()
 
@@ -2798,7 +2798,7 @@ class PropertiesData(Properties):
 
             `!set`
 
-        **Examples:**
+        **Examples**
 
         >>> f.cyclic()
         set()
@@ -2866,7 +2866,7 @@ class PropertiesData(Properties):
                 A copy of the specified element of the array as a suitable
                 Python scalar.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.array)
         2
@@ -3010,7 +3010,7 @@ class PropertiesData(Properties):
             `bool`
                 Whether the two instances are equal.
 
-        **Examples:**
+        **Examples**
 
         >>> f.equals(f)
         True
@@ -3209,7 +3209,7 @@ class PropertiesData(Properties):
             `{{class}}` or `None`
                 The construct with converted reference time data values.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.array)
         [1  2  3  4]
@@ -3398,7 +3398,7 @@ class PropertiesData(Properties):
                 The construct with floored data. If the operation was
                 in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.array)
         [-1.9 -1.5 -1.1 -1.   0.   1.   1.1  1.5  1.9]
@@ -3439,7 +3439,7 @@ class PropertiesData(Properties):
             `bool`
                 Whether or not there is a match.
 
-        **Examples:**
+        **Examples**
 
         >>> f.ndim
         3
@@ -3503,7 +3503,7 @@ class PropertiesData(Properties):
             `bool`
                 Whether or not there is a match.
 
-        **Examples:**
+        **Examples**
 
         >>> f.units
         'metres'
@@ -3564,7 +3564,7 @@ class PropertiesData(Properties):
             `bool`
                 Whether to not all data elements evaluate to True.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.array)
         [[0  3  0]]
@@ -3620,7 +3620,7 @@ class PropertiesData(Properties):
                 Returns `True` if the data are equal within the given
                 tolerance; `False` otherwise.
 
-        **Examples:**
+        **Examples**
 
         >>> x = f.allclose(g)
 
@@ -3661,7 +3661,7 @@ class PropertiesData(Properties):
             `bool`
                 Whether to not any data elements evaluate to `True`.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.array)
         [[0  0  0]]
@@ -3725,7 +3725,7 @@ class PropertiesData(Properties):
                 The missing data value or, if one has not been set, the
                 value specified by *default*
 
-        **Examples:**
+        **Examples**
 
         >>> f.fill_value()
         None
@@ -3790,7 +3790,7 @@ class PropertiesData(Properties):
                 The construct with flipped axes, or `None` if the
                 operation was in-place.
 
-        **Examples:**
+        **Examples**
 
         >>> f.flip()
         >>> f.flip(1)
@@ -3831,7 +3831,7 @@ class PropertiesData(Properties):
                 The construct with the exponential of data values. If
                 the operation was in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> f.data
         <CF Data(1, 2): [[1, 2]]>
@@ -3886,7 +3886,7 @@ class PropertiesData(Properties):
                 The construct with the sine of data values. If the
                 operation was in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> f.Units
         <Units: degrees_north>
@@ -3945,7 +3945,7 @@ class PropertiesData(Properties):
                 of data values. If the operation was in-place then
                 `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.array)
         [[0.5 0.7]
@@ -3998,7 +3998,7 @@ class PropertiesData(Properties):
                 data values. If the operation was in-place then `None`
                 is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.array)
         [[0.5 0.7]
@@ -4053,7 +4053,7 @@ class PropertiesData(Properties):
                 data values. If the operation was in-place then `None`
                 is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.array)
         [[0.5 0.7]
@@ -4108,7 +4108,7 @@ class PropertiesData(Properties):
                 values.  If the operation was in-place then `None` is
                 returned.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.array)
         [[0.5 0.7]
@@ -4162,7 +4162,7 @@ class PropertiesData(Properties):
                 data values. If the operation was in-place then `None`
                 is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.array)
         [[0.5 0.7]
@@ -4217,7 +4217,7 @@ class PropertiesData(Properties):
                 data values. If the operation was in-place then `None`
                 is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.array)
         [[0.5 0.7]
@@ -4277,7 +4277,7 @@ class PropertiesData(Properties):
                 The construct with the tangent of data values. If the
                 operation was in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> f.Units
         <Units: degrees_north>
@@ -4340,7 +4340,7 @@ class PropertiesData(Properties):
                 values. If the operation was in-place then `None` is
                 returned.
 
-        **Examples:**
+        **Examples**
 
         >>> f.Units
         <Units: degrees_north>
@@ -4401,7 +4401,7 @@ class PropertiesData(Properties):
                 values. If the operation was in-place then `None` is
                 returned.
 
-        **Examples:**
+        **Examples**
 
         >>> f.Units
         <Units: degrees_north>
@@ -4462,7 +4462,7 @@ class PropertiesData(Properties):
                 values. If the operation was in-place then `None` is
                 returned.
 
-        **Examples:**
+        **Examples**
 
         >>> f.Units
         <Units: degrees_north>
@@ -4521,7 +4521,7 @@ class PropertiesData(Properties):
                 The construct with the logarithm of data values, or
                 `None` if the operation was in-place.
 
-        **Examples:**
+        **Examples**
 
         >>> f.data
         <CF Data(1, 2): [[1, 2]]>
@@ -4579,7 +4579,7 @@ class PropertiesData(Properties):
                 The construct with truncated data. If the operation
                 was in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.array)
         [-1.9 -1.5 -1.1 -1.   0.   1.   1.1  1.5  1.9]
@@ -4606,7 +4606,7 @@ class PropertiesData(Properties):
                 The unique data array values in a one dimensional `Data`
                 object.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.array)
         [[4 2 1]
@@ -4681,7 +4681,7 @@ class PropertiesData(Properties):
 
                 The identity.
 
-        **Examples:**
+        **Examples**
 
         >>> f.properties()
         {'foo': 'bar',
@@ -4785,7 +4785,7 @@ class PropertiesData(Properties):
                    `list`
                        The identities.
 
-               **Examples:**
+               **Examples**
 
                >>> f.properties()
                {'foo': 'bar',
@@ -4843,7 +4843,7 @@ class PropertiesData(Properties):
             `bool`
                 `True` if the selected axis is cyclic, otherwise `False`.
 
-        **Examples:**
+        **Examples**
 
         >>> f.iscyclic('X')
         True
@@ -4898,7 +4898,7 @@ class PropertiesData(Properties):
 
                 The data.
 
-        **Examples:**
+        **Examples**
 
         >>> d = cf.Data(range(10))
         >>> f.set_data(d)
@@ -5030,7 +5030,7 @@ class PropertiesData(Properties):
                 The expanded construct, or `None` if the operation was
                 in-place.
 
-        **Examples:**
+        **Examples**
 
             TODO
 
@@ -5085,7 +5085,7 @@ class PropertiesData(Properties):
             `{{class}}` or `None`
                 TODO
 
-        **Examples:**
+        **Examples**
 
         TODO
 
@@ -5143,7 +5143,7 @@ class PropertiesData(Properties):
 
         TODO
 
-        **Examples:**
+        **Examples**
 
         >>> f.Units
         <Units: hPa>
@@ -5199,7 +5199,7 @@ class PropertiesData(Properties):
                 The construct with rounded data. If the operation was
                 in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.array)
         [-1.9 -1.5 -1.1 -1.   0.   1.   1.1  1.5  1.9]
@@ -5250,7 +5250,7 @@ class PropertiesData(Properties):
                 The construct with rounded data. If the operation was
                 in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.array)
         [-1.81, -1.41, -1.01, -0.91,  0.09,  1.09,  1.19,  1.59,  1.99])
@@ -5292,7 +5292,7 @@ class PropertiesData(Properties):
             `{{class}}` or `None`
                 TODO
 
-        **Examples:**
+        **Examples**
 
         TODO
 
@@ -5337,7 +5337,7 @@ class PropertiesData(Properties):
                 otherwise return a new `{{class}}` instance containing
                 the new data.
 
-        **Examples:**
+        **Examples**
 
         >>> f = cf.{{class}}()
         >>> f.set_data([1, 2, 3])
@@ -5392,7 +5392,7 @@ class PropertiesData(Properties):
 
             TODO
 
-        **Examples:**
+        **Examples**
 
             TODO
 

--- a/cf/mixin/propertiesdatabounds.py
+++ b/cf/mixin/propertiesdatabounds.py
@@ -799,7 +799,7 @@ class PropertiesDataBounds(PropertiesData):
 
         .. versionadded:: 2.0
 
-        **Examples:**
+        **Examples**
 
         >>> print(c.bounds.array)
         [[-90. -87.]
@@ -840,7 +840,7 @@ class PropertiesDataBounds(PropertiesData):
 
         .. versionadded:: 2.0
 
-        **Examples:**
+        **Examples**
 
         >>> c.dtype
         dtype('float64')
@@ -911,7 +911,7 @@ class PropertiesDataBounds(PropertiesData):
 
         .. seealso:: `upper_bounds`
 
-        **Examples:**
+        **Examples**
 
         >>> print(c.array)
         [4  2  0]
@@ -949,7 +949,7 @@ class PropertiesDataBounds(PropertiesData):
         consistent manner. These are mirrored by the `units` and
         `calendar` CF properties respectively.
 
-        **Examples:**
+        **Examples**
 
         >>> f.Units
         <Units: K>
@@ -1020,7 +1020,7 @@ class PropertiesDataBounds(PropertiesData):
 
         .. seealso:: `lower_bounds`
 
-        **Examples:**
+        **Examples**
 
         >>> print(c.array)
         [4  2  0]
@@ -1083,7 +1083,7 @@ class PropertiesDataBounds(PropertiesData):
             `{{class}}` or `None`
                 The construct with masked elements.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.array)
         [ 0.  1.]
@@ -1151,7 +1151,7 @@ class PropertiesDataBounds(PropertiesData):
         reinstated default data type may be different to the data type
         prior to `dtype` being set.
 
-        **Examples:**
+        **Examples**
 
         >>> f.dtype
         dtype('float64')
@@ -1234,7 +1234,7 @@ class PropertiesDataBounds(PropertiesData):
                 The construct with the ceiling of the data. If the operation was
                 in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.array)
         [-1.9 -1.5 -1.1 -1.   0.   1.   1.1  1.5  1.9]
@@ -1265,7 +1265,7 @@ class PropertiesDataBounds(PropertiesData):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> c.chunksize()
 
@@ -1326,7 +1326,7 @@ class PropertiesDataBounds(PropertiesData):
                 The construct with clipped data. If the operation was
                 in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> g = f.clip(-90, 90)
         >>> g = f.clip(-90, 90, 'degrees_north')
@@ -1354,7 +1354,7 @@ class PropertiesDataBounds(PropertiesData):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >> c.close()
 
@@ -1454,7 +1454,7 @@ class PropertiesDataBounds(PropertiesData):
     #        of data values. If the operation was in-place then `None` is
     #        returned.
     #
-    #    **Examples:**
+    #    **Examples**
     #
     #    TODO
     #
@@ -1500,7 +1500,7 @@ class PropertiesDataBounds(PropertiesData):
                 The construct with the cosine of data values. If the
                 operation was in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> f.Units
         <Units: degrees_east>
@@ -1546,7 +1546,7 @@ class PropertiesDataBounds(PropertiesData):
 
             `set`
 
-        **Examples:**
+        **Examples**
 
             TODO
 
@@ -1685,7 +1685,7 @@ class PropertiesDataBounds(PropertiesData):
             `bool`
                 Whether or not the construct's cells are contiguous.
 
-        **Examples:**
+        **Examples**
 
         >>> c.has_bounds()
         False
@@ -1871,7 +1871,7 @@ class PropertiesDataBounds(PropertiesData):
                 The construct with converted reference time data
                 values.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.array)
         [1  2  3  4]
@@ -1934,7 +1934,7 @@ class PropertiesDataBounds(PropertiesData):
                 The value of the named property or the default value, if
                 set.
 
-        **Examples:**
+        **Examples**
 
         >>> f = cf.{{class}}()
         >>> f.set_property('project', 'CMIP7')
@@ -2060,7 +2060,7 @@ class PropertiesDataBounds(PropertiesData):
                 The construct with floored data. If the operation was
                 in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.array)
         [-1.9 -1.5 -1.1 -1.   0.   1.   1.1  1.5  1.9]
@@ -2089,7 +2089,7 @@ class PropertiesDataBounds(PropertiesData):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> c.direction()
         None
@@ -2110,7 +2110,7 @@ class PropertiesDataBounds(PropertiesData):
             `bool`
                 Whether or not the variable matches the given criteria.
 
-        **Examples:**
+        **Examples**
 
         TODO
 
@@ -2159,7 +2159,7 @@ class PropertiesDataBounds(PropertiesData):
             `bool`
                 Whether or not the variable matches the given criteria.
 
-        **Examples:**
+        **Examples**
 
             TODO
 
@@ -2212,7 +2212,7 @@ class PropertiesDataBounds(PropertiesData):
 
         TODO
 
-        **Examples:**
+        **Examples**
 
         TODO
 
@@ -2258,7 +2258,7 @@ class PropertiesDataBounds(PropertiesData):
 
                 TODO
 
-        **Examples:**
+        **Examples**
 
         >>> f.Units
         <Units: hPa>
@@ -2421,7 +2421,7 @@ class PropertiesDataBounds(PropertiesData):
                 The expanded data, or `None` if the operation was
                 in-place.
 
-        **Examples:**
+        **Examples**
 
         TODO
 
@@ -2466,7 +2466,7 @@ class PropertiesDataBounds(PropertiesData):
                 The construct with flipped axes, or `None` if the
                 operation was in-place.
 
-        **Examples:**
+        **Examples**
 
         >>> f.flip()
         >>> f.flip(1)
@@ -2543,7 +2543,7 @@ class PropertiesDataBounds(PropertiesData):
                 The construct with the exponential of data values. If the
                 operation was in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> f.data
         <CF Data(1, 2): [[1, 2]]>
@@ -2589,7 +2589,7 @@ class PropertiesDataBounds(PropertiesData):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> import numpy
         >>> b = {{package}}.Bounds(data=numpy.arange(10).reshape(5, 2))
@@ -2677,7 +2677,7 @@ class PropertiesDataBounds(PropertiesData):
                 The construct with the sine of data values. If the
                 operation was in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> f.Units
         <Units: degrees_north>
@@ -2734,7 +2734,7 @@ class PropertiesDataBounds(PropertiesData):
                 The construct with the trigonometric inverse tangent of data
                 values. If the operation was in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.array)
         [[0.5 0.7]
@@ -2783,7 +2783,7 @@ class PropertiesDataBounds(PropertiesData):
                 The construct with the inverse hyperbolic tangent of data
                 values. If the operation was in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.array)
         [[0.5 0.7]
@@ -2835,7 +2835,7 @@ class PropertiesDataBounds(PropertiesData):
                 The construct with the trigonometric inverse sine of data
                 values. If the operation was in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.array)
         [[0.5 0.7]
@@ -2887,7 +2887,7 @@ class PropertiesDataBounds(PropertiesData):
                 The construct with the inverse hyperbolic sine of data values.
                 If the operation was in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.array)
         [[0.5 0.7]
@@ -2938,7 +2938,7 @@ class PropertiesDataBounds(PropertiesData):
                 The construct with the trigonometric inverse cosine of data
                 values. If the operation was in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.array)
         [[0.5 0.7]
@@ -2992,7 +2992,7 @@ class PropertiesDataBounds(PropertiesData):
                 values. If the operation was in-place then `None` is
                 returned.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.array)
         [[0.5 0.7]
@@ -3051,7 +3051,7 @@ class PropertiesDataBounds(PropertiesData):
                 values. If the operation was in-place then `None` is
                 returned.
 
-        **Examples:**
+        **Examples**
 
         >>> f.Units
         <Units: degrees_north>
@@ -3110,7 +3110,7 @@ class PropertiesDataBounds(PropertiesData):
                 The construct with the hyperbolic sine of data values. If
                 the operation was in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> f.Units
         <Units: degrees_north>
@@ -3169,7 +3169,7 @@ class PropertiesDataBounds(PropertiesData):
                 values. If the operation was in-place then `None` is
                 returned.
 
-        **Examples:**
+        **Examples**
 
         >>> f.Units
         <Units: degrees_north>
@@ -3229,7 +3229,7 @@ class PropertiesDataBounds(PropertiesData):
                 The construct with the tangent of data values. If the
                 operation was in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> f.Units
         <Units: degrees_north>
@@ -3289,7 +3289,7 @@ class PropertiesDataBounds(PropertiesData):
                 The construct with the logarithm of data values. If the
                 operation was in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> f.data
         <CF Data(1, 2): [[1, 2]]>
@@ -3361,7 +3361,7 @@ class PropertiesDataBounds(PropertiesData):
                 The new construct with removed data axes. If the operation
                 was in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> f.shape
         (1, 73, 1, 96)
@@ -3409,7 +3409,7 @@ class PropertiesDataBounds(PropertiesData):
                 The construct with truncated data. If the operation was
                 in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.array)
         [-1.9 -1.5 -1.1 -1.   0.   1.   1.1  1.5  1.9]
@@ -3455,7 +3455,7 @@ class PropertiesDataBounds(PropertiesData):
     #           `list`
     #               The identities.
     #
-    #       **Examples:**
+    #       **Examples**
     #
     #       >>> f.properties()
     #       {'foo': 'bar',
@@ -3542,7 +3542,7 @@ class PropertiesDataBounds(PropertiesData):
 
                 The identity.
 
-        **Examples:**
+        **Examples**
 
         >>> f.properties()
         {'foo': 'bar',
@@ -3638,7 +3638,7 @@ class PropertiesDataBounds(PropertiesData):
                 no *value* was specified. `None` is always returned if the
                 period had not been set previously.
 
-        **Examples:**
+        **Examples**
 
         >>> print(c.period())
         None
@@ -3699,7 +3699,7 @@ class PropertiesDataBounds(PropertiesData):
                 The construct with rounded data. If the operation was
                 in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.array)
         [-1.9 -1.5 -1.1 -1.   0.   1.   1.1  1.5  1.9]
@@ -3757,7 +3757,7 @@ class PropertiesDataBounds(PropertiesData):
                 The construct with rounded data. If the operation was
                 in-place then `None` is returned.
 
-        **Examples:**
+        **Examples**
 
         >>> print(f.array)
         [-1.81, -1.41, -1.01, -0.91,  0.09,  1.09,  1.19,  1.59,  1.99])
@@ -3799,7 +3799,7 @@ class PropertiesDataBounds(PropertiesData):
             `{{class}}` or `None`
                 TODO
 
-        **Examples:**
+        **Examples**
 
         TODO
 

--- a/cf/query.py
+++ b/cf/query.py
@@ -350,7 +350,7 @@ class Query:
     def attr(self):
         """The object attribute on which to apply the query condition.
 
-        **Examples:**
+        **Examples**
 
         >>> q = cf.Query('ge', 4)
         >>> print(q.attr)
@@ -368,7 +368,7 @@ class Query:
 
         Compound conditions return `None`.
 
-        **Examples:**
+        **Examples**
 
         >>> q = cf.Query('ge', 4)
         >>> q.operator
@@ -386,7 +386,7 @@ class Query:
 
         An exception is raised for compound conditions.
 
-        **Examples:**
+        **Examples**
 
         >>> q = cf.Query('ge', 4)
         >>> q.value
@@ -419,7 +419,7 @@ class Query:
             `Query`
                 The new query object.
 
-        **Examples:**
+        **Examples**
 
         >>> q = cf.eq(2001)
         >>> q
@@ -457,7 +457,7 @@ class Query:
 
                 The deep copy.
 
-        **Examples:**
+        **Examples**
 
         >>> r = q.copy()
 
@@ -563,7 +563,7 @@ class Query:
                 The result of the query. The nature of the result is
                 dependent on the object type of *x*.
 
-        **Examples:**
+        **Examples**
 
         >>> q = cf.Query('lt', 5.5)
         >>> q.evaluate(6)
@@ -773,7 +773,7 @@ def lt(value, units=None, attr=None):
         `Query`
             The query object.
 
-    **Examples:**
+    **Examples**
 
     >>> c = cf.lt(5)
     >>> c == 2
@@ -834,7 +834,7 @@ def le(value, units=None, attr=None):
         `Query`
             The query object.
 
-    **Examples:**
+    **Examples**
 
     >>> q = cf.le(5)
     >>> q
@@ -878,7 +878,7 @@ def gt(value, units=None, attr=None):
         `Query`
             The query object.
 
-    **Examples:**
+    **Examples**
 
     >>> q = cf.gt(5)
     >>> q
@@ -922,7 +922,7 @@ def ge(value, units=None, attr=None):
         `Query`
             The query object.
 
-    **Examples:**
+    **Examples**
 
     >>> q = cf.ge(5)
     >>> q
@@ -977,7 +977,7 @@ def eq(value, units=None, attr=None, exact=True):
         `Query`
             The query object.
 
-    **Examples:**
+    **Examples**
 
     >>> q = cf.eq(5)
     >>> q
@@ -1037,7 +1037,7 @@ def ne(value, units=None, attr=None, exact=True):
         `Query`
             The query object.
 
-    **Examples:**
+    **Examples**
 
     >>> q = cf.ne(5)
     >>> q
@@ -1089,7 +1089,7 @@ def wi(value0, value1, units=None, attr=None):
         `Query`
             The query object.
 
-    **Examples:**
+    **Examples**
 
     >>> q = cf.wi(5, 7)
     >>> q
@@ -1136,7 +1136,7 @@ def wo(value0, value1, units=None, attr=None):
         `Query`
             The query object.
 
-    **Examples:**
+    **Examples**
 
     >>> q = cf.wo(5)
     >>> q
@@ -1183,7 +1183,7 @@ def set(values, units=None, attr=None, exact=True):
         `Query`
             The query object.
 
-    **Examples:**
+    **Examples**
 
     >>> c = cf.set([3, 5])
     >>> c == 4
@@ -1227,7 +1227,7 @@ def contains(value, units=None):
         `Query`
             The query object.
 
-    **Examples:**
+    **Examples**
 
     >>> cf.contains(8)
     <CF Query: [lower_bounds(le 8) & upper_bounds(ge 8)]>
@@ -1271,7 +1271,7 @@ def year(value):
         `Query`
             The query object.
 
-    **Examples:**
+    **Examples**
 
     >>> d = cf.dt(2002, 6, 16)
     >>> d == cf.year(2002)
@@ -1307,7 +1307,7 @@ def month(value):
         `Query`
             The query object.
 
-    **Examples:**
+    **Examples**
 
     >>> d = cf.dt(2002, 6, 16)
     >>> d == cf.month(6)
@@ -1343,7 +1343,7 @@ def day(value):
         `Query`
             The query object.
 
-    **Examples:**
+    **Examples**
 
     >>> d = cf.dt(2002, 6, 16)
     >>> d == cf.day(16)
@@ -1400,7 +1400,7 @@ def hour(value):
         `Query`
             The query object.
 
-    **Examples:**
+    **Examples**
 
     >>> d = cf.dt(2002, 6, 16, 18)
     >>> d == cf.hour(18)
@@ -1436,7 +1436,7 @@ def minute(value):
         `Query`
             The query object.
 
-    **Examples:**
+    **Examples**
 
     >>> d = cf.dt(2002, 6, 16, 18, 30, 0)
     >>> d == cf.minute(30)
@@ -1472,7 +1472,7 @@ def second(value):
         `Query`
             The query object.
 
-    **Examples:**
+    **Examples**
 
     >>> d = cf.dt(2002, 6, 16, 18, 30, 0)
     >>> d == cf.second(0)
@@ -1514,7 +1514,7 @@ def cellsize(value, units=None):
         `Query`
             The query object.
 
-    **Examples:**
+    **Examples**
 
     >>> cf.cellsize(cf.lt(5, 'km'))
     <CF Query: cellsize(lt <CF Data: 5 km>)>
@@ -1556,7 +1556,7 @@ def cellwi(value0, value1, units=None):
         `Query`
             The query object.
 
-    **Examples:**
+    **Examples**
 
     >>> cf.cellwi(cf.Data(5, 'km'), cf.Data(10, 'km'))
     <CF Query: [lower_bounds(ge 5 km) & upper_bounds(le 10 km)]>
@@ -1597,7 +1597,7 @@ def cellwo(value0, value1, units=None):
         `Query`
             The query object.
 
-    **Examples:**
+    **Examples**
 
     >>> cf.cellwo(cf.Data(5, 'km'), cf.Data(10, 'km'))
     <CF Query: [lower_bounds(lt 5 km) & upper_bounds(gt 10 km)]>
@@ -1639,7 +1639,7 @@ def cellgt(value, units=None):
         `Query`
             The query object.
 
-    **Examples:**
+    **Examples**
 
     >>> cf.cellgt(cf.Data(300, 'K'))
     <CF Query: lower_bounds(gt 300 K)>
@@ -1678,7 +1678,7 @@ def cellge(value, units=None):
         `Query`
             The query object.
 
-    **Examples:**
+    **Examples**
 
     >>> cf.cellge(cf.Data(300, 'K'))
     <CF Query: lower_bounds(ge 300 K)>
@@ -1716,7 +1716,7 @@ def celllt(value, units=None):
         `Query`
             The query object.
 
-    **Examples:**
+    **Examples**
 
     >>> cf.celllt(cf.Data(300, 'K'))
     <CF Query: upper_bounds(lt 300 K)>
@@ -1754,7 +1754,7 @@ def cellle(value, units=None):
         `Query`
             The query object.
 
-    **Examples:**
+    **Examples**
 
     >>> cf.cellle(cf.Data(300, 'K'))
     <CF Query: upper_bounds(le 300 K)>
@@ -1782,7 +1782,7 @@ def jja():
         `Query`
             The query object.
 
-    **Examples:**
+    **Examples**
 
     >>> f
     <CF Field: air_temperature(time(365), latitude(64), longitude(128)) K>
@@ -1808,7 +1808,7 @@ def son():
         `Query`
             The query object.
 
-    **Examples:**
+    **Examples**
 
     >>> f
     <CF Field: air_temperature(time(365), latitude(64), longitude(128)) K>
@@ -1834,7 +1834,7 @@ def djf():
         `Query`
             The query object.
 
-    **Examples:**
+    **Examples**
 
     >>> f
     <CF Field: air_temperature(time(365), latitude(64), longitude(128)) K>
@@ -1861,7 +1861,7 @@ def mam():
         `Query`
             The query object.
 
-    **Examples:**
+    **Examples**
 
     >>> f
     <CF Field: air_temperature(time(365), latitude(64), longitude(128)) K>
@@ -1903,7 +1903,7 @@ def seasons(n=4, start=12):
         `list` of `Query`
             The query objects.
 
-    **Examples:**
+    **Examples**
 
     >>> cf.seasons()
     [<CF Query: month[(ge 12) | (le 2)]>,

--- a/cf/read_write/netcdf/netcdfread.py
+++ b/cf/read_write/netcdf/netcdfread.py
@@ -48,7 +48,7 @@ class NetCDFRead(cfdm.read_write.netcdf.NetCDFRead):
             `list`
                 The netCDF dimension names spanned by the netCDF variable.
 
-        **Examples:**
+        **Examples**
 
         >>> n._ncdimensions('humidity')
         ['time', 'lat', 'lon']
@@ -93,7 +93,7 @@ class NetCDFRead(cfdm.read_write.netcdf.NetCDFRead):
 
             `list`
 
-        **Examples:**
+        **Examples**
 
         >>> r._get_domain_axes('areacello')
         ['domainaxis0', 'domainaxis1']

--- a/cf/read_write/netcdf/netcdfwrite.py
+++ b/cf/read_write/netcdf/netcdfwrite.py
@@ -317,7 +317,7 @@ class NetCDFWrite(cfdm.read_write.netcdf.NetCDFWrite):
                 The list of netCDF auxiliary coordinate names updated in
                 place.
 
-        **Examples:**
+        **Examples**
 
         >>> coordinates = _write_auxiliary_coordinate(f, 'aux2', coordinates)
 
@@ -615,7 +615,7 @@ class NetCDFWrite(cfdm.read_write.netcdf.NetCDFWrite):
             `str`
                 The hexadecimal string.
 
-        **Examples:**
+        **Examples**
 
         >>> _random_hex_string()
         'C3eECbBBcf'
@@ -650,7 +650,7 @@ class NetCDFWrite(cfdm.read_write.netcdf.NetCDFWrite):
 
             'int' or `float` or `bool`
 
-        **Examples:**
+        **Examples**
 
         >>> type(_convert_to_builtin_type(numpy.bool_(True)))
         bool

--- a/cf/read_write/read.py
+++ b/cf/read_write/read.py
@@ -539,7 +539,7 @@ def read(
             The field or domain constructs found in the input
             dataset(s). The list may be empty.
 
-    **Examples:**
+    **Examples**
 
     >>> x = cf.read('file.nc')
 
@@ -1039,7 +1039,7 @@ def file_type(filename):
             The format type of the file. One of ``'netCDF'``, ``'UM'``
             or ``'CDL'``.
 
-    **Examples:**
+    **Examples**
 
     >>> file_type(filename)
     'netCDF'

--- a/cf/read_write/um/filearray.py
+++ b/cf/read_write/um/filearray.py
@@ -47,7 +47,7 @@ class UMFileArray(FileArray):
 
         byte_ordering: `str`, optional
 
-    **Examples:**
+    **Examples**
 
     >>> a = UMFileArray(file='file.pp', header_offset=3156,
     ...                 data_offset=3420,
@@ -163,7 +163,7 @@ class UMFileArray(FileArray):
 
             `None`
 
-        **Examples:**
+        **Examples**
 
         >>> f.close()
 
@@ -177,7 +177,7 @@ class UMFileArray(FileArray):
 
             `um.umread.umfile.File`
 
-        **Examples:**
+        **Examples**
 
         >>> f.open()
 

--- a/cf/read_write/um/functions.py
+++ b/cf/read_write/um/functions.py
@@ -25,7 +25,7 @@ def _open_um_file(
         `umread.umfile.File`
             The opened file with an open file descriptor.
 
-    **Examples:**
+    **Examples**
 
     """
     #    filename = abspath(filename)
@@ -82,7 +82,7 @@ def _close_um_file(filename):
 
         `None`
 
-    **Examples:**
+    **Examples**
 
     """
     f = _file_to_UM.pop(filename, None)

--- a/cf/read_write/um/umread.py
+++ b/cf/read_write/um/umread.py
@@ -1702,7 +1702,7 @@ class UMField:
 
             `list`
 
-        **Examples:**
+        **Examples**
 
         >>> u.header_vtime(rec)
         [1991, 1, 1, 0, 0]
@@ -1722,7 +1722,7 @@ class UMField:
 
             `list`
 
-        **Examples:**
+        **Examples**
 
         >>> u.header_dtime(rec)
         [1991, 2, 1, 0, 0]
@@ -1742,7 +1742,7 @@ class UMField:
 
             `list`
 
-        **Examples:**
+        **Examples**
 
         >>> u.header_bz(rec)
 
@@ -1766,7 +1766,7 @@ class UMField:
 
             `list`
 
-        **Examples:**
+        **Examples**
 
         >>> u.header_lz(rec)
 
@@ -1796,7 +1796,7 @@ class UMField:
 
             `list`
 
-        **Examples:**
+        **Examples**
 
         >>> u.header_z(rec)
 
@@ -2033,7 +2033,7 @@ class UMField:
                A string derived from LBEXP. If LBEXP is a negative integer
                then that number is returned as a string.
 
-        **Examples:**
+        **Examples**
 
         >>> self.decode_lbexp()
         'aaa5u'
@@ -2085,7 +2085,7 @@ class UMField:
 
             `float`
 
-        **Examples:**
+        **Examples**
 
         >>> u.dtime(rec)
         31.5
@@ -2377,7 +2377,7 @@ class UMField:
 
         This is a bit like printfdr in the UKMO IDL PP library.
 
-        **Examples:**
+        **Examples**
 
         >>> u.printfdr()
 
@@ -2537,7 +2537,7 @@ class UMField:
                 `True` if a field satisfies the condition specified,
                 `False` otherwise.
 
-        **Examples:**
+        **Examples**
 
         >>> ok = u.test_um_condition('true_latitude_longitude', ...)
 
@@ -2597,7 +2597,7 @@ class UMField:
                 `True` if the UM version applicable to this field
                 construct is within the range, `False` otherwise.
 
-        **Examples:**
+        **Examples**
 
         >>> ok = u.test_um_version(401, 505, 1001)
         >>> ok = u.test_um_version(401, None, 606.3)
@@ -2775,7 +2775,7 @@ class UMField:
 
             `float`
 
-        **Examples:**
+        **Examples**
 
         >>> u.vtime(rec)
         31.5
@@ -3281,7 +3281,7 @@ class UMField:
 #
 #     `None`
 #
-# *Examples:*
+# *Examples*
 #
 # >>> load_stash2standard_name()
 # >>> load_stash2standard_name('my_table.txt')
@@ -3475,7 +3475,7 @@ class UMRead(cfdm.read_write.IORead):
             `list`
                 The fields in the file.
 
-        **Examples:**
+        **Examples**
 
         >>> f = read('file.pp')
         >>> f = read('*/file[0-9].pp', um_version=708)
@@ -3536,7 +3536,7 @@ class UMRead(cfdm.read_write.IORead):
 
             `bool`
 
-        **Examples:**
+        **Examples**
 
         >>> r.is_um_file('myfile.pp')
         True

--- a/cf/read_write/write.py
+++ b/cf/read_write/write.py
@@ -594,7 +594,7 @@ def write(
 
         `None`
 
-    **Examples:**
+    **Examples**
 
     There are further worked examples
     :ref:`in the tutorial <Writing-to-a-netCDF-dataset>`.

--- a/cf/regrid/regridoperator.py
+++ b/cf/regrid/regridoperator.py
@@ -92,7 +92,7 @@ class RegridOperator:
     def method(self):
         """The regridding method.
 
-        **Examples:**
+        **Examples**
 
         >>> r.method
         'conservative'
@@ -108,7 +108,7 @@ class RegridOperator:
     def name(self):
         """The name of the regrid method.
 
-        **Examples:**
+        **Examples**
 
         >>> r.name
         'regrids'
@@ -124,7 +124,7 @@ class RegridOperator:
         that the these are well defined during the creation and
         subsequent use of a `RegridOperator` instance.
 
-        **Examples:**
+        **Examples**
 
         >>> type(r.parameters)
         dict
@@ -136,7 +136,7 @@ class RegridOperator:
     def regrid(self):
         """The contained regridding operator.
 
-        **Examples:**
+        **Examples**
 
         >>> type(r.regrid)
         ESMF.api.regrid.Regrid
@@ -159,7 +159,7 @@ class RegridOperator:
                 Whether or not method is equivalent to the regridding
                 method.
 
-        **Examples:**
+        **Examples**
 
         >>> r.method
         'conservative'
@@ -185,7 +185,7 @@ class RegridOperator:
             `RegridOperator`
                 The copy.
 
-        **Examples:**
+        **Examples**
 
         >>> s = r.copy()
 
@@ -202,7 +202,7 @@ class RegridOperator:
     def destroy(self):
         """Free the memory allocated by the `ESMF.Regrid` instance.
 
-        **Examples:**
+        **Examples**
 
         >>> r.destroy()
 
@@ -223,7 +223,7 @@ class RegridOperator:
     def get_parameter(self, parameter):
         """Return a regrid operation parameter.
 
-        **Examples:**
+        **Examples**
 
         >>> r.get_parameter('ignore_degenerate')
         True

--- a/cf/subspacefield.py
+++ b/cf/subspacefield.py
@@ -114,7 +114,7 @@ class SubspaceField(mixin.Subspace):
             An independent field construct containing the subspace of
             the original field.
 
-    **Examples:**
+    **Examples**
 
     There are further worked examples
     :ref:`in the tutorial <Subspacing-by-metadata>`.
@@ -244,7 +244,7 @@ class SubspaceField(mixin.Subspace):
                 whether or not it is possible to create specified
                 subspace.
 
-        **Examples:**
+        **Examples**
 
         There are further worked examples
         :ref:`in the tutorial <Subspacing-by-metadata>`.

--- a/cf/timeduration.py
+++ b/cf/timeduration.py
@@ -312,7 +312,7 @@ class TimeDuration:
                   (cftime.DatetimeGregorian(1999-12-30 00:00:00),
                    cftime.DatetimeGregorian(2000-01-30 00:00:00))
 
-        **Examples:**
+        **Examples**
 
         >>> t = cf.TimeDuration(cf.Data(3 , 'calendar_years'))
         >>> t = cf.TimeDuration(cf.Data(12 , 'hours'))
@@ -900,7 +900,7 @@ class TimeDuration:
 
         .. versionadded:: 1.0
 
-        **Examples:**
+        **Examples**
 
         >>> cf.TimeDuration(45, 'days').iso
         'P45D'
@@ -939,7 +939,7 @@ class TimeDuration:
 
         .. versionadded:: 1.0
 
-        **Examples:**
+        **Examples**
 
         >>> cf.TimeDuration(2, 'hours').isint
         True
@@ -963,7 +963,7 @@ class TimeDuration:
 
         .. versionadded:: 1.0
 
-        **Examples:**
+        **Examples**
 
         >>> cf.TimeDuration(3, 'days').Units
         <CF Units: days>
@@ -1004,7 +1004,7 @@ class TimeDuration:
 
                 The deep copy.
 
-        **Examples:**
+        **Examples**
 
         >>> u = t.copy()
 
@@ -1050,7 +1050,7 @@ class TimeDuration:
             `int`
                 The number of days in the specified month.
 
-        **Examples:**
+        **Examples**
 
         >>> cf.TimeDuration.days_in_month(2004, 2, calendar='360_day')
         30
@@ -1147,7 +1147,7 @@ class TimeDuration:
             `bool`
                 Whether or not the two instances are equal.
 
-        **Examples:**
+        **Examples**
 
         >>> t = cf.TimeDuration(36, 'calendar_months')
         >>> u = cf.TimeDuration(3, 'calendar_years')
@@ -1250,7 +1250,7 @@ class TimeDuration:
             `bool`
                 Whether or not the two instances logically equivalent.
 
-        **Examples:**
+        **Examples**
 
         >>> t = cf.TimeDuration(36, 'calendar_months')
         >>> u = cf.TimeDuration(3, 'calendar_years')
@@ -1360,7 +1360,7 @@ class TimeDuration:
                 date-time. If *iso* has been set then an ISO 8601 time
                 interval string is returned instead of a tuple.
 
-        **Examples:**
+        **Examples**
 
         >>> t = cf.TimeDuration(6, 'calendar_months')
         >>> t
@@ -1547,7 +1547,7 @@ class TimeDuration:
             `tuple`
                 The two bounds.
 
-        **Examples:**
+        **Examples**
 
         >>> t = cf.M()
         >>> t.bounds(cf.dt(2000, 1, 1))
@@ -1601,7 +1601,7 @@ class TimeDuration:
 
             `bool`
 
-        **Examples:**
+        **Examples**
 
         >>> cf.TimeDuration(0.5, 'days').is_day_factor()
         True
@@ -1688,7 +1688,7 @@ def Y(duration=1, month=1, day=1, hour=0, minute=0, second=0):
         `TimeDuration`
             The new `cf.TimeDuration` object.
 
-    **Examples:**
+    **Examples**
 
     >>> cf.Y()
     <CF TimeDuration: P1Y (Y-01-01 00:00:00)>
@@ -1741,7 +1741,7 @@ def M(duration=1, month=1, day=1, hour=0, minute=0, second=0):
         `TimeDuration`
             The new `cf.TimeDuration` object.
 
-    **Examples:**
+    **Examples**
 
     >>> cf.M()
     <CF TimeDuration: P1M (Y-M-01 00:00:00)>
@@ -1792,7 +1792,7 @@ def D(duration=1, month=1, day=1, hour=0, minute=0, second=0):
         `TimeDuration`
             The new `cf.TimeDuration` object.
 
-    **Examples:**
+    **Examples**
 
     >>> cf.D()
     <CF TimeDuration: P1D (Y-M-D 00:00:00)>
@@ -1846,7 +1846,7 @@ def h(duration=1, month=1, day=1, hour=0, minute=0, second=0):
         `TimeDuration`
             The new `cf.TimeDuration` object.
 
-    **Examples:**
+    **Examples**
 
     >>> cf.h()
     <CF TimeDuration: PT1H (Y-M-D h:00:00)>
@@ -1900,7 +1900,7 @@ def m(duration=1, month=1, day=1, hour=0, minute=0, second=0):
         `TimeDuration`
             The new `cf.TimeDuration` object.
 
-    **Examples:**
+    **Examples**
 
     >>> cf.m()
     <CF TimeDuration: PT1M (Y-M-D h:m:00)>
@@ -1954,7 +1954,7 @@ def s(duration=1, month=1, day=1, hour=0, minute=0, second=0):
         `TimeDuration`
             The new `cf.TimeDuration` object.
 
-    **Examples:**
+    **Examples**
 
     >>> cf.s()
     <CF TimeDuration: PT1S (Y-M-D h:m:s)>


### PR DESCRIPTION
Inverse to #362, touching all modules except `data` ones and this time onto `master`.

In terms of figures, before we had:

```console
$ git grep "Examples" | wc -l
688
$ git grep "Examples:" | wc -l
677
```

and afterwards:

```console
$ git grep "Examples" | wc -l
688
$ git grep "Examples:" | wc -l
217
$ cd data
$ git grep "Examples:" | wc -l
217
```