### PR TITLE
dask: `Field.where`

### DIFF
--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -9565,7 +9565,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         The array and the *condition*, *x* and *y* parameters must all
         be broadcastable across the original array, such that the size
-        of the result is identical to the orginal size of the
+        of the result is identical to the original size of the
         array. Leading size 1 dimensions of these parameters are
         ignored, thereby also ensuring that the shape of the result is
         identical to the orginal shape of the array.

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -8202,10 +8202,12 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         d = _inplace_enabled_define_and_cleanup(self)
 
         # Cast 'a' as a Data object so that it definitely has sensible
-        # Units
+        # Units. We don't mind if the units of 'a' are incompatible
+        # with those of 'self', but if they are then it's nice if the
+        # units are conformed.
         a = self.asdata(a)
         try:
-            a = conform_units(a, d.Units)
+            a = conform_units(a, d.Units, message="")
         except ValueError:
             pass
 
@@ -9562,8 +9564,11 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         **Broadcasting**
 
         The array and the *condition*, *x* and *y* parameters must all
-        be broadcastable to each other, such that the shape of the
-        result is identical to the orginal shape of the array.
+        be broadcastable across the original array, such that the size
+        of the result is identical to the orginal size of the
+        array. Leading size 1 dimensions of these parameters are
+        ignored, thereby also ensuring that the shape of the result is
+        identical to the orginal shape of the array.
 
         If *condition* is a `Query` object then for the purposes of
         broadcasting, the condition is considered to be that which is
@@ -9581,7 +9586,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         :Parameters:
 
-            condition: array-like or `Query`
+            condition: array_like or `Query`
                 The condition which determines how to assign values to
                 the data.
 
@@ -9714,7 +9719,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         >>> d = cf.Data(x)
         >>> e = d.where(condition, d, 10 + y)
             ...
-        ValueError: where: Broadcasting the 'condition' parameter with shape (3, 4) would change the shape of the data with shape (3, 1)
+        ValueError: where: 'condition' parameter with shape (3, 4) can not be broadcast across data with shape (3, 1) when the result will have a different shape to the data
 
         >>> d = cf.Data(np.arange(9).reshape(3, 3))
         >>> e = d.copy()
@@ -9732,6 +9737,8 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
          [ 6.      7.      8.    ]]
 
         """
+        from .utils import where_broadcastable
+
         d = _inplace_enabled_define_and_cleanup(self)
 
         # Missing values could be affected, so make sure that the mask
@@ -9744,13 +9751,13 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         if getattr(condition, "isquery", False):
             # Condition is a cf.Query object: Make sure that the
             # condition units are OK, and convert the condition to a
-            # boolean dask array with the same shape as the data.
+            # boolean Data instance with the same shape as the data.
             condition = condition.copy()
-            condition = condition.set_condition_units(units)
+            condition.set_condition_units(units)
             condition = condition.evaluate(d)
 
         condition = type(self).asdata(condition)
-        _where_broadcastable(d, condition, "condition")
+        condition = where_broadcastable(d, condition, "condition")
 
         # If x or y is self then change it to None. This prevents an
         # unnecessary copy; and, at compute time, an unncessary numpy
@@ -9778,18 +9785,16 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
                 continue
 
             arg = type(self).asdata(arg)
-            _where_broadcastable(d, arg, name)
+            arg = where_broadcastable(d, arg, name)
 
-            if arg.Units:
-                # Make sure that units are OK.
-                arg = arg.copy()
-                try:
-                    arg.Units = units
-                except ValueError:
-                    raise ValueError(
-                        f"where: {name!r} parameter units {arg.Units!r} "
-                        f"are not equivalent to data units {units!r}"
-                    )
+            arg_units = arg.Units
+            if arg_units:
+                arg = conform_units(
+                    arg,
+                    units,
+                    message=f"where: {name!r} parameter units {arg_units!r} "
+                    f"are not equivalent to data units {units!r}",
+                )
 
             xy.append(arg.to_dask_array())
 
@@ -11772,90 +11777,6 @@ def _size_of_index(index, size=None):
     else:
         # Index is a list of integers
         return len(index)
-
-
-def _broadcast(a, shape):
-    """Broadcast an array to a given shape.
-
-    It is assumed that ``len(array.shape) <= len(shape)`` and that the
-    array is broadcastable to the shape by the normal numpy
-    boradcasting rules, but neither of these things are checked.
-
-    For example, ``d[...] = d._broadcast(e, d.shape)`` gives the same
-    result as ``d[...] = e``
-
-    :Parameters:
-
-        a: numpy array-like
-
-        shape: `tuple`
-
-    :Returns:
-
-        `numpy.ndarray`
-
-    """
-    # Replace with numpy.broadcast_to v1.10 ??/ TODO
-
-    a_shape = np.shape(a)
-    if a_shape == shape:
-        return a
-
-    tile = [(m if n == 1 else 1) for n, m in zip(a_shape[::-1], shape[::-1])]
-    tile = shape[0 : len(shape) - len(a_shape)] + tuple(tile[::-1])
-
-    return np.tile(a, tile)
-
-
-def _where_broadcastable(data, x, name):
-    """Check broadcastability for `where` assignments.
-
-    Raises an exception if the result of broadcasting *data* and *x*
-    together does not have the same shape as *data*.
-
-    .. versionadded:: TODODASKVER
-
-    .. seealso:: `where`
-
-    :Parameters:
-
-        data, x: `Data`
-            The arrays to compare.
-
-        name: `str`
-            A name for *x* that is used in any exception error
-            message.
-
-    :Returns:
-
-        `bool`
-             If *x* is acceptably broadcastable to *data* then `True`
-             is returned, otherwise a `ValueError` is raised.
-
-    """
-    ndim_x = x.ndim
-    if not ndim_x:
-        return True
-
-    ndim_data = data.ndim
-    if ndim_x > ndim_data:
-        raise ValueError(
-            f"where: Broadcasting the {name!r} parameter with {ndim_x} "
-            f"dimensions would change the shape of the data with "
-            f"{ndim_data} dimensions"
-        )
-
-    shape_x = x.shape
-    shape_data = data.shape
-    for n, m in zip(shape_x[::-1], shape_data[::-1]):
-        if n != m and n != 1:
-            raise ValueError(
-                f"where: Broadcasting the {name!r} parameter with shape "
-                f"{shape_x} would change the shape of the data with shape "
-                f"{shape_data}"
-            )
-
-    return True
 
 
 def _collapse(

--- a/cf/field.py
+++ b/cf/field.py
@@ -14632,7 +14632,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
             construct: `str`, optional
                 Define the condition by applying the *construct*
                 parameter to the given metadata construct's data,
-                rather then the data of the field construct. Must be
+                rather than the data of the field construct. Must be
 
                 * The identity or key of a metadata coordinate
                   construct that has data.

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -2834,6 +2834,12 @@ class DataTest(unittest.TestCase):
         self.assertTrue((e.array.mask == [1, 1, 1, 1, 1, 0, 0, 0, 0, 0]).all())
         self.assertTrue((e.array == a).all())
 
+        d = cf.Data(np.arange(12).reshape(3, 4))
+        for condition in (True, 3, [True], [[1]], [[[1]]], [[[1, 1, 1, 1]]]):
+            e = d.where(condition, -9)
+            self.assertEqual(e.shape, d.shape)
+            self.assertTrue((e.array == -9).all())
+
     def test_Data__init__compression(self):
         """Test Data initialised from compressed data sources."""
         import cfdm

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -2184,20 +2184,19 @@ class FieldTest(unittest.TestCase):
 
         for condition in (True, 1, [[[True]]], [[[[[456]]]]]):
             g = f.where(condition, -9)
-            self.assertTrue(g[0].minimum() == -9, str(condition))
-            self.assertTrue(g[0].maximum() == -9, str(condition))
+            self.assertTrue((g.array == -9).all())
 
         g = f.where(cf.le(34), 34)
-        self.assertTrue(g[0].minimum() == 34)
-        self.assertTrue(g[0].maximum() == 89)
+        self.assertTrue(g.min() == 34)
+        self.assertTrue(g.max() == 89)
 
         g = f.where(cf.le(34), cf.masked)
-        self.assertTrue(g[0].minimum() == 35)
-        self.assertTrue(g[0].maximum() == 89)
+        self.assertTrue(g.min() == 35)
+        self.assertTrue(g.max() == 89)
 
         self.assertIsNone(f.where(cf.le(34), cf.masked, 45, inplace=True))
-        self.assertTrue(f[0].minimum() == 45)
-        self.assertTrue(f[0].maximum() == 45)
+        self.assertTrue(f.min() == 45)
+        self.assertTrue(f.max() == 45)
 
     def test_Field_mask_invalid(self):
         f = self.f.copy()


### PR DESCRIPTION
A bit of a tidy, and a change to `Data.where` to allow leading size one dimensions. Deleted the `_broadcast` function as it is not used.