### PR TITLE
dask: `Data._set_subspace`

### DIFF
--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -4291,6 +4291,10 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         """TODO."""
         return (self < value[0]) | (self > value[1])
 
+    def _set_subspace(self, *args, **kwargs):
+        """'cf.Data._set_subspace' is unavailable."""
+        raise NotImplementedError("'cf.Data._set_subspace' is unavailable.")
+
     @classmethod
     def concatenate(cls, data, axis=0, _preserve=True):
         """Join a sequence of data arrays together.


### PR DESCRIPTION
`_set_subspace` is no longer needed, as it's functionality has been replicated in `__setitem__`, and the slicing of chunks is now out of our control (i.e. dask deals with it)