### PR TITLE
dask: `Data` query interface

### DIFF
--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -4272,25 +4272,6 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
 
             return self
 
-    def __query_set__(self, values):
-        """Implements the “member of set” condition."""
-        i = iter(values)
-        v = next(i)
-
-        out = self == v
-        for v in i:
-            out |= self == v
-
-        return out
-
-    def __query_wi__(self, value):
-        """Implements the “within a range” condition."""
-        return (self >= value[0]) & (self <= value[1])
-
-    def __query_wo__(self, value):
-        """TODO."""
-        return (self < value[0]) | (self > value[1])
-
     @classmethod
     def concatenate(cls, data, axis=0, _preserve=True):
         """Join a sequence of data arrays together.

--- a/cf/mixin/propertiesdata.py
+++ b/cf/mixin/propertiesdata.py
@@ -820,40 +820,6 @@ class PropertiesData(Properties):
     #
     #        return matches
 
-    def __query_set__(self, values):
-        """Implements the “member of set” condition."""
-        new = self.copy()
-        new.set_data(self.data.__query_set__(values), copy=False)
-        return new
-
-    #    def _query_contain(self, value):
-    #        '''TODO#
-    #
-    #        '''
-    #        new = self.copy()
-    #        new.set_data(self.data._query_contain(value), copy=False)
-    #        return new
-
-    #    def _query_contains(self, value):
-    #        '''TODO
-    #
-    #        '''
-    #        new = self.copy()
-    #        new.set_data(self.data._query_contains(value), copy=False)
-    #        return new
-
-    def __query_wi__(self, value):
-        """Implements the “within a range” condition."""
-        new = self.copy()
-        new.set_data(self.data.__query_wi__(value), copy=False)
-        return new
-
-    def __query_wo__(self, value):
-        """Implements the “without a range” condition."""
-        new = self.copy()
-        new.set_data(self.data.__query_wo__(value), copy=False)
-        return new
-
     def _unary_operation(self, method):
         """Implement unary arithmetic operations on the data array.
 

--- a/cf/query.py
+++ b/cf/query.py
@@ -690,13 +690,6 @@ class Query:
 
             return (x < value[0]) | (x > value[1])
 
-        #        if operator == 'contains':
-        #            _contain = getattr(x, '__query_contains__', None)
-        #            if _contain is not None:
-        #                return _contain(value)
-        #            else:
-        #                return x == value
-
         if operator == "set":
             if isinstance(x, str):
                 for v in value:


### PR DESCRIPTION
Just deleting these methods, as they merely duplicate code in `cf.Query` (https://github.com/NCAS-CMS/cf-python/blob/v3.12.0/cf/query.py#L667-L710). That code is already as efficient as it can be for dask arrays.