### PR TITLE
dask: `Data.__round__`

### DIFF
--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -879,19 +879,6 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         """
         return float(self._get_dask())
 
-    def __round__(self, *ndigits):
-        """Called to implement the built-in function `round`
-
-        x.__round__(*ndigits) <==> round(x, *ndigits)
-
-        """
-        if self.size != 1:
-            raise TypeError(
-                "only length-1 arrays can be converted to Python scalars"
-            )
-
-        return round(self.datum(), *ndigits)
-
     @daskified(_DASKIFIED_VERBOSE)
     def __int__(self):
         """Called to implement the built-in function `int`

--- a/cf/data/mixin/deprecations.py
+++ b/cf/data/mixin/deprecations.py
@@ -7,6 +7,22 @@ from ...functions import (
 class DataClassDeprecationsMixin:
     """Deprecated attributes and methods for the Data class."""
 
+    def __round__(self, *ndigits):
+        """Called to implement the built-in function `round`
+
+        Deprecated at version TODODASK, use method `round` instead.
+
+        x.__round__(*ndigits) <==> round(x, *ndigits)
+
+        """
+        _DEPRECATION_ERROR_METHOD(
+            self,
+            "__round__",
+            "Use method 'round' instead.",
+            version="TODODASK",
+            removed_at="5.0.0",
+        )  # pragma: no cover
+
     @property
     def Data(self):
         """Deprecated at version 3.0.0, use attribute `data` instead."""

--- a/cf/data/mixin/deprecations.py
+++ b/cf/data/mixin/deprecations.py
@@ -69,22 +69,6 @@ class DataClassDeprecationsMixin:
             removed_at="5.0.0",
         )
 
-    def __round__(self, *ndigits):
-        """Called to implement the built-in function `round`.
-
-        Deprecated at version TODODASK, use method `round` instead.
-
-        x.__round__(*ndigits) <==> round(x, *ndigits)
-      
-        """
-        _DEPRECATION_ERROR_METHOD(
-            self,
-            "__round__",
-            "Use method 'round' instead.",
-            version="TODODASK",
-            removed_at="5.0.0",
-        )  # pragma: no cover
-
     @property
     def Data(self):
         """Deprecated at version 3.0.0, use attribute `data` instead."""

--- a/cf/data/mixin/deprecations.py
+++ b/cf/data/mixin/deprecations.py
@@ -70,7 +70,7 @@ class DataClassDeprecationsMixin:
         )
 
     def __round__(self, *ndigits):
-        """Called to implement the built-in function `round`
+        """Called to implement the built-in function `round`.
 
         Deprecated at version TODODASK, use method `round` instead.
 

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -2364,32 +2364,6 @@ class DataTest(unittest.TestCase):
         with self.assertRaises(Exception):
             _ = int(cf.Data([1, 2]))
 
-    def test_Data__round__(self):
-        if self.test_only and inspect.stack()[0][3] not in self.test_only:
-            return
-
-        for ndigits in ([], [0], [1], [2], [3]):
-            for x in (
-                -1.9123,
-                -1.5789,
-                -1.4123,
-                -1.789,
-                0,
-                1.123,
-                1.0234,
-                1.412,
-                1.9345,
-            ):
-                self.assertEqual(
-                    round(cf.Data(x), *ndigits), round(x, *ndigits)
-                )
-                self.assertEqual(
-                    round(cf.Data(x), *ndigits), round(x, *ndigits)
-                )
-
-        with self.assertRaises(Exception):
-            _ = round(cf.Data([1, 2]))
-
     def test_Data_argmax(self):
         if self.test_only and inspect.stack()[0][3] not in self.test_only:
             return


### PR DESCRIPTION
`__round__` is not implemented by numpy nor dask - I reckon it's OK to also not implement it here.