### PR TITLE
dask: `Data.array` return type (and test housekeeping)

### DIFF
--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -4625,7 +4625,11 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         2000-12-01 00:00:00
 
         """
-        return self.compute().copy()
+        array = self.compute().copy()
+        if not isinstance(array, np.ndarray):
+            array = np.asanyarray(array)
+
+        return array
 
     @property
     @daskified(_DASKIFIED_VERBOSE)

--- a/cf/test/test_TimeDuration.py
+++ b/cf/test/test_TimeDuration.py
@@ -3,7 +3,7 @@ import datetime
 import faulthandler
 import unittest
 
-import numpy
+import numpy as np
 
 faulthandler.enable()  # to debug seg faults and timeouts
 
@@ -37,11 +37,9 @@ class TimeDurationTest(unittest.TestCase):
         self.assertLessEqual(cf.TimeDuration(2, "hours"), 2)
         self.assertEqual(cf.TimeDuration(0.1, units="seconds"), 0.1)
         self.assertNotEqual(cf.TimeDuration(2, "days"), 30.5)
-        self.assertGreater(
-            cf.TimeDuration(2, "calendar_years"), numpy.array(1.5)
-        )
+        self.assertGreater(cf.TimeDuration(2, "calendar_years"), np.array(1.5))
         self.assertLess(
-            cf.TimeDuration(2, "calendar_months"), numpy.array([[12]])
+            cf.TimeDuration(2, "calendar_months"), np.array([[12]])
         )
 
         self.assertGreater(
@@ -78,11 +76,9 @@ class TimeDurationTest(unittest.TestCase):
         )
         self.assertEqual(cf.TimeDuration(2, "hours"), 2)
         self.assertNotEqual(cf.TimeDuration(2, "days"), 30.5)
-        self.assertGreater(
-            cf.TimeDuration(2, "calendar_years"), numpy.array(1.5)
-        )
+        self.assertGreater(cf.TimeDuration(2, "calendar_years"), np.array(1.5))
         self.assertLess(
-            cf.TimeDuration(2, "calendar_months"), numpy.array([[12]])
+            cf.TimeDuration(2, "calendar_months"), np.array([[12]])
         )
 
         self.assertEqual(cf.TimeDuration(64, "calendar_years") + 2, cf.Y(66))
@@ -100,7 +96,7 @@ class TimeDurationTest(unittest.TestCase):
         self.assertEqual(cf.TimeDuration(36, "calendar_months") // 8, cf.M(4))
 
         self.assertEqual(
-            cf.TimeDuration(36, "calendar_months") / numpy.array(8.0),
+            cf.TimeDuration(36, "calendar_months") / np.array(8.0),
             cf.M(36 / 8.0),
         )
         self.assertEqual(
@@ -138,7 +134,7 @@ class TimeDurationTest(unittest.TestCase):
         self.assertEqual(t, cf.h(17))
         t += 5.5
         self.assertEqual(t, cf.h(22.5))
-        t //= numpy.array(2)
+        t //= np.array(2)
         self.assertEqual(t, cf.h(11.0))
         t *= 10
         self.assertEqual(t, cf.h(110.0))


### PR DESCRIPTION
Sometime dask's `compute` returns a numpy int/float type rather than a scalar array, which doesn't work well with downstream methods (like `Data.__array__`), so `Data.array` make sure we trap those cases and cast it as a proper scalar array.

Also some housekeeping in `test_TimeDuration.py` (no substantive changes).