### PR TITLE
dask: `Data._parse indices`

### DIFF
--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -4291,6 +4291,17 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         """TODO."""
         return (self < value[0]) | (self > value[1])
 
+    def _parse_indices(self, *args, **kwargs):
+        """'cf.Data._parse_indices' is not available.
+
+        Use function `cf.parse_indices` instead.
+
+        """
+        raise NotImplementedError(
+            "'cf.Data._parse_indices' is not available. "
+            "Use function 'cf.parse_indices' instead."
+        )
+
     @classmethod
     def concatenate(cls, data, axis=0, _preserve=True):
         """Join a sequence of data arrays together.


### PR DESCRIPTION
`_parse_indices` inherited from cfdm has been replaced with `cf.parse_indices` (because the functionality is also used elsewhere), and so the former should not be used.