### PR TITLE
dask: `Data.outerproduct` _axes/_cyclic fix

### DIFF
--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -8206,10 +8206,23 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
             pass
 
         dx = d.to_dask_array()
+        ndim = dx.ndim
+
         dx = da.ufunc.multiply.outer(dx, a)
         d._set_dask(dx)
 
         d.override_units(d.Units * a.Units, inplace=True)
+
+        # Include axis names for the new dimensions
+        axes = d._axes
+        for i, a_axis in enumerate(a._axes):
+            axes += (new_axis_identifier(axes),)
+
+        d._axes = axes
+
+        # Make sure that cyclic axes in 'a' are still cyclic in 'd'
+        for a_axis in a._cyclic:
+            d.cyclic(ndim + a._axes.index(a_axis))
 
         return d
 

--- a/cf/domain.py
+++ b/cf/domain.py
@@ -672,7 +672,8 @@ class Domain(mixin.FieldDomain, mixin.Properties, cfdm.Domain):
         return out
 
     def indices(self, *mode, **kwargs):
-        """Create indices that define a subspace of the domain construct.
+        """Create indices that define a subspace of the domain
+        construct.
 
         The indices returned by this method be used to create the
         subspace by passing them to the `subspace` method of the

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -1413,6 +1413,15 @@ class DataTest(unittest.TestCase):
         self.assertEqual(d.shape, (4, 3, 5))
         self.assertEqual(d.Units, cf.Units("m.s-1"))
 
+        # axes/cyclic
+        d = cf.Data(np.arange(12).reshape(4, 3))
+        e = cf.Data(np.arange(6).reshape(2, 3))
+        d.cyclic(0)
+        e.cyclic(1)
+        f = d.outerproduct(e)
+        self.assertEqual(len(f._axes), d.ndim + e.ndim)
+        self.assertEqual(f.cyclic(), set([0, d.ndim + 1]))
+
     def test_Data_all(self):
         """Test the `all` Data method."""
         d = cf.Data([[1, 2], [3, 4]], "m")


### PR DESCRIPTION
This fix allows `test_Field_cell_area` and `test_Field_weights` to pass.