### PR TITLE
LAMA to Dask: (deprecate) `Data.concatenate_data`

### DIFF
--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -5640,37 +5640,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @classmethod
-    def concatenate_data(cls, data_list, axis):
-        """Concatenates a list of Data objects into a single Data object
-        along the specified access (see cf.Data.concatenate for
-        details). In the case that the list contains only one element,
-        that element is simply returned.
-
-        :Parameters:
-
-            data_list: `list`
-                The list of data objects to concatenate.
-
-            axis: `int`
-                The axis along which to perform the concatenation.
-
-        :Returns:
-
-            `Data`
-                The resulting single `Data` object.
-
-        """
-        if len(data_list) > 1:
-            data = cls.concatenate(data_list, axis=axis)
-            if data.fits_in_one_chunk_in_memory(data.dtype.itemsize):
-                data.varray
-
-            return data
-        else:
-            assert len(data_list) == 1
-            return data_list[0]
-
     def argmax(self, axis=None, unravel=False):
         """Return the indices of the maximum values along an axis.
 

--- a/cf/data/mixin/deprecations.py
+++ b/cf/data/mixin/deprecations.py
@@ -969,10 +969,12 @@ class DataClassDeprecationsMixin:
 
     @classmethod
     def concatenate_data(cls, data_list, axis):
-        """Concatenates a list of Data objects into a single Data object
-        along the specified access (see cf.Data.concatenate for
-        details). In the case that the list contains only one element,
-        that element is simply returned.
+        """Concatenates a list of Data objects along the specified axis.
+
+        See cf.Data.concatenate for details.
+
+        In the case that the list contains only one element, that element
+        is simply returned.
 
         :Parameters:
 

--- a/cf/data/mixin/deprecations.py
+++ b/cf/data/mixin/deprecations.py
@@ -966,3 +966,30 @@ class DataClassDeprecationsMixin:
             "Data method 'reconstruct_sectioned_data' has been deprecated "
             "at version TODODASK and is no longer available"
         )
+
+    @classmethod
+    def concatenate_data(cls, data_list, axis):
+        """Concatenates a list of Data objects into a single Data object
+        along the specified access (see cf.Data.concatenate for
+        details). In the case that the list contains only one element,
+        that element is simply returned.
+
+        :Parameters:
+
+            data_list: `list`
+                The list of data objects to concatenate.
+
+            axis: `int`
+                The axis along which to perform the concatenation.
+
+        :Returns:
+
+            `Data`
+                The resulting single `Data` object.
+
+        """
+        raise DeprecationError(
+            "Data method 'concatenate_data' has been deprecated at "
+            "version TODODASK and is no longer available. Use "
+            "'concatenate' instead."
+        )


### PR DESCRIPTION
Migrating the `Data.concatenate_data` method towards #182, by deprecating it.

I don't think this approach will be controversial (so-as to have required pre-PR discussion) since it seems to be essentially the same method as `concatenate`, just compare the inputs and outputs on the docstrings to see this, with no real difference except for the behaviour of:

> In the case that the list contains only one element, that element is simply returned.

and it is not used anywhere throughout the codebase, unlike `concatenate` which is used quite widely (note this was a post-PR grep, but regardless the only usage is to define it):

```console
$ pwd
/home/sadie/cf-python/cf
$ git grep "concatenate_data"
data/mixin/deprecations.py:    def concatenate_data(cls, data_list, axis):
data/mixin/deprecations.py:            "Data method 'concatenate_data' has been deprecated at "
```

Anyhow @davidhassell you can object at this stage and close if there is a justification to keep the method, else review this towards merging, as the change itself is almost trivial. Thanks.