### PR TITLE
dask: `Data.__iter__`

### DIFF
--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -772,8 +772,14 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         except TypeError:
             raise TypeError(f"iteration over a 0-d {self.__class__.__name__}")
 
+        keepdims_indexing = self.__keepdims_indexing__
+
         for i in range(n):
-            yield self[i]
+            out = self[i]
+            if keepdims_indexing:
+                out.reshape(out.shape[1:], inplace=True)
+
+            yield out
 
     def __len__(self):
         """Called to implement the built-in function `len`.

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -2920,8 +2920,18 @@ class DataTest(unittest.TestCase):
             cf.Data([1, 2, 3], "metres"),
             cf.Data([[1, 2], [3, 4]], "metres"),
         ):
+            d.__keepdims_indexing__ = False
             for i, e in enumerate(d):
                 self.assertTrue(e.equals(d[i]))
+
+        for d in (
+            cf.Data([1, 2, 3], "metres"),
+            cf.Data([[1, 2], [3, 4]], "metres"),
+        ):
+            d.__keepdims_indexing__ = True
+            for i, e in enumerate(d):
+                out = d[i]
+                self.assertTrue(e.equals(out.reshape(out.shape[1:])))
 
         # iteration over a 0-d Data
         with self.assertRaises(TypeError):


### PR DESCRIPTION
Update `Data.__iter__` functionality to more closely match that of cf-python v3.13.0.

This fix (along with the related https://github.com/NCAS-CMS/cfdm/pull/219) is needed for `test_Field_compress_uncompress` to pass.