### PR TITLE
LAMA to Dask: `_combined_units` & further branch tidy

### DIFF
--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -3144,7 +3144,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
                         return data0, data1, _units_1
                 else:
                     # units1 is defined and is not dimensionless
-                    if data0._size > 1:
+                    if data0.size > 1:
                         raise ValueError(
                             "Can only raise units to the power of a single "
                             "value at a time. Asking to raise to the power of "
@@ -3220,7 +3220,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
                         return data0, data1, _units_1
                 else:
                     # units0 is defined and is not dimensionless
-                    if data1._size > 1:
+                    if data1.size > 1:
                         raise ValueError(
                             "Can only raise units to the power of a single "
                             "value at a time. Asking to raise to the power of "
@@ -8496,7 +8496,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
                     index = (slice(-1, None),) * self.ndim
                 elif isinstance(index, int):
                     if index < 0:
-                        index += self._size
+                        index += self.size
 
                     index = np.unravel_index(index, self.shape)
                 elif len(index) == self.ndim:

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -3372,6 +3372,13 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         elif inplace:
             # Find non-in-place equivalent operator (remove 'i')
             equiv_method = method[:2] + method[3:]
+            # Need to add check in here to ensure that the operation is not
+            # trying to cast in a way which is invalid. For example, doing
+            # [an int array] ** float value = [a float array] is fine, but
+            # doing this in-place would try to chance an int array into a
+            # float one, which isn't valid casting. Therefore we need to
+            # catch cases where __i<op>__ isn't possible even if __<op>__
+            # is due to datatype consistency rules.
             result = getattr(dx0, equiv_method)(dx1)
         else:
             result = getattr(dx0, method)(dx1)

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -2120,18 +2120,22 @@ class DataTest(unittest.TestCase):
                         e.equals(cf.Data(a, "m"), verbose=1), message
                     )
 
-                a = a0.copy()
-                try:
-                    a **= x
-                except TypeError:
-                    pass
-                else:
-                    e = d.copy()
-                    e **= x
-                    message = "Failed in {!r}**={}".format(d, x)
-                    self.assertTrue(
-                        e.equals(cf.Data(a, "m2"), verbose=1), message
-                    )
+                # TODO: this test fails due to casting issues. It is actually
+                # testing against expected behaviour with contradicts that of
+                # NumPy so we might want to change the logic: see Issue 435,
+                # github.com/NCAS-CMS/cf-python/issues/435. Skip for now.
+                # a = a0.copy()
+                # try:
+                #     a **= x
+                # except TypeError:
+                #     pass
+                # else:
+                #     e = d.copy()
+                #     e **= x
+                #     message = "Failed in {!r}**={}".format(d, x)
+                #     self.assertTrue(
+                #         e.equals(cf.Data(a, "m2"), verbose=1), message
+                #     )
 
                 a = a0.copy()
                 try:

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -293,7 +293,7 @@ class DataTest(unittest.TestCase):
         self.assertTrue(sa2.equals(sa2.copy()))
         # Unlike for numeric types, for string-like data as long as the data
         # is the same consider the arrays equal, even if the dtype differs.
-        # TODO DASK: this behaviour will be added via cfdm, test fails for now
+        # TODODASK: this behaviour will be added via cfdm, test fails for now
         # ## self.assertTrue(sa1.equals(sa2))
         sa3_data = sa2_data.astype("S5")
         sa3 = cf.Data(sa3_data, "m", chunks=mask_test_chunksize)

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -2004,14 +2004,10 @@ class DataTest(unittest.TestCase):
                 self.assertTrue(
                     (d // x).equals(cf.Data(a0 // x, "m"), verbose=1), message
                 )
-                # TODODASK SB: re-instate this once _combined_units is sorted,
-                # presently fails with error:
-                #     AttributeError: 'Data' object has no attribute '_size'
-                #
-                # message = "Failed in {!r}**{}".format(d, x)
-                # self.assertTrue(
-                #     (d ** x).equals(cf.Data(a0 ** x, "m2"), verbose=1), message
-                # )
+                message = "Failed in {!r}**{}".format(d, x)
+                self.assertTrue(
+                    (d**x).equals(cf.Data(a0**x, "m2"), verbose=1), message
+                )
                 message = "Failed in {!r}.__truediv__{}".format(d, x)
                 self.assertTrue(
                     d.__truediv__(x).equals(
@@ -2124,21 +2120,18 @@ class DataTest(unittest.TestCase):
                         e.equals(cf.Data(a, "m"), verbose=1), message
                     )
 
-                # TODODASK SB: re-instate this once _combined_units is sorted,
-                # presently fails with error, as with __pow__:
-                #     AttributeError: 'Data' object has no attribute '_size'
-                # a = a0.copy()
-                # try:
-                #     a **= x
-                # except TypeError:
-                #     pass
-                # else:
-                #     e = d.copy()
-                #     e **= x
-                #     message = "Failed in {!r}**={}".format(d, x)
-                #     self.assertTrue(
-                #         e.equals(cf.Data(a, "m2"), verbose=1), message
-                #     )
+                a = a0.copy()
+                try:
+                    a **= x
+                except TypeError:
+                    pass
+                else:
+                    e = d.copy()
+                    e **= x
+                    message = "Failed in {!r}**={}".format(d, x)
+                    self.assertTrue(
+                        e.equals(cf.Data(a, "m2"), verbose=1), message
+                    )
 
                 a = a0.copy()
                 try:


### PR DESCRIPTION
Ultimately reinstate a commented-out test case, failing due to a minor issue in `_combined_units`, which turned out to simply be a use of the property `Data._size` which has straightforwardly been replaced by `Data.size`. I also updated all other remaining usage of `_size` in the Data module, which turned out to be two extra cases overall.

There were in fact two test cases due to be reinstated from the above fix, but one (that concerns `__ipow__`) is failing due to data type differences summarised by #435, so I have updated the messages provided by the commented-out case.

