### PR TITLE
dask: `Data.Units` @Units.setter

### DIFF
--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -4169,7 +4169,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         except KeyError:
             pass
         else:
-            if not old_units.equivalent(value):
+            if old_units and not old_units.equivalent(value):
                 raise ValueError(
                     f"Can't set Units to {value!r} that are not "
                     f"equivalent to the current units {old_units!r}. "

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -4054,13 +4054,13 @@ class DataTest(unittest.TestCase):
 
         # Assign units when none were set
         d = cf.Data(100)
-        d.Units = cf.Units('km')
+        d.Units = cf.Units("km")
         self.assertEqual(d.Units, cf.Units("km"))
 
-        d = cf.Data(100, '')
+        d = cf.Data(100, "")
         with self.assertRaises(ValueError):
-            d.Units = cf.Units('km')
- 
+            d.Units = cf.Units("km")
+
         # Assign non-equivalent units
         with self.assertRaises(ValueError):
             d.Units = cf.Units("watt")

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -4052,6 +4052,15 @@ class DataTest(unittest.TestCase):
         self.assertEqual(d.Units, cf.Units("km"))
         self.assertEqual(d.array, 0.1)
 
+        # Assign units when none were set
+        d = cf.Data(100)
+        d.Units = cf.Units('km')
+        self.assertEqual(d.Units, cf.Units("km"))
+
+        d = cf.Data(100, '')
+        with self.assertRaises(ValueError):
+            d.Units = cf.Units('km')
+ 
         # Assign non-equivalent units
         with self.assertRaises(ValueError):
             d.Units = cf.Units("watt")


### PR DESCRIPTION
Allow `Data.Units` assignment when the data units have no been set.