### PR TITLE
LAMA to Dask migration: `Data.stats`

### DIFF
--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -9317,55 +9317,55 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         [[0  1  2]
          [3 --  5]]
         >>> d.stats()
-        {'minimum': <CF Data(): 0>,
-         'mean': <CF Data(): 2.2>,
-         'median': <CF Data(): 2.0>,
-         'maximum': <CF Data(): 5>,
-         'range': <CF Data(): 5>,
-         'mid_range': <CF Data(): 2.5>,
-         'standard_deviation': <CF Data(): 1.7204650534085253>,
-         'root_mean_square': <CF Data(): 2.792848008753788>,
+        {'minimum': 0,
+         'mean': 2.2,
+         'median': 2.0,
+         'maximum': 5,
+         'range': 5,
+         'mid_range': 2.5,
+         'standard_deviation': 1.7204650534085255,
+         'root_mean_square': 2.792848008753788,
          'sample_size': 5}
         >>> d.stats(all=True)
+        {'minimum': 0,
+         'mean': 2.2,
+         'median': 2.0,
+         'maximum': 5,
+         'range': 5,
+         'mid_range': 2.5,
+         'standard_deviation': 1.7204650534085255,
+         'root_mean_square': 2.792848008753788,
+         'minimum_absolute_value': 0,
+         'maximum_absolute_value': 5,
+         'mean_absolute_value': 2.2,
+         'mean_of_upper_decile': 5.0,
+         'sum': 11,
+         'sum_of_squares': 39,
+         'variance': 2.9600000000000004,
+         'sample_size': 5}
+        >>> d.stats(mean_of_upper_decile=True, range=False)
+        {'minimum': 0,
+         'mean': 2.2,
+         'median': 2.0,
+         'maximum': 5,
+         'mid_range': 2.5,
+         'standard_deviation': 1.7204650534085255,
+         'root_mean_square': 2.792848008753788,
+         'mean_of_upper_decile': 5.0,
+         'sample_size': 5}
+
+        To ask for delayed operations instead of computed values:
+
+        >>> d.stats(compute=False)
         {'minimum': <CF Data(): 0>,
          'mean': <CF Data(): 2.2>,
          'median': <CF Data(): 2.0>,
          'maximum': <CF Data(): 5>,
          'range': <CF Data(): 5>,
          'mid_range': <CF Data(): 2.5>,
-         'standard_deviation': <CF Data(): 1.7204650534085253>,
+         'standard_deviation': <CF Data(): 1.7204650534085255>,
          'root_mean_square': <CF Data(): 2.792848008753788>,
-         'minimum_absolute_value': <CF Data(): 0>,
-         'maximum_absolute_value': <CF Data(): 5>,
-         'mean_absolute_value': <CF Data(): 2.2>,
-         'mean_of_upper_decile': <CF Data(): 5.0>,
-         'sum': <CF Data(): 11>,
-         'sum_of_squares': <CF Data(): 39>,
-         'variance': <CF Data(): 2.96>,
-         'sample_size': 5}
-        >>> d.stats(mean_of_upper_decile=True, range=False)
-        {'minimum': <CF Data(): 0>,
-         'mean': <CF Data(): 2.2>,
-         'median': <CF Data(): 2.0>,
-         'maximum': <CF Data(): 5>,
-         'mid_range': <CF Data(): 2.5>,
-         'standard_deviation': <CF Data(): 1.7204650534085253>,
-         'root_mean_square': <CF Data(): 2.792848008753788>,
-         'mean_of_upper_decile': <CF Data(): 5.0>,
-         'sample_size': 5}
-
-        Ask for delayed operations instead of computed values for the stats:
-
-        >>> d.stats(compute=False)
-        {'minimum': Delayed('minimum-0161ad64-aa89-43a7-b651-85a939822f7d'),
-         'mean': Delayed('mean-cef11472-c0b2-4f92-b19a-41295758a870'),
-         'median': Delayed('median-22330dad-f9ff-4337-ae66-03545a529021'),
-         'maximum': Delayed('maximum-81e21125-e99e-4d4f-9131-9c3d95b9fcc1'),
-         'range': Delayed('range-6adfd9a0-d2c3-4262-b7b7-d2e69b28ce2f'),
-         'mid_range': Delayed('mid_range-60d75030-78dc-4f41-befd-380190282da2'),
-         'standard_deviation': Delayed('standard_deviation-804f3fe4-c3e6-4a96-a895-f403f9fbc43a'),
-         'root_mean_square': Delayed('root_mean_square-1ff687b2-2988-4512-937d-198b5477b216'),
-         'sample_size': Delayed('lambda-5498333c-9889-4442-869e-81cfead6196b')}
+         'sample_size': <CF Data(1, 1): [[5]]>}
 
         """
         no_weights = (

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -9437,7 +9437,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
                 out[stat] = value
 
         if all or sample_size:
-            out["sample_size"] = delayed(lambda: int(self.sample_size()))()
+            out["sample_size"] = delayed(lambda: self.sample_size())()
 
         return compute(out)[0]
 

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -9354,6 +9354,18 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
          'mean_of_upper_decile': <CF Data(): 5.0>,
          'sample_size': 5}
 
+        # Ask for delayed operations instead of computed values for the stats:
+        >>> d.stats(compute=False)
+        {'minimum': Delayed('minimum-0161ad64-aa89-43a7-b651-85a939822f7d'),
+         'mean': Delayed('mean-cef11472-c0b2-4f92-b19a-41295758a870'),
+         'median': Delayed('median-22330dad-f9ff-4337-ae66-03545a529021'),
+         'maximum': Delayed('maximum-81e21125-e99e-4d4f-9131-9c3d95b9fcc1'),
+         'range': Delayed('range-6adfd9a0-d2c3-4262-b7b7-d2e69b28ce2f'),
+         'mid_range': Delayed('mid_range-60d75030-78dc-4f41-befd-380190282da2'),
+         'standard_deviation': Delayed('standard_deviation-804f3fe4-c3e6-4a96-a895-f403f9fbc43a'),
+         'root_mean_square': Delayed('root_mean_square-1ff687b2-2988-4512-937d-198b5477b216'),
+         'sample_size': Delayed('lambda-5498333c-9889-4442-869e-81cfead6196b')}
+
         """
         no_weights = (
             "minimum",

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -10,6 +10,7 @@ import cfdm
 import cftime
 import dask.array as da
 import numpy as np
+from dask import compute, delayed
 from dask.array import Array
 from dask.array.core import normalize_chunks
 from dask.base import is_dask_collection, tokenize
@@ -9376,16 +9377,16 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
             if all or locals()[stat]:
                 func = getattr(self, stat)
                 if stat in no_weights:
-                    value = func(squeeze=True)
+                    value = delayed(func)(squeeze=True)
                 else:
-                    value = func(squeeze=True, weights=weights)
+                    value = delayed(func)(squeeze=True, weights=weights)
 
                 out[stat] = value
 
         if all or sample_size:
-            out["sample_size"] = int(self.sample_size())
+            out["sample_size"] = delayed(lambda: int(self.sample_size()))()
 
-        return out
+        return compute(out)[0]
 
     @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -9196,6 +9196,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         d._set_dask(da.round(dx, decimals=decimals))
         return d
 
+    @daskified(_DASKIFIED_VERBOSE)
     def stats(
         self,
         all=False,

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -9354,7 +9354,8 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
          'mean_of_upper_decile': <CF Data(): 5.0>,
          'sample_size': 5}
 
-        # Ask for delayed operations instead of computed values for the stats:
+        Ask for delayed operations instead of computed values for the stats:
+        
         >>> d.stats(compute=False)
         {'minimum': Delayed('minimum-0161ad64-aa89-43a7-b651-85a939822f7d'),
          'mean': Delayed('mean-cef11472-c0b2-4f92-b19a-41295758a870'),

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -9410,7 +9410,14 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
             out["sample_size"] = delayed(lambda: self.sample_size())()
 
         if compute:
-            return globals()["compute"](out)[0]  # noqa: F811
+            data_values = globals()["compute"](out)[0]  # noqa: F811
+
+            # Convert cf.Data objects holding the scalars (or ndim value
+            # for the case of sample_size only) to scalar values
+            scalar_values = {
+                op: val.array.item() for op, val in data_values.items()
+            }
+            return scalar_values
         else:
             return out
 

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -9345,6 +9345,58 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
          'sample_size': 5}
 
         """
+        # First define an inner function for each statistic to enable
+        # the sharing of any of the same underlying data, in order to
+        # avoid potentially having to read the data from disk each time.
+
+        def minimum(x):
+            return x.minimum()
+
+        def maximum(x):
+            return x.maximum()
+
+        def maximum_absolute_value(x):
+            return x.maximum_absolute_value()
+
+        def minimum_absolute_value(x):
+            return x.minimum_absolute_value()
+
+        def mid_range(x):
+            return x.mid_range()
+
+        def median(x):
+            return x.median()
+
+        def range(x):
+            return x.range()
+
+        def sum(x):
+            return x.sum()
+
+        def sum_of_squares(x):
+            return x.sum_of_squares()
+
+        def sample_size(x):
+            return x.sample_size()
+
+        def mean(x):
+            return x.mean()
+
+        def mean_absolute_value(x):
+            return x.mean_absolute_value()
+
+        def mean_of_upper_decile(x):
+            return x.mean_of_upper_decile()
+
+        def variance(x):
+            return x.variance()
+
+        def standard_deviation(x):
+            return x.standard_deviation()
+
+        def root_mean_square(x):
+            return x.root_mean_square()
+
         no_weights = (
             "minimum",
             "median",

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -9345,58 +9345,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
          'sample_size': 5}
 
         """
-        # First define an inner function for each statistic to enable
-        # the sharing of any of the same underlying data, in order to
-        # avoid potentially having to read the data from disk each time.
-
-        def minimum(x):
-            return x.minimum()
-
-        def maximum(x):
-            return x.maximum()
-
-        def maximum_absolute_value(x):
-            return x.maximum_absolute_value()
-
-        def minimum_absolute_value(x):
-            return x.minimum_absolute_value()
-
-        def mid_range(x):
-            return x.mid_range()
-
-        def median(x):
-            return x.median()
-
-        def range(x):
-            return x.range()
-
-        def sum(x):
-            return x.sum()
-
-        def sum_of_squares(x):
-            return x.sum_of_squares()
-
-        def sample_size(x):
-            return x.sample_size()
-
-        def mean(x):
-            return x.mean()
-
-        def mean_absolute_value(x):
-            return x.mean_absolute_value()
-
-        def mean_of_upper_decile(x):
-            return x.mean_of_upper_decile()
-
-        def variance(x):
-            return x.variance()
-
-        def standard_deviation(x):
-            return x.standard_deviation()
-
-        def root_mean_square(x):
-            return x.root_mean_square()
-
         no_weights = (
             "minimum",
             "median",

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -9355,7 +9355,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
          'sample_size': 5}
 
         Ask for delayed operations instead of computed values for the stats:
-        
+
         >>> d.stats(compute=False)
         {'minimum': Delayed('minimum-0161ad64-aa89-43a7-b651-85a939822f7d'),
          'mean': Delayed('mean-cef11472-c0b2-4f92-b19a-41295758a870'),
@@ -9410,17 +9410,13 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         if all or sample_size:
             out["sample_size"] = delayed(lambda: self.sample_size())()
 
+        data_values = globals()["compute"](out)[0]  # noqa: F811
         if compute:
-            data_values = globals()["compute"](out)[0]  # noqa: F811
-
-            # Convert cf.Data objects holding the scalars (or ndim value
+            # Convert cf.Data objects holding the scalars (or scalar array
             # for the case of sample_size only) to scalar values
-            scalar_values = {
-                op: val.array.item() for op, val in data_values.items()
-            }
-            return scalar_values
+            return {op: val.array.item() for op, val in data_values.items()}
         else:
-            return out
+            return data_values
 
     @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -704,16 +704,16 @@ class DataTest(unittest.TestCase):
         self.assertEqual(
             d.stats(sum=True, weights=1),
             {
-                "minimum": 1,
-                "mean": 1.0,
-                "median": 1.0,
-                "maximum": 1,
-                "range": 0,
-                "mid_range": 1.0,
-                "standard_deviation": 0.0,
-                "root_mean_square": 1.0,
-                "sum": 2,
-                "sample_size": 2,
+                "minimum": cf.Data(1),
+                "mean": cf.Data(1.0),
+                "median": cf.Data(1.0),
+                "maximum": cf.Data(1),
+                "range": cf.Data(0),
+                "mid_range": cf.Data(1.0),
+                "standard_deviation": cf.Data(0.0),
+                "root_mean_square": cf.Data(1.0),
+                "sum": cf.Data(2),
+                "sample_size": cf.Data(2),
             },
         )
 

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -104,10 +104,16 @@ class DataTest(unittest.TestCase):
         # expected due to the nature of the tests being performed.
         expexted_warning_msgs = [
             "divide by zero encountered in arctanh",
-            "invalid value encountered in arctanh",
             "divide by zero encountered in log",
-            "invalid value encountered in log",
+            "divide by zero encountered in double_scalars",
             "invalid value encountered in arcsin",
+            "invalid value encountered in arccos",
+            "invalid value encountered in arctanh",
+            "invalid value encountered in arccosh",
+            "invalid value encountered in log",
+            "invalid value encountered in sqrt",
+            "invalid value encountered in double_scalars",
+            "invalid value encountered in true_divide",
         ]
         for expected_warning in expexted_warning_msgs:
             warnings.filterwarnings(

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -701,8 +701,51 @@ class DataTest(unittest.TestCase):
         """Test the `stats` Data method."""
         d = cf.Data([1, 1])
 
+        s1 = d.stats()
+        self.assertEqual(len(s1), 9)
         self.assertEqual(
-            d.stats(sum=True, weights=1),
+            s1,
+            {
+                "minimum": cf.Data(1),
+                "mean": cf.Data(1.0),
+                "median": cf.Data(1.0),
+                "maximum": cf.Data(1),
+                "range": cf.Data(0),
+                "mid_range": cf.Data(1.0),
+                "standard_deviation": cf.Data(0.0),
+                "root_mean_square": cf.Data(1.0),
+                "sample_size": cf.Data([2]),
+            },
+        )
+
+        s2 = d.stats(all=True)
+        self.assertEqual(len(s2), 16)
+        self.assertEqual(
+            s2,
+            {
+                "minimum": cf.Data(1),
+                "mean": cf.Data(1.0),
+                "median": cf.Data(1.0),
+                "maximum": cf.Data(1),
+                "range": cf.Data(0),
+                "mid_range": cf.Data(1.0),
+                "standard_deviation": cf.Data(0.0),
+                "root_mean_square": cf.Data(1.0),
+                "minimum_absolute_value": cf.Data(1),
+                "maximum_absolute_value": cf.Data(1),
+                "mean_absolute_value": cf.Data(1.0),
+                "mean_of_upper_decile": cf.Data(1.0),
+                "sum": cf.Data(2),
+                "sum_of_squares": cf.Data(2),
+                "variance": cf.Data(0.0),
+                "sample_size": cf.Data([2]),
+            },
+        )
+
+        s3 = d.stats(sum=True, weights=1)
+        self.assertEqual(len(s3), 10)  # 9 + 1 because the 'sum' op. is added
+        self.assertEqual(
+            s3,
             {
                 "minimum": cf.Data(1),
                 "mean": cf.Data(1.0),
@@ -713,13 +756,24 @@ class DataTest(unittest.TestCase):
                 "standard_deviation": cf.Data(0.0),
                 "root_mean_square": cf.Data(1.0),
                 "sum": cf.Data(2),
-                "variance": cf.Data(0.0),
-                "minimum_absolute_value": cf.Data(1),
-                "maximum_absolute_value": cf.Data(1),
-                "mean_absolute_value": cf.Data(1.0),
+                "sample_size": cf.Data([2]),
+            },
+        )
+
+        s4 = d.stats(mean_of_upper_decile=True, range=False, weights=2.0)
+        self.assertEqual(len(s4), 9)  # 9 + 1 - 1 for adding MOUD, losing range
+        self.assertEqual(
+            s4,
+            {
+                "minimum": cf.Data(1),
+                "mean": cf.Data(1.0),
+                "median": cf.Data(1.0),
+                "maximum": cf.Data(1),
+                "mid_range": cf.Data(1.0),
+                "standard_deviation": cf.Data(0.0),
+                "root_mean_square": cf.Data(1.0),
                 "mean_of_upper_decile": cf.Data(1.0),
-                "sum_of_squares": cf.Data(2),
-                "sample_size": cf.Data([2]),  # note the different dim here!
+                "sample_size": cf.Data([2]),
             },
         )
 

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -11,6 +11,7 @@ from operator import mul
 
 import dask.array as da
 import numpy as np
+from dask.delayed import Delayed
 
 SCIPY_AVAILABLE = False
 try:
@@ -731,6 +732,14 @@ class DataTest(unittest.TestCase):
             },
         )
 
+        # Check compute parameter i.e. delayed value return
+        s1_del = d.stats(compute=False)
+        self.assertEqual(len(s1_del), 9)
+        self.assertIsInstance(s1_del["mean"], Delayed)
+        s1_del_computed = {op: val.compute() for op, val in s1_del.items()}
+        self.assertEqual(s1_del_computed, s1)
+
+        # Other parameter testing...
         s2 = d.stats(all=True)
         self.assertEqual(len(s2), 16)
         self.assertEqual(
@@ -754,7 +763,6 @@ class DataTest(unittest.TestCase):
                 "sample_size": cf.Data([2]),
             },
         )
-
         s3 = d.stats(sum=True, weights=1)
         self.assertEqual(len(s3), 10)  # 9 + 1 because the 'sum' op. is added
         self.assertEqual(
@@ -772,7 +780,6 @@ class DataTest(unittest.TestCase):
                 "sample_size": cf.Data([2]),
             },
         )
-
         s4 = d.stats(mean_of_upper_decile=True, range=False, weights=2.0)
         self.assertEqual(len(s4), 9)  # 9 + 1 - 1 for adding MOUD, losing range
         self.assertEqual(

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -697,7 +697,6 @@ class DataTest(unittest.TestCase):
         self.assertEqual(e.shape, (0,))
         self.assertTrue((e.array == a.compressed()).all())
 
-    @unittest.skipIf(TEST_DASKIFIED_ONLY, "Needs __eq__")
     def test_Data_stats(self):
         """Test the `stats` Data method."""
         d = cf.Data([1, 1])

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -713,7 +713,13 @@ class DataTest(unittest.TestCase):
                 "standard_deviation": cf.Data(0.0),
                 "root_mean_square": cf.Data(1.0),
                 "sum": cf.Data(2),
-                "sample_size": cf.Data([2]),
+                "variance": cf.Data(0.0),
+                "minimum_absolute_value": cf.Data(1),
+                "maximum_absolute_value": cf.Data(1),
+                "mean_absolute_value": cf.Data(1.0),
+                "mean_of_upper_decile": cf.Data(1.0),
+                "sum_of_squares": cf.Data(2),
+                "sample_size": cf.Data([2]),  # note the different dim here!
             },
         )
 

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -713,7 +713,7 @@ class DataTest(unittest.TestCase):
                 "standard_deviation": cf.Data(0.0),
                 "root_mean_square": cf.Data(1.0),
                 "sum": cf.Data(2),
-                "sample_size": cf.Data(2),
+                "sample_size": cf.Data([2]),
             },
         )
 

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -103,17 +103,24 @@ class DataTest(unittest.TestCase):
         # Suppress the warning output for some specific warnings which are
         # expected due to the nature of the tests being performed.
         expexted_warning_msgs = [
-            "divide by zero encountered in arctanh",
-            "divide by zero encountered in log",
-            "divide by zero encountered in double_scalars",
-            "invalid value encountered in arcsin",
-            "invalid value encountered in arccos",
-            "invalid value encountered in arctanh",
-            "invalid value encountered in arccosh",
-            "invalid value encountered in log",
-            "invalid value encountered in sqrt",
-            "invalid value encountered in double_scalars",
-            "invalid value encountered in true_divide",
+            "divide by zero encountered in " + np_method
+            for np_method in (
+                "arctanh",
+                "log",
+                "double_scalars",
+            )
+        ] + [
+            "invalid value encountered in " + np_method
+            for np_method in (
+                "arcsin",
+                "arccos",
+                "arctanh",
+                "arccosh",
+                "log",
+                "sqrt",
+                "double_scalars",
+                "true_divide",
+            )
         ]
         for expected_warning in expexted_warning_msgs:
             warnings.filterwarnings(

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -720,15 +720,15 @@ class DataTest(unittest.TestCase):
         self.assertEqual(
             s1,
             {
-                "minimum": cf.Data(1),
-                "mean": cf.Data(1.0),
-                "median": cf.Data(1.0),
-                "maximum": cf.Data(1),
-                "range": cf.Data(0),
-                "mid_range": cf.Data(1.0),
-                "standard_deviation": cf.Data(0.0),
-                "root_mean_square": cf.Data(1.0),
-                "sample_size": cf.Data([2]),
+                "minimum": 1,
+                "mean": 1.0,
+                "median": 1.0,
+                "maximum": 1,
+                "range": 0,
+                "mid_range": 1.0,
+                "standard_deviation": 0.0,
+                "root_mean_square": 1.0,
+                "sample_size": 2,
             },
         )
 
@@ -745,22 +745,22 @@ class DataTest(unittest.TestCase):
         self.assertEqual(
             s2,
             {
-                "minimum": cf.Data(1),
-                "mean": cf.Data(1.0),
-                "median": cf.Data(1.0),
-                "maximum": cf.Data(1),
-                "range": cf.Data(0),
-                "mid_range": cf.Data(1.0),
-                "standard_deviation": cf.Data(0.0),
-                "root_mean_square": cf.Data(1.0),
-                "minimum_absolute_value": cf.Data(1),
-                "maximum_absolute_value": cf.Data(1),
-                "mean_absolute_value": cf.Data(1.0),
-                "mean_of_upper_decile": cf.Data(1.0),
-                "sum": cf.Data(2),
-                "sum_of_squares": cf.Data(2),
-                "variance": cf.Data(0.0),
-                "sample_size": cf.Data([2]),
+                "minimum": 1,
+                "mean": 1.0,
+                "median": 1.0,
+                "maximum": 1,
+                "range": 0,
+                "mid_range": 1.0,
+                "standard_deviation": 0.0,
+                "root_mean_square": 1.0,
+                "minimum_absolute_value": 1,
+                "maximum_absolute_value": 1,
+                "mean_absolute_value": 1.0,
+                "mean_of_upper_decile": 1.0,
+                "sum": 2,
+                "sum_of_squares": 2,
+                "variance": 0.0,
+                "sample_size": 2,
             },
         )
         s3 = d.stats(sum=True, weights=1)
@@ -768,16 +768,16 @@ class DataTest(unittest.TestCase):
         self.assertEqual(
             s3,
             {
-                "minimum": cf.Data(1),
-                "mean": cf.Data(1.0),
-                "median": cf.Data(1.0),
-                "maximum": cf.Data(1),
-                "range": cf.Data(0),
-                "mid_range": cf.Data(1.0),
-                "standard_deviation": cf.Data(0.0),
-                "root_mean_square": cf.Data(1.0),
-                "sum": cf.Data(2),
-                "sample_size": cf.Data([2]),
+                "minimum": 1,
+                "mean": 1.0,
+                "median": 1.0,
+                "maximum": 1,
+                "range": 0,
+                "mid_range": 1.0,
+                "standard_deviation": 0.0,
+                "root_mean_square": 1.0,
+                "sum": 2,
+                "sample_size": 2,
             },
         )
         s4 = d.stats(mean_of_upper_decile=True, range=False, weights=2.0)
@@ -785,15 +785,15 @@ class DataTest(unittest.TestCase):
         self.assertEqual(
             s4,
             {
-                "minimum": cf.Data(1),
-                "mean": cf.Data(1.0),
-                "median": cf.Data(1.0),
-                "maximum": cf.Data(1),
-                "mid_range": cf.Data(1.0),
-                "standard_deviation": cf.Data(0.0),
-                "root_mean_square": cf.Data(1.0),
-                "mean_of_upper_decile": cf.Data(1.0),
-                "sample_size": cf.Data([2]),
+                "minimum": 1,
+                "mean": 1.0,
+                "median": 1.0,
+                "maximum": 1,
+                "mid_range": 1.0,
+                "standard_deviation": 0.0,
+                "root_mean_square": 1.0,
+                "mean_of_upper_decile": 1.0,
+                "sample_size": 2,
             },
         )
 
@@ -801,24 +801,24 @@ class DataTest(unittest.TestCase):
         self.assertEqual(
             cf.Data(10).stats(),
             {
-                "minimum": cf.Data(10),
-                "mean": cf.Data(10.0),
-                "median": cf.Data(10.0),
-                "maximum": cf.Data(10),
-                "range": cf.Data(0),
-                "mid_range": cf.Data(10.0),
-                "standard_deviation": cf.Data(0.0),
-                "root_mean_square": cf.Data(10.0),
-                "sample_size": cf.Data(1),
+                "minimum": 10,
+                "mean": 10.0,
+                "median": 10.0,
+                "maximum": 10,
+                "range": 0,
+                "mid_range": 10.0,
+                "standard_deviation": 0.0,
+                "root_mean_square": 10.0,
+                "sample_size": 1,
             },
         )
         # NaN values aren't 'equal' to e/o, so check call works and that some
         # representative values are as expected, in this case
         s5 = cf.Data([[-2, -1, 0], [1, 2, 3]]).stats(all=True, weights=0)
         self.assertEqual(len(s5), 16)
-        self.assertEqual(s5["minimum"], cf.Data(-2))
-        self.assertEqual(s5["sum"], cf.Data(3))
-        self.assertEqual(s5["sample_size"], cf.Data([[6]]))
+        self.assertEqual(s5["minimum"], -2)
+        self.assertEqual(s5["sum"], 3)
+        self.assertEqual(s5["sample_size"], 6)
         self.assertTrue(np.isnan(s5["mean"]))
         self.assertTrue(np.isnan(s5["variance"]))  # needs all=True to show up
 

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -11,7 +11,6 @@ from operator import mul
 
 import dask.array as da
 import numpy as np
-from dask.delayed import Delayed
 
 SCIPY_AVAILABLE = False
 try:
@@ -715,86 +714,95 @@ class DataTest(unittest.TestCase):
         """Test the `stats` Data method."""
         d = cf.Data([1, 1])
 
+        # Test outputs covering a representative selection of parameters
         s1 = d.stats()
+        s1_lazy = d.stats(compute=False)
+        exp_result = {
+            "minimum": 1,
+            "mean": 1.0,
+            "median": 1.0,
+            "maximum": 1,
+            "range": 0,
+            "mid_range": 1.0,
+            "standard_deviation": 0.0,
+            "root_mean_square": 1.0,
+            "sample_size": 2,
+        }
         self.assertEqual(len(s1), 9)
+        self.assertEqual(s1, exp_result)
+        self.assertEqual(len(s1_lazy), len(s1))
         self.assertEqual(
-            s1,
-            {
-                "minimum": 1,
-                "mean": 1.0,
-                "median": 1.0,
-                "maximum": 1,
-                "range": 0,
-                "mid_range": 1.0,
-                "standard_deviation": 0.0,
-                "root_mean_square": 1.0,
-                "sample_size": 2,
-            },
+            s1_lazy, {op: cf.Data(val) for op, val in exp_result.items()}
         )
 
-        # Check compute parameter i.e. delayed value return
-        s1_del = d.stats(compute=False)
-        self.assertEqual(len(s1_del), 9)
-        self.assertIsInstance(s1_del["mean"], Delayed)
-        s1_del_computed = {op: val.compute() for op, val in s1_del.items()}
-        self.assertEqual(s1_del_computed, s1)
-
-        # Other parameter testing...
         s2 = d.stats(all=True)
+        s2_lazy = d.stats(compute=False, all=True)
+        exp_result = {
+            "minimum": 1,
+            "mean": 1.0,
+            "median": 1.0,
+            "maximum": 1,
+            "range": 0,
+            "mid_range": 1.0,
+            "standard_deviation": 0.0,
+            "root_mean_square": 1.0,
+            "minimum_absolute_value": 1,
+            "maximum_absolute_value": 1,
+            "mean_absolute_value": 1.0,
+            "mean_of_upper_decile": 1.0,
+            "sum": 2,
+            "sum_of_squares": 2,
+            "variance": 0.0,
+            "sample_size": 2,
+        }
         self.assertEqual(len(s2), 16)
+        self.assertEqual(s2, exp_result)
+        self.assertEqual(len(s2_lazy), len(s2))
         self.assertEqual(
-            s2,
-            {
-                "minimum": 1,
-                "mean": 1.0,
-                "median": 1.0,
-                "maximum": 1,
-                "range": 0,
-                "mid_range": 1.0,
-                "standard_deviation": 0.0,
-                "root_mean_square": 1.0,
-                "minimum_absolute_value": 1,
-                "maximum_absolute_value": 1,
-                "mean_absolute_value": 1.0,
-                "mean_of_upper_decile": 1.0,
-                "sum": 2,
-                "sum_of_squares": 2,
-                "variance": 0.0,
-                "sample_size": 2,
-            },
+            s2_lazy, {op: cf.Data(val) for op, val in exp_result.items()}
         )
+
         s3 = d.stats(sum=True, weights=1)
+        s3_lazy = d.stats(compute=False, sum=True, weights=1)
+        exp_result = {
+            "minimum": 1,
+            "mean": 1.0,
+            "median": 1.0,
+            "maximum": 1,
+            "range": 0,
+            "mid_range": 1.0,
+            "standard_deviation": 0.0,
+            "root_mean_square": 1.0,
+            "sum": 2,
+            "sample_size": 2,
+        }
         self.assertEqual(len(s3), 10)  # 9 + 1 because the 'sum' op. is added
+        self.assertEqual(s3, exp_result)
+        self.assertEqual(len(s3_lazy), len(s3))
         self.assertEqual(
-            s3,
-            {
-                "minimum": 1,
-                "mean": 1.0,
-                "median": 1.0,
-                "maximum": 1,
-                "range": 0,
-                "mid_range": 1.0,
-                "standard_deviation": 0.0,
-                "root_mean_square": 1.0,
-                "sum": 2,
-                "sample_size": 2,
-            },
+            s3_lazy, {op: cf.Data(val) for op, val in exp_result.items()}
         )
+
         s4 = d.stats(mean_of_upper_decile=True, range=False, weights=2.0)
+        s4_lazy = d.stats(
+            compute=False, mean_of_upper_decile=True, range=False, weights=2.0
+        )
+        exp_result = {
+            "minimum": 1,
+            "mean": 1.0,
+            "median": 1.0,
+            "maximum": 1,
+            "mid_range": 1.0,
+            "standard_deviation": 0.0,
+            "root_mean_square": 1.0,
+            "mean_of_upper_decile": 1.0,
+            "sample_size": 2,
+        }
         self.assertEqual(len(s4), 9)  # 9 + 1 - 1 for adding MOUD, losing range
+        self.assertEqual(s4, exp_result)
+        self.assertEqual(len(s4_lazy), len(s4))
         self.assertEqual(
-            s4,
-            {
-                "minimum": 1,
-                "mean": 1.0,
-                "median": 1.0,
-                "maximum": 1,
-                "mid_range": 1.0,
-                "standard_deviation": 0.0,
-                "root_mean_square": 1.0,
-                "mean_of_upper_decile": 1.0,
-                "sample_size": 2,
-            },
+            s4_lazy, {op: cf.Data(val) for op, val in exp_result.items()}
         )
 
         # Check some weird/edge cases to ensure they are handled elegantly...

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -777,6 +777,31 @@ class DataTest(unittest.TestCase):
             },
         )
 
+        # Check some weird/edge cases to ensure they are handled elegantly...
+        self.assertEqual(
+            cf.Data(10).stats(),
+            {
+                "minimum": cf.Data(10),
+                "mean": cf.Data(10.0),
+                "median": cf.Data(10.0),
+                "maximum": cf.Data(10),
+                "range": cf.Data(0),
+                "mid_range": cf.Data(10.0),
+                "standard_deviation": cf.Data(0.0),
+                "root_mean_square": cf.Data(10.0),
+                "sample_size": cf.Data(1),
+            },
+        )
+        # NaN values aren't 'equal' to e/o, so check call works and that some
+        # representative values are as expected, in this case
+        s5 = cf.Data([[-2, -1, 0], [1, 2, 3]]).stats(all=True, weights=0)
+        self.assertEqual(len(s5), 16)
+        self.assertEqual(s5["minimum"], cf.Data(-2))
+        self.assertEqual(s5["sum"], cf.Data(3))
+        self.assertEqual(s5["sample_size"], cf.Data([[6]]))
+        self.assertTrue(np.isnan(s5["mean"]))
+        self.assertTrue(np.isnan(s5["variance"]))  # needs all=True to show up
+
     def test_Data__init__dtype_mask(self):
         """Test `__init__` for Data with `dtype` and `mask` keywords."""
         for m in (1, 20, True):


### PR DESCRIPTION
Migrates the `Data.stats` method towards https://github.com/NCAS-CMS/cf-python/issues/182.

Since `stats` is a compound method, in that it is in essence just reporting the outputs from various other `cf` stats/collapsing methods, each of which have already been 'daskified' hence utilise dask under-the-hood, the simplest way to migrate with full performance (bar working out and making use of any sub-calculation operations which might be shared between any of the statistics or something like that which would surely be over the top for our purposes?) is (I believe) to run each statistic calculation in parallel, which in Dask world for this context is done with `delayed` functions and a final `compute`.

This PR implements this. As indicated by the resultant Dask task graph shown below, all statistics are calculated separately, not in serial, so `stats` should take only as long as the most intensive calculation rather than the sum of all calculation times.

(I hope I haven't misunderstood the assignment here, so to speak, by taking such an approach centered on Dask's `delayed`.)


#### Graph

With the code as-is on the branch/PR here and now, but with a little tweak so we can access and save the Dask task graph, namely I did:

```diff
diff --git a/cf/data/data.py b/cf/data/data.py
index e91d6df03..2da53c70f 100644
--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -15,6 +15,7 @@ from dask.array.core import normalize_chunks
 from dask.base import is_dask_collection, tokenize
 from dask.core import flatten
 from dask.highlevelgraph import HighLevelGraph
+from dask import delayed, compute, visualize
 
 from ..cfdatetime import dt as cf_dt
 from ..constants import masked as cf_masked
@@ -9376,16 +9377,20 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
-        return compute(out)[0]
+        return out
```

the task graph generated interactively via:

```python
In [1]: import cf
   ...: import numpy as np
   ...: import dask

In [2]: a = cf.example_field(1)

In [3]: b = a.data.stats()

In [4]: dask.visualize(b, filename='stats-graph-final.png')
Out[4]: <IPython.core.display.Image object>
```

is:

![stats-graph-final](https://user-images.githubusercontent.com/30274190/184034032-ff925563-56bb-49d5-83aa-29579c0740a4.png)

which looks right to me. The task graph here doesn't indicate but obviously all results get pulled together into the `dict` output at compute-time at the end via querying the `compute` output tuple).