### PR TITLE
Reinstate read/write tests, account for CFA files

### DIFF
--- a/cf/read_write/netcdf/netcdfread.py
+++ b/cf/read_write/netcdf/netcdfread.py
@@ -4,8 +4,8 @@ import numpy as np
 
 _cfa_message = (
     "Reading CFA files has been temporarily disabled, "
-    "and will return at version 4.0.0. "
-    "CFA-0.4 functionality is still available at version 3.13.x."
+    "but will return at a version later soon after TODODASKVER."
+    "CFA-0.4 functionality is still available at versions<=3.13.1"
 )
 
 
@@ -81,7 +81,7 @@ class NetCDFRead(cfdm.read_write.netcdf.NetCDFRead):
         g = self.read_vars
 
         cfa = (
-            g["cfa"]
+            g.get("cfa")
             and ncvar not in g["external_variables"]
             and g["variable_attributes"][ncvar].get("cf_role")
             == "cfa_variable"
@@ -95,8 +95,8 @@ class NetCDFRead(cfdm.read_write.netcdf.NetCDFRead):
         # Still here? Then we have a CFA variable.
         raise ValueError(_cfa_message)
 
-        # Leave the following CFA code here, as it may be useful at
-        # v4.0.0.
+        # Leave the following CFA code here for now, as it may be
+        # useful at version>TODODASKVER
         ncdimensions = (
             g["variable_attributes"][ncvar].get("cfa_dimensions", "").split()
         )
@@ -140,7 +140,7 @@ class NetCDFRead(cfdm.read_write.netcdf.NetCDFRead):
         g = self.read_vars
 
         cfa = (
-            g["cfa"]
+            g.get("cfa")
             and ncvar not in g["external_variables"]
             and g["variable_attributes"][ncvar].get("cf_role")
             == "cfa_variable"
@@ -209,7 +209,7 @@ class NetCDFRead(cfdm.read_write.netcdf.NetCDFRead):
         g = self.read_vars
 
         is_cfa_variable = (
-            g["cfa"]
+            g.get("cfa")
             and construct.get_property("cf_role", None) == "cfa_variable"
         )
 
@@ -290,6 +290,8 @@ class NetCDFRead(cfdm.read_write.netcdf.NetCDFRead):
         if g["cfa"]:
             raise ValueError(_cfa_message)
 
+            # Leave the following CFA code here for now, as it may be
+            # useful at version>TODODASKVER
             for ncvar in g["variables"]:
                 if (
                     g["variable_attributes"][ncvar].get("cf_role", None)
@@ -303,8 +305,8 @@ class NetCDFRead(cfdm.read_write.netcdf.NetCDFRead):
         if g["cfa"]:
             raise ValueError(_cfa_message)
 
-            # Leave the following CFA code here, as it may be useful
-            # at v4.0.0.
+            # Leave the following CFA code here for now, as it may be
+            # useful at version>TODODASKVER
             for ncvar, ncdims in tuple(g["variable_dimensions"].items()):
                 if ncdims != ():
                     continue

--- a/cf/test/test_read_write.py
+++ b/cf/test/test_read_write.py
@@ -245,7 +245,7 @@ class read_writeTest(unittest.TestCase):
         cf.write(self.f1, tmpfile)
         f = cf.read(tmpfile)[0]
 
-        # TODO: reinstate "CFA" at v4.0.0
+        # TODO: reinstate "CFA" at version > 3.14
         for fmt in self.netcdf_fmts:  # + ["CFA"]:
             cf.write(f, tmpfile2, fmt=fmt)
             g = cf.read(tmpfile2, verbose=0)
@@ -257,9 +257,6 @@ class read_writeTest(unittest.TestCase):
                 f"Bad read/write of format {fmt!r}",
             )
 
-    @unittest.skipIf(
-        TEST_DASKIFIED_ONLY, "'Data' object has no attribute '_pmsize'"
-    )
     def test_write_netcdf_mode(self):
         """Test the `mode` parameter to `write`, notably append mode."""
         g = cf.read(self.filename)  # note 'g' has one field
@@ -548,7 +545,7 @@ class read_writeTest(unittest.TestCase):
 
     def test_read_write_netCDF4_compress_shuffle(self):
         f = cf.read(self.filename)[0]
-        # TODO: reinstate "CFA4" at v4.0.0
+        # TODO: reinstate "CFA4" at version > 3.14
         for fmt in ("NETCDF4", "NETCDF4_CLASSIC"):  # , "CFA4"):
             cf.write(f, tmpfile, fmt=fmt, compress=1, shuffle=True)
             g = cf.read(tmpfile)[0]
@@ -726,9 +723,6 @@ class read_writeTest(unittest.TestCase):
         with self.assertRaises(Exception):
             cf.read("test_read_write.py")
 
-    @unittest.skipIf(
-        TEST_DASKIFIED_ONLY, "'Data' object has no attribute '_pmsize'"
-    )
     def test_read_cdl_string(self):
         """Test the `cdl_string` keyword of the `read` function."""
         # Test CDL in full, header-only and coordinate-only type:
@@ -820,9 +814,6 @@ class read_writeTest(unittest.TestCase):
         self.assertEqual(len(g), 1)
         self.assertTrue(g[0].equals(f))
 
-    @unittest.skipIf(
-        TEST_DASKIFIED_ONLY, "'Data' object has no attribute '_pmsize'"
-    )
     def test_read_write_domain(self):
         f = cf.read(self.filename)[0]
         d = f.domain


### PR DESCRIPTION
Not entirely sure  know why the `g["cfa"]` items worked before, but replacing them with `g.get("cfa")` seems safe. 