### PR TITLE
dask: `FieldTest.test_Field_transpose`

### DIFF
--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -2162,7 +2162,6 @@ class FieldTest(unittest.TestCase):
             ("grid_longitude", re.compile("^atmos"), "grid_latitude"),
             inplace=True,
         )
-        h.varray
         h.transpose(
             (re.compile("^atmos"), "grid_latitude", "grid_longitude"),
             inplace=True,


### PR DESCRIPTION
Removes non-needed `varray` call in test.