### PR TITLE
dask: `Dask.get_filenames`

### DIFF
--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -29,7 +29,6 @@ from ..functions import (
     _DEPRECATION_ERROR_KWARGS,
     _numpy_isclose,
     _section,
-    abspath,
     atol,
     default_netCDF_fillvals,
     free_memory,
@@ -39,7 +38,6 @@ from ..functions import (
 )
 from ..mixin_container import Container
 from ..units import Units
-from . import FileArray
 from .collapse import Collapse
 from .creation import compressed_to_dask, generate_axis_identifiers, to_dask
 from .dask_utils import (
@@ -7800,45 +7798,6 @@ class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
         d._axes = data_axes
 
         return d
-
-    @daskified(_DASKIFIED_VERBOSE)
-    def get_filenames(self):
-        """Return the names of files containing parts of the data array.
-
-        :Returns:
-
-            `set`
-                The file names in normalized, absolute form. If the
-                data is in memory then an empty `set` is returned.
-
-        **Examples**
-
-        >>> f = cf.NetCDFArray(TODODASK)
-        >>> d = cf.Data(f)
-        >>> d.get_filenames()
-        {TODODASK}
-
-        >>> d = cf.Data([1, 2, 3])
-        >>> d.get_filenames()
-        set()
-
-        """
-        out = set()
-
-        dx = self.to_dask_array()
-        hlg = dx.dask
-        dsk = hlg.to_dict()
-        for key, value in hlg.get_all_dependencies().items():
-            if value:
-                continue
-
-            # This key has no dependencies, and so is raw data.
-            a = dsk[key]
-            if isinstance(a, FileArray):
-                out.add(abspath(a.get_filename()))
-
-        out.discard(None)
-        return out
 
     @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("size")

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -133,7 +133,7 @@ _DEFAULT_CHUNKS = "auto"
 _DEFAULT_HARDMASK = True
 
 
-class Data(Container, cfdm.Data, DataClassDeprecationsMixin):
+class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
     """An N-dimensional data array with units and masked values.
 
     * Contains an N-dimensional, indexable and broadcastable array with

--- a/cf/data/mixin/deprecations.py
+++ b/cf/data/mixin/deprecations.py
@@ -315,6 +315,23 @@ class DataClassDeprecationsMixin:
             removed_at="5.0.0",
         )  # pragma: no cover
 
+    def get_filenames(self):
+        """Return the names of files containing parts of the data array.
+
+        Deprecated at version TODODASK.
+
+        :Returns:
+
+            `set`
+                The file names in normalized, absolute form. If the
+                data is in memory then an empty `set` is returned.
+
+        """
+        raise DeprecationError(
+            "Data method 'get_filenames' has been deprecated at "
+            "version TODODASK and is not available."
+        )  # pragma: no cover
+
     def chunk(self, chunksize=None, total=None, omit_axes=None, pmshape=None):
         """Partition the data array.
 

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -3819,10 +3819,6 @@ class DataTest(unittest.TestCase):
             list(d.flat(ignore_masked=False)), [1, np.ma.masked, 3, 4]
         )
 
-    @unittest.skipIf(TEST_DASKIFIED_ONLY, "Needs updated NetCDFArray to test")
-    def test_Data_get_filenames(self):
-        pass
-
     def test_Data_tolist(self):
         for x in (1, [1, 2], [[1, 2], [3, 4]]):
             d = cf.Data(x)
@@ -3954,7 +3950,7 @@ class DataTest(unittest.TestCase):
         d.soften_mask()
         self.assertFalse(d.hardmask)
         self.assertEqual(len(d.to_dask_array().dask.layers), 2)
-        
+
     def test_Data_compressed_array(self):
         import cfdm
 


### PR DESCRIPTION
Following on from https://github.com/NCAS-CMS/cf-python/issues/365, I think that this method is just too "dangerous", now, and it would be better to manage this from the `Field`/`Domain`, with content injected by `cf.read`/`cf.aggregate`. All of which would be the topic of a later PR.