### PR TITLE
dask: `Field.cumsum`

### DIFF
--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -736,11 +736,11 @@ class FieldTest(unittest.TestCase):
         f.domain_mask(grid_longitude=cf.wi(25, 31))
 
     def test_Field_cumsum(self):
-        f = self.f.copy()
+        f = cf.example_field(0)
 
         g = f.copy()
-        h = g.cumsum(2)
-        self.assertIsNone(g.cumsum(2, inplace=True))
+        h = g.cumsum(1)
+        self.assertIsNone(g.cumsum(1, inplace=True))
         self.assertTrue(g.equals(h, verbose=2))
 
         # Check that a new cell method that has been added
@@ -748,21 +748,29 @@ class FieldTest(unittest.TestCase):
         self.assertEqual(len(cell_methods), len(f.cell_methods()) + 1)
         _, cm = cell_methods.popitem()
         self.assertEqual(cm.method, "sum")
-        self.assertEqual(cm.axes, (h.get_data_axes()[2],))
+        self.assertEqual(cm.axes, (h.get_data_axes()[1],))
 
-        # Check the dimension coordinate bounds
+        # Check increasing dimension coordinate bounds
         fx = f.dimension_coordinate("X")
         hx = h.dimension_coordinate("X")
         self.assertTrue((hx.lower_bounds == fx.lower_bounds[0]).all())
         self.assertTrue((hx.upper_bounds == fx.upper_bounds).all())
+
+        # Check decreasing dimension coordinate bounds
+        g = f.flip("X")
+        h = g.cumsum("X")
+        gx = g.dimension_coordinate("X")
+        hx = h.dimension_coordinate("X")
+        self.assertTrue((hx.upper_bounds == gx.upper_bounds[0]).all())
+        self.assertTrue((hx.lower_bounds == gx.lower_bounds).all())
 
         a = f.array
         for axis in range(f.ndim):
             b = np.cumsum(a, axis=axis)
             self.assertTrue((f.cumsum(axis=axis).array == b).all())
 
-        f[0, 0, 3] = cf.masked
-        f[0, 2, 7] = cf.masked
+        f[0, 3] = cf.masked
+        f[2, 7] = cf.masked
 
         a = f.array
         for axis in range(f.ndim):

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -743,36 +743,32 @@ class FieldTest(unittest.TestCase):
         self.assertIsNone(g.cumsum(2, inplace=True))
         self.assertTrue(g.equals(h, verbose=2))
 
+        # Check that a new cell method that has been added
+        cell_methods = h.cell_methods(todict=True)
+        self.assertEqual(len(cell_methods), len(f.cell_methods()) + 1)
+        _, cm = cell_methods.popitem()
+        self.assertEqual(cm.method, "sum")
+        self.assertEqual(cm.axes, (h.get_data_axes()[2],))
+
+        # Check the dimension coordinate bounds
+        fx = f.dimension_coordinate("X")
+        hx = h.dimension_coordinate("X")
+        self.assertTrue((hx.lower_bounds == fx.lower_bounds[0]).all())
+        self.assertTrue((hx.upper_bounds == fx.upper_bounds).all())
+
+        a = f.array
         for axis in range(f.ndim):
-            a = numpy.cumsum(f.array, axis=axis)
-            self.assertTrue((f.cumsum(axis=axis).array == a).all())
+            b = np.cumsum(a, axis=axis)
+            self.assertTrue((f.cumsum(axis=axis).array == b).all())
 
         f[0, 0, 3] = cf.masked
         f[0, 2, 7] = cf.masked
 
+        a = f.array
         for axis in range(f.ndim):
-            a = f.array
-            a = numpy.cumsum(a, axis=axis)
+            b = np.cumsum(a, axis=axis)
             g = f.cumsum(axis=axis)
-            self.assertTrue(cf.functions._numpy_allclose(g.array, a))
-
-        for axis in range(f.ndim):
-            g = f.cumsum(axis=axis, masked_as_zero=True)
-
-            a = f.array
-            mask = a.mask
-            a = a.filled(0)
-            a = numpy.cumsum(a, axis=axis)
-            size = a.shape[axis]
-            shape = [1] * a.ndim
-            shape[axis] = size
-            new_mask = numpy.cumsum(mask, axis=axis) == numpy.arange(
-                1, size + 1
-            ).reshape(shape)
-            a = numpy.ma.array(a, mask=new_mask, copy=False)
-            self.assertTrue(
-                cf.functions._numpy_allclose(g.array, a, verbose=2)
-            )
+            self.assertTrue(cf.functions._numpy_allclose(g.array, b))
 
     def test_Field_flip(self):
         f = self.f.copy()


### PR DESCRIPTION
API changes:
* `masked_as_zero` parameter deprecated (see #343 for details)
* `coordinate` parameter deprecated. This is because it was always flaky, and I didn't want to make the effort to daskify dodgy code that will be going anyway. It is flaky because it allowed non-CF compliant dimension coordinates to be created automatically. Specifically, the moving of the coordinate coordinate values could result in non strictly monotonic values, because the bounds do not have to follow this restriction. 