### PR TITLE
Fix formatting of message for deprecated attributes

### DIFF
--- a/cf/functions.py
+++ b/cf/functions.py
@@ -3228,11 +3228,10 @@ def _DEPRECATION_ERROR_ATTRIBUTE(
 ):
     if removed_at:
         removed_at = f" and will be removed at version {removed_at}"
-    
+
     raise DeprecationError(
         f"{instance.__class__.__name__} attribute {attribute!r} has been "
-        f"deprecated at version {version} and will be removed at version "
-        f"{removed_at}. {message}"
+        f"deprecated at version {version}{removed_at}. {message}"
     )
 
 


### PR DESCRIPTION
Quick one to fix a formatting issue (spotted in https://github.com/NCAS-CMS/cf-python/pull/395#pullrequestreview-966168080) due to a (valid) change that went in as part of #384 but which has been partially reverted, likely due to a merge conflict resolution mistake somewhere along the line.

Before this PR for e.g. `d.ismasked()` on some `cf.Data`:

```python
DeprecationError: Data attribute 'ismasked' has been deprecated at version TODODASK and will be removed at version  and will be removed at version 5.0.0. Use the 'is_masked' attribute instead
```

And after this PR, the obvious fix is made:

```python
DeprecationError: Data attribute 'ismasked' has been deprecated at version TODODASK and will be removed at version 5.0.0. Use the 'is_masked' attribute instead
```

No review requested as this is a trivial fix.
