### PR TITLE
dask: datetime `Data` init, and combination with `Query` objects

### DIFF
--- a/cf/cfdatetime.py
+++ b/cf/cfdatetime.py
@@ -405,9 +405,11 @@ def st2elements(date_string):
 
 
 def rt2dt(array, units_in, units_out=None, dummy1=None):
-    """Convert reference times  to date-time objects.
+    """Convert reference times to date-time objects.
 
     The returned array is always independent.
+
+    .. seealso:: `dt2rt`
 
     :Parameters:
 
@@ -426,6 +428,17 @@ def rt2dt(array, units_in, units_out=None, dummy1=None):
         `numpy.ndarray`
             An array of `cftime.datetime` objects with the same shape
             as *array*.
+
+    **Examples**
+
+    >>> print(
+    ...   cf.cfdatetime.rt2dt(
+    ...     np.ma.array([0, 685.5], mask=[True, False]),
+    ...     units_in=cf.Units('days since 2000-01-01')
+    ...   )
+    ... )
+    [--
+     cftime.DatetimeGregorian(2001, 11, 16, 12, 0, 0, 0, has_year_zero=False)]
 
     """
     ndim = np.ndim(array)
@@ -456,20 +469,23 @@ def dt2Dt(x, calendar=None):
 
 
 def dt2rt(array, units_in, units_out, dummy1=None):
-    """Round to the nearest millisecond. This is only necessary whilst
-    netCDF4 time functions have an accuracy of no better than 1
-    millisecond (which is still the case at version 1.2.2).
+    """Return numeric time values from datetime objects.
 
-    The returned array is always independent.
+    .. seealso:: `rt2dt`
 
     :Parameters:
 
         array: numpy array-like of date-time objects
+            The datetime objects must be in UTC with no time-zone
+            offset.
 
-        units_in:
+      units_in:
             Ignored.
 
         units_out: `Units`
+            The units of the numeric time values. If there is a
+            time-zone offset in *units_out*, it will be applied to the
+            returned numeric values.
 
         dummy1:
             Ignored.
@@ -479,8 +495,19 @@ def dt2rt(array, units_in, units_out, dummy1=None):
         `numpy.ndarray`
             An array of numbers with the same shape as *array*.
 
+    **Examples**
+
+    >>> print(
+    ...   cf.cfdatetime.dt2rt(
+    ...     np.ma.array([0, cf.dt('2001-11-16 12:00')], mask=[True, False]),
+    ...     None,
+    ...     units_out=cf.Units('days since 2000-01-01'))
+    ...   )
+    ... )
+    [-- 685.5]
+
     """
-    isscalar = np.ndim(array)
+    isscalar = not np.ndim(array)
 
     array = cftime.date2num(
         array, units=units_out.units, calendar=units_out._utime.calendar

--- a/cf/cfdatetime.py
+++ b/cf/cfdatetime.py
@@ -501,7 +501,7 @@ def dt2rt(array, units_in, units_out, dummy1=None):
     ...   cf.cfdatetime.dt2rt(
     ...     np.ma.array([0, cf.dt('2001-11-16 12:00')], mask=[True, False]),
     ...     None,
-    ...     units_out=cf.Units('days since 2000-01-01'))
+    ...     units_out=cf.Units('days since 2000-01-01')
     ...   )
     ... )
     [-- 685.5]

--- a/cf/data/creation.py
+++ b/cf/data/creation.py
@@ -115,14 +115,14 @@ def to_dask(array, chunks, **from_array_options):
 
     try:
         return da.from_array(array, chunks=chunks, **kwargs)
-    except NotImplementedError as e:
-        if (
-            str(e)
-            == "Can not use auto rechunking with object dtype. We are unable to estimate the size in bytes of object data"
-        ):
-            # Try again with 'chunks=-1'
+    except NotImplementedError as error:
+        if chunks == "auto":
+            # Try again with 'chunks=-1', in case the failure was due
+            # to not being able to use auto rechunking with object
+            # dtype.
             return da.from_array(array, chunks=-1, **kwargs)
 
+        raise(error)
 
 def compressed_to_dask(array, chunks):
     """Create a dask array with `Subarray` chunks.

--- a/cf/data/creation.py
+++ b/cf/data/creation.py
@@ -82,7 +82,7 @@ def to_dask(array, chunks, **from_array_options):
 
     **Examples**
 
-    >>> cf.data.creation.to_dask([1, 2, 3])
+    >>> cf.data.creation.to_dask([1, 2, 3], 'auto')
     dask.array<array, shape=(3,), dtype=int64, chunksize=(3,), chunktype=numpy.ndarray>
     >>> cf.data.creation.to_dask([1, 2, 3], chunks=2)
     dask.array<array, shape=(3,), dtype=int64, chunksize=(2,), chunktype=numpy.ndarray>

--- a/cf/data/creation.py
+++ b/cf/data/creation.py
@@ -115,13 +115,9 @@ def to_dask(array, chunks, **from_array_options):
     try:
         return da.from_array(array, chunks=chunks, **kwargs)
     except NotImplementedError as error:
-        if chunks == "auto":
-            # Try again with 'chunks=-1', in case the failure was due
-            # to not being able to use auto rechunking with object
-            # dtype.
-            return da.from_array(array, chunks=-1, **kwargs)
-
-        raise (error)
+        # Try again with 'chunks=-1', in case the failure was due to
+        # not being able to use auto rechunking with object dtype.
+        return da.from_array(array, chunks=-1, **kwargs)
 
 
 def compressed_to_dask(array, chunks):

--- a/cf/data/creation.py
+++ b/cf/data/creation.py
@@ -99,11 +99,10 @@ def to_dask(array, chunks, **from_array_options):
         or isinstance(
             array, (np.ndarray, list, tuple, memoryview) + np.ScalarType
         )
-    ):
-        if not hasattr(array, "shape"):
-            # 'array' is not of a type that `da.from_array` can cope
-            # with, so convert it to a numpy array
-            array = np.asanyarray(array)
+    ) and not hasattr(array, "shape"):
+        # 'array' is not of a type that `da.from_array` can cope with,
+        # so convert it to a numpy array
+        array = np.asanyarray(array)
 
     kwargs = from_array_options
     lock = getattr(array, "_dask_lock", False)
@@ -122,7 +121,8 @@ def to_dask(array, chunks, **from_array_options):
             # dtype.
             return da.from_array(array, chunks=-1, **kwargs)
 
-        raise(error)
+        raise (error)
+
 
 def compressed_to_dask(array, chunks):
     """Create a dask array with `Subarray` chunks.

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -3313,16 +3313,16 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         [0 2 4 6]
 
         """
+        if getattr(other, "_NotImplemented_RHS_Data_op", False):
+            return NotImplemented
+
         inplace = method[2] == "i"
 
         # ------------------------------------------------------------
         # Ensure other is an independent Data object, for example
         # so that combination with cf.Query objects works.
         # ------------------------------------------------------------
-        if getattr(other, "_NotImplemented_RHS_Data_op", False):
-            return NotImplemented
-
-        elif not isinstance(other, self.__class__):
+        if not isinstance(other, self.__class__):
             if (
                 isinstance(other, cftime.datetime)
                 and other.calendar == ""

--- a/cf/data/utils.py
+++ b/cf/data/utils.py
@@ -183,7 +183,7 @@ def convert_to_reftime(a, units=None, first_value=None):
         d_units = getattr(units, "units", None)
 
         if x_calendar != "":
-            if units is None:
+            if not units:
                 d_calendar = x_calendar
             elif not units.equivalent(Units(x_since, x_calendar)):
                 raise ValueError(

--- a/cf/field.py
+++ b/cf/field.py
@@ -944,11 +944,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
         >>> f._binary_operation(g, '__rdiv__')
 
         """
-
-        if isinstance(other, Query):
-            # --------------------------------------------------------
-            # Combine the field with a Query object
-            # --------------------------------------------------------
+        if getattr(other, "_NotImplemented_RHS_Data_op", False):
             return NotImplemented
 
         if not isinstance(other, self.__class__):

--- a/cf/mixin/propertiesdata.py
+++ b/cf/mixin/propertiesdata.py
@@ -568,6 +568,9 @@ class PropertiesData(Properties):
         >>> u._binary_operation(v, '__idiv__')
 
         """
+        if getattr(y, "_NotImplemented_RHS_Data_op", False):
+            return NotImplemented
+
         data = self.get_data(None, _fill_value=None)
         if data is None:
             raise ValueError(

--- a/cf/mixin/propertiesdatabounds.py
+++ b/cf/mixin/propertiesdatabounds.py
@@ -439,6 +439,9 @@ class PropertiesDataBounds(PropertiesData):
                 was in-place.
 
         """
+        if getattr(other, "_NotImplemented_RHS_Data_op", False):
+            return NotImplemented
+
         inplace = method[2] == "i"
 
         bounds_AND = bounds and bounds_combination_mode() == "AND"

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -4111,9 +4111,16 @@ class DataTest(unittest.TestCase):
         d = cf.Data(dt)
         self.assertTrue((d.array == [0, 31]).all())
 
+        q = cf.wi(cf.dt(1999, 9, 1), cf.dt(2001, 11, 16, 12))
+        self.assertTrue((q == d).array.all())
+        self.assertTrue((d == q).array.all())
+
         dt = np.ma.array(dt, mask=[True, False])
         d = cf.Data(dt)
         self.assertTrue((d.array == [-999, 0]).all())
+
+        self.assertTrue((q == d).array.all())
+        self.assertTrue((d == q).array.all())
 
 
 if __name__ == "__main__":

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -4100,6 +4100,21 @@ class DataTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             d.get_list()
 
+    def test_Data__init__datetime(self):
+        """Test `Data.__init__` for datetime objects."""
+        dt = cf.dt(2000, 1, 1)
+        for a in (dt, [dt], [[dt]]):
+            d = cf.Data(a)
+            self.assertEqual(d.array, 0)
+
+        dt = [dt, cf.dt(2000, 2, 1)]
+        d = cf.Data(dt)
+        self.assertTrue((d.array == [0, 31]).all())
+
+        dt = np.ma.array(dt, mask=[True, False])
+        d = cf.Data(dt)
+        self.assertTrue((d.array == [-999, 0]).all())
+
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -2763,6 +2763,24 @@ class FieldTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             f.to_dask_array()
 
+    def test_Field_combine_with_Query(self):
+        f = self.f0
+        q = cf.lt(0.1)
+        q == f
+        f == q
+
+        f = cf.example_field(2)
+
+        x = f.coordinate("X")
+        q = cf.eq(337.5)
+        q == x
+        x == q
+
+        t = f.coordinate("T")
+        q = cf.dt(1962, 11, 16)
+        q == t
+        t == q
+
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -2766,20 +2766,28 @@ class FieldTest(unittest.TestCase):
     def test_Field_combine_with_Query(self):
         f = self.f0
         q = cf.lt(0.1)
-        q == f
-        f == q
+        (q == f).array
+        (f == q).array
 
         f = cf.example_field(2)
 
         x = f.coordinate("X")
         q = cf.eq(337.5)
-        q == x
-        x == q
+        (q == x).array
+        (x == q).array
 
         t = f.coordinate("T")
         q = cf.dt(1962, 11, 16)
-        q == t
-        t == q
+        (q == t).array
+        (t == q).array
+
+        q = cf.wi(cf.dt(1960, 9, 1), cf.dt(1962, 11, 16, 12))
+        (q == t).array
+        (t == q).array
+
+        q = cf.eq(cf.dt(1962, 11, 16, 12))
+        (q == t).array
+        (t == q).array
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi Sadie, bit rambling, but fixes a bug that didn't allow `Data` objects to be instantiated from datetime objects, and also one that prevented constructs from being combined with Query objects, in some circumstances (the latter uncovered the former). 