### PR TITLE
Minor changes to allow test_docstring.py to pass

### DIFF
--- a/cf/domain.py
+++ b/cf/domain.py
@@ -576,7 +576,7 @@ class Domain(mixin.FieldDomain, mixin.Properties, cfdm.Domain):
 
         # Get the indices for every domain axis in the domain, without
         # any auxiliary masks.
-        domain_indices = self._indices(mode, None, False, **kwargs)
+        domain_indices = self._indices(mode, None, False, kwargs)
 
         return domain_indices["indices"]
 
@@ -1022,9 +1022,10 @@ class Domain(mixin.FieldDomain, mixin.Properties, cfdm.Domain):
         construct_data_axes = new.constructs.data_axes()
 
         for key, construct in new.constructs.filter_by_data().items():
+            print (key, repr(construct))
             construct_axes = construct_data_axes[key]
             dice = [indices[axes.index(axis)] for axis in construct_axes]
-
+            print (dice)
             # Replace existing construct with its subspace
             new.set_construct(
                 construct[tuple(dice)],

--- a/cf/test/test_Domain.py
+++ b/cf/test/test_Domain.py
@@ -101,13 +101,13 @@ class DomainTest(unittest.TestCase):
         f = self.d.copy()
 
         x = f.dimension_coordinate("X")
-        a = x.varray
-        a[...] = numpy.arange(0, 360, 40)
+#        a = x.varray
+        x[...] = numpy.arange(0, 360, 40)
         x.set_bounds(x.create_bounds())
         f.cyclic("X", iscyclic=True, period=360)
 
         f0 = f.copy()
-
+        print(f)
         # wi (increasing)
         g = f.subspace(grid_longitude=cf.wi(50, 130))
         self.assertEqual(g.size, 20)


### PR DESCRIPTION
A few changes to help `test_docstring.py` pass. In particular, the `@daskified` decorators weren't playing nicely with the test, so I've removed them. They have been very useful, but I think they are no longer needed given how far along we are.