### PR TITLE
dask: Changes to allow test_docstring.py to pass

### DIFF
--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -62,55 +62,8 @@ from .utils import (  # is_small,; is_very_small,
     scalar_masked_array,
 )
 
-_DASKIFIED_VERBOSE = None  # see below for valid levels, adapt as useful
-
 
 logger = logging.getLogger(__name__)
-
-daskified_log_level = 0
-
-
-def daskified(apply_temp_log_level=None):
-    def decorator(method):
-        """Temporary decorator to mark and log methods migrated to Dask.
-
-        A log level argument will set the log level throughout the call of
-        the method to that level and then reset it back to the previous
-        global level. A message will also be emitted to indicate whenever
-        the method is called, unless no argument is given [daskified()]
-        in which case the decorator does nothing except mark methods
-        which are considered to be daskified, a main purpose for this
-        decorator.
-
-        Note: for properties the decorator must be placed underneath the
-        property decorator so it is called before and not after it.
-
-        """
-
-        @wraps(method)
-        def wrapper(*args, **kwargs):
-            if apply_temp_log_level is None:  # distingush from 0
-                return method(*args, **kwargs)
-
-            original_global_log_level = log_level()
-            # Switch log level for the duration of the method call, with an
-            # initial message to indicate a run first guaranteed to show
-            log_level(apply_temp_log_level)
-            # Not actually a warning, but setting as warning ensures it shows
-            # (unless logging is disabled, but ignore that complication for
-            # this temporary and informal decorator!)
-            logger.warning(f"%%%%% Running daskified {method.__name__} %%%%%")
-
-            out = method(*args, **kwargs)
-
-            # ... then return the log level to the global level afterwards
-            log_level(original_global_log_level)
-            return out
-
-        return wrapper
-
-    return decorator
-
 
 # --------------------------------------------------------------------
 # Constants
@@ -559,7 +512,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return ca.to_dask_array()
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __contains__(self, value):
         """Membership test operator ``in``
 
@@ -672,13 +624,11 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         return bool(dx.any())
 
     @property
-    @daskified(_DASKIFIED_VERBOSE)
     def _atol(self):
         """Return the current value of the `cf.atol` function."""
         return atol().value
 
     @property
-    @daskified(_DASKIFIED_VERBOSE)
     def _rtol(self):
         """Return the current value of the `cf.rtol` function."""
         return rtol().value
@@ -697,12 +647,10 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return isinstance(array, cfdm.Array)
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __data__(self):
         """Returns a new reference to self."""
         return self
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __float__(self):
         """Called to implement the built-in function `float`
 
@@ -717,7 +665,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return float(self.to_dask_array())
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __int__(self):
         """Called to implement the built-in function `int`
 
@@ -846,7 +793,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return super().__repr__().replace("<", "<CF ", 1)
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __getitem__(self, indices):
         """Return a subspace of the data defined by indices.
 
@@ -1031,7 +977,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return new
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __setitem__(self, indices, value):
         """Implement indexed assignment.
 
@@ -1180,7 +1125,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
     # Indexing behaviour attributes
     # ----------------------------------------------------------------
     @property
-    @daskified(_DASKIFIED_VERBOSE)
     def __orthogonal_indexing__(self):
         """Flag to indicate that orthogonal indexing is supported.
 
@@ -1215,7 +1159,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         return True
 
     @property
-    @daskified(_DASKIFIED_VERBOSE)
     def __keepdims_indexing__(self):
         """Flag to indicate whether dimensions indexed with integers are
         kept.
@@ -1398,7 +1341,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return out
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     def diff(self, axis=-1, n=1, inplace=False):
         """Calculate the n-th discrete difference along the given axis.
@@ -1486,7 +1428,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     def digitize(
         self,
@@ -1783,7 +1724,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("_preserve_partitions")
     def median(self, axes=None, squeeze=False, mtol=1, inplace=False):
         """Calculate median values.
@@ -1830,7 +1770,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
             50, axes=axes, squeeze=squeeze, mtol=mtol, inplace=inplace
         )
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     def mean_of_upper_decile(
         self,
@@ -1940,7 +1879,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("_preserve_partitions")
     @_inplace_enabled(default=False)
     def percentile(
@@ -2199,7 +2137,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     def persist(self, inplace=False):
         """Persist the underlying dask array into memory.
@@ -2357,7 +2294,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
             ]
         )
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     def ceil(self, inplace=False, i=False):
@@ -2396,7 +2332,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         d._set_dask(da.ceil(dx))
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     def compute(self):
         """A numpy view the data.
 
@@ -2441,7 +2376,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return a
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     def convolution_filter(
         self,
@@ -2640,7 +2574,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     def cumsum(
         self,
@@ -2735,7 +2668,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     def rechunk(
         self,
@@ -2820,7 +2752,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     def _asdatetime(self, inplace=False):
         """Change the internal representation of data array elements
@@ -2874,12 +2805,11 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     def _isdatetime(self):
         """True if the internal representation is a datetime object."""
         return self.dtype.kind == "O" and self.Units.isreftime
 
-    @daskified(_DASKIFIED_VERBOSE)
+
     @_inplace_enabled(default=False)
     def _asreftime(self, inplace=False):
         """Change the internal representation of data array elements
@@ -3318,7 +3248,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
             )
         )
 
-    @daskified(_DASKIFIED_VERBOSE)
     def _binary_operation(self, other, method):
         """Implement binary arithmetic and comparison operations with
         the numpy broadcasting rules.
@@ -3452,7 +3381,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         )
 
     @classmethod
-    @daskified(_DASKIFIED_VERBOSE)
     def concatenate(cls, data, axis=0, _preserve=True):
         """Join a sequence of data arrays together.
 
@@ -3561,7 +3489,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return data0
 
-    @daskified(_DASKIFIED_VERBOSE)
     def _unary_operation(self, operation):
         """Implement unary arithmetic operations.
 
@@ -3606,7 +3533,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return out
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __add__(self, other):
         """The binary arithmetic operation ``+``
 
@@ -3615,7 +3541,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__add__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __iadd__(self, other):
         """The augmented arithmetic assignment ``+=``
 
@@ -3624,7 +3549,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__iadd__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __radd__(self, other):
         """The binary arithmetic operation ``+`` with reflected
         operands.
@@ -3634,7 +3558,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__radd__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __sub__(self, other):
         """The binary arithmetic operation ``-``
 
@@ -3643,7 +3566,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__sub__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __isub__(self, other):
         """The augmented arithmetic assignment ``-=``
 
@@ -3652,7 +3574,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__isub__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __rsub__(self, other):
         """The binary arithmetic operation ``-`` with reflected
         operands.
@@ -3662,7 +3583,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__rsub__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __mul__(self, other):
         """The binary arithmetic operation ``*``
 
@@ -3671,7 +3591,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__mul__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __imul__(self, other):
         """The augmented arithmetic assignment ``*=``
 
@@ -3680,7 +3599,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__imul__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __rmul__(self, other):
         """The binary arithmetic operation ``*`` with reflected
         operands.
@@ -3690,7 +3608,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__rmul__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __div__(self, other):
         """The binary arithmetic operation ``/``
 
@@ -3699,7 +3616,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__div__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __idiv__(self, other):
         """The augmented arithmetic assignment ``/=``
 
@@ -3708,7 +3624,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__idiv__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __rdiv__(self, other):
         """The binary arithmetic operation ``/`` with reflected
         operands.
@@ -3718,7 +3633,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__rdiv__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __floordiv__(self, other):
         """The binary arithmetic operation ``//``
 
@@ -3727,7 +3641,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__floordiv__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __ifloordiv__(self, other):
         """The augmented arithmetic assignment ``//=``
 
@@ -3736,7 +3649,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__ifloordiv__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __rfloordiv__(self, other):
         """The binary arithmetic operation ``//`` with reflected
         operands.
@@ -3746,7 +3658,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__rfloordiv__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __truediv__(self, other):
         """The binary arithmetic operation ``/`` (true division)
 
@@ -3755,7 +3666,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__truediv__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __itruediv__(self, other):
         """The augmented arithmetic assignment ``/=`` (true division)
 
@@ -3764,7 +3674,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__itruediv__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __rtruediv__(self, other):
         """The binary arithmetic operation ``/`` (true division) with
         reflected operands.
@@ -3774,7 +3683,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__rtruediv__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __pow__(self, other, modulo=None):
         """The binary arithmetic operations ``**`` and ``pow``
 
@@ -3790,7 +3698,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return self._binary_operation(other, "__pow__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __ipow__(self, other, modulo=None):
         """The augmented arithmetic assignment ``**=``
 
@@ -3806,7 +3713,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return self._binary_operation(other, "__ipow__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __rpow__(self, other, modulo=None):
         """The binary arithmetic operations ``**`` and ``pow`` with
         reflected operands.
@@ -3823,7 +3729,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return self._binary_operation(other, "__rpow__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __mod__(self, other):
         """The binary arithmetic operation ``%``
 
@@ -3832,7 +3737,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__mod__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __imod__(self, other):
         """The binary arithmetic operation ``%=``
 
@@ -3841,7 +3745,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__imod__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __rmod__(self, other):
         """The binary arithmetic operation ``%`` with reflected
         operands.
@@ -3851,7 +3754,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__rmod__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __eq__(self, other):
         """The rich comparison operator ``==``
 
@@ -3860,7 +3762,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__eq__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __ne__(self, other):
         """The rich comparison operator ``!=``
 
@@ -3869,7 +3770,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__ne__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __ge__(self, other):
         """The rich comparison operator ``>=``
 
@@ -3878,7 +3778,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__ge__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __gt__(self, other):
         """The rich comparison operator ``>``
 
@@ -3887,7 +3786,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__gt__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __le__(self, other):
         """The rich comparison operator ``<=``
 
@@ -3896,7 +3794,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__le__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __lt__(self, other):
         """The rich comparison operator ``<``
 
@@ -3905,7 +3802,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__lt__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __and__(self, other):
         """The binary bitwise operation ``&``
 
@@ -3914,7 +3810,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__and__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __iand__(self, other):
         """The augmented bitwise assignment ``&=``
 
@@ -3923,7 +3818,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__iand__")
 
-    @daskified(_DASKIFIED_VERBOSE)
+
     def __rand__(self, other):
         """The binary bitwise operation ``&`` with reflected operands.
 
@@ -3932,7 +3827,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__rand__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __or__(self, other):
         """The binary bitwise operation ``|``
 
@@ -3941,7 +3835,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__or__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __ior__(self, other):
         """The augmented bitwise assignment ``|=``
 
@@ -3950,7 +3843,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__ior__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __ror__(self, other):
         """The binary bitwise operation ``|`` with reflected operands.
 
@@ -3959,7 +3851,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__ror__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __xor__(self, other):
         """The binary bitwise operation ``^``
 
@@ -3968,7 +3859,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__xor__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __ixor__(self, other):
         """The augmented bitwise assignment ``^=``
 
@@ -3977,7 +3867,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__ixor__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __rxor__(self, other):
         """The binary bitwise operation ``^`` with reflected operands.
 
@@ -3986,7 +3875,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(other, "__rxor__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __lshift__(self, y):
         """The binary bitwise operation ``<<``
 
@@ -3995,7 +3883,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(y, "__lshift__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __ilshift__(self, y):
         """The augmented bitwise assignment ``<<=``
 
@@ -4004,7 +3891,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(y, "__ilshift__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __rlshift__(self, y):
         """The binary bitwise operation ``<<`` with reflected operands.
 
@@ -4013,7 +3899,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(y, "__rlshift__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __rshift__(self, y):
         """The binary bitwise operation ``>>``
 
@@ -4022,7 +3907,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(y, "__rshift__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __irshift__(self, y):
         """The augmented bitwise assignment ``>>=``
 
@@ -4031,7 +3915,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(y, "__irshift__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __rrshift__(self, y):
         """The binary bitwise operation ``>>`` with reflected operands.
 
@@ -4040,7 +3923,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._binary_operation(y, "__rrshift__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __abs__(self):
         """The unary arithmetic operation ``abs``
 
@@ -4049,7 +3931,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._unary_operation("__abs__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __neg__(self):
         """The unary arithmetic operation ``-``
 
@@ -4058,7 +3939,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._unary_operation("__neg__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __invert__(self):
         """The unary bitwise operation ``~``
 
@@ -4067,7 +3947,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self._unary_operation("__invert__")
 
-    @daskified(_DASKIFIED_VERBOSE)
     def __pos__(self):
         """The unary arithmetic operation ``+``
 
@@ -4137,7 +4016,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         self._custom["_cyclic"] = _empty_set
 
     @property
-    @daskified(_DASKIFIED_VERBOSE)
     def _axes(self):
         """Storage for the axis identifiers.
 
@@ -4190,7 +4068,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
     # Attributes
     # ----------------------------------------------------------------
     @property
-    @daskified(_DASKIFIED_VERBOSE)
     def Units(self):
         """The `cf.Units` object containing the units of the data array.
 
@@ -4255,7 +4132,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         )
 
     @property
-    @daskified(_DASKIFIED_VERBOSE)
     def data(self):
         """The data as an object identity.
 
@@ -4269,7 +4145,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         return self
 
     @property
-    @daskified(_DASKIFIED_VERBOSE)
     def dtype(self):
         """The `numpy` data-type of the data.
 
@@ -4316,7 +4191,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
             self._set_dask(dx)
 
     @property
-    @daskified(_DASKIFIED_VERBOSE)
     def fill_value(self):
         """The data array missing data value.
 
@@ -4347,7 +4221,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         self.del_fill_value(None)
 
     @property
-    @daskified(_DASKIFIED_VERBOSE)
     def hardmask(self):
         """Hardness of the mask.
 
@@ -4401,7 +4274,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         self._custom["hardmask"] = value
 
     @property
-    @daskified(_DASKIFIED_VERBOSE)
     def is_masked(self):
         """True if the data array has any masked values.
 
@@ -4441,7 +4313,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         return bool(dx.any())
 
     @property
-    @daskified(_DASKIFIED_VERBOSE)
     def nbytes(self):
         """Total number of bytes consumed by the elements of the array.
 
@@ -4476,7 +4347,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         return dx.nbytes
 
     @property
-    @daskified(_DASKIFIED_VERBOSE)
     def ndim(self):
         """Number of dimensions in the data array.
 
@@ -4507,7 +4377,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         return dx.ndim
 
     @property
-    @daskified(_DASKIFIED_VERBOSE)
     def shape(self):
         """Tuple of the data array's dimension sizes.
 
@@ -4543,7 +4412,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         return dx.shape
 
     @property
-    @daskified(_DASKIFIED_VERBOSE)
     def size(self):
         """Number of elements in the data array.
 
@@ -4585,7 +4453,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         return size
 
     @property
-    @daskified(_DASKIFIED_VERBOSE)
     def array(self):
         """A numpy array copy of the data.
 
@@ -4632,7 +4499,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         return array
 
     @property
-    @daskified(_DASKIFIED_VERBOSE)
     def datetime_array(self):
         """An independent numpy array of date-time objects.
 
@@ -4706,7 +4572,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         return a
 
     @property
-    @daskified(_DASKIFIED_VERBOSE)
     def mask(self):
         """The Boolean missing data mask of the data array.
 
@@ -4740,7 +4605,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         return mask_data_obj
 
     # `arctan2`, AT2 seealso
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     def arctan(self, inplace=False):
         """Take the trigonometric inverse tangent of the data element-
@@ -4830,7 +4694,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
     #        '''
     #        return cls(numpy_arctan2(y, x), units=_units_radians)
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     def arctanh(self, inplace=False):
         """Take the inverse hyperbolic tangent of the data element-wise.
@@ -4885,7 +4748,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     def arcsin(self, inplace=False):
         """Take the trigonometric inverse sine of the data element-wise.
@@ -4940,7 +4802,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     def arcsinh(self, inplace=False):
         """Take the inverse hyperbolic sine of the data element-wise.
@@ -4988,7 +4849,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     def arccos(self, inplace=False):
         """Take the trigonometric inverse cosine of the data element-
@@ -5044,7 +4904,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     def arccosh(self, inplace=False):
         """Take the inverse hyperbolic cosine of the data element-wise.
@@ -5099,7 +4958,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     def all(self, axis=None, keepdims=True, split_every=None):
         """Test whether all data array elements evaluate to True.
 
@@ -5164,7 +5022,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         d.override_units(_units_None, inplace=True)
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     def allclose(self, y, rtol=None, atol=None):
         """Whether an array is element-wise equal within a tolerance.
 
@@ -5277,7 +5134,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         d.override_units(_units_None, inplace=True)
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     def apply_masking(
         self,
@@ -5561,7 +5417,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return type(self)(a)
 
-    @daskified(_DASKIFIED_VERBOSE)
     def get_data(self, default=ValueError(), _units=None, _fill_value=None):
         """Returns the data.
 
@@ -5574,7 +5429,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self
 
-    @daskified(_DASKIFIED_VERBOSE)
     def get_units(self, default=ValueError()):
         """Return the units.
 
@@ -5608,7 +5462,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         except AttributeError:
             return super().get_units(default=default)
 
-    @daskified(_DASKIFIED_VERBOSE)
     def get_calendar(self, default=ValueError()):
         """Return the calendar.
 
@@ -5642,7 +5495,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         except (AttributeError, KeyError):
             return super().get_calendar(default=default)
 
-    @daskified(_DASKIFIED_VERBOSE)
     def set_calendar(self, calendar):
         """Set the calendar.
 
@@ -5672,7 +5524,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         self.Units = Units(self.get_units(default=None), calendar)
 
-    @daskified(_DASKIFIED_VERBOSE)
     def set_units(self, value):
         """Set the units.
 
@@ -5702,7 +5553,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         self.Units = Units(value, self.get_calendar(default=None))
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     @_deprecated_kwarg_check("i")
     def max(
@@ -5772,7 +5622,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     def maximum_absolute_value(
         self, axes=None, squeeze=False, mtol=1, split_every=None, inplace=False
@@ -5835,7 +5684,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         )
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     @_deprecated_kwarg_check("i")
     def min(
@@ -5905,7 +5753,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         )
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     def minimum_absolute_value(
         self, axes=None, squeeze=False, mtol=1, split_every=None, inplace=False
@@ -5969,7 +5816,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         )
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     @_deprecated_kwarg_check("i")
     def mean(
@@ -6048,7 +5894,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         )
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     def mean_absolute_value(
         self,
@@ -6125,7 +5970,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         )
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     def integral(
         self,
@@ -6220,7 +6064,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     @_deprecated_kwarg_check("i")
     def sample_size(
@@ -6291,7 +6134,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         return d
 
     @property
-    @daskified(_DASKIFIED_VERBOSE)
     def binary_mask(self):
         """A binary (0 and 1) mask of the data array.
 
@@ -6324,7 +6166,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         m.override_units(_units_1, inplace=True)
         return m
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     def clip(self, a_min, a_max, units=None, inplace=False, i=False):
@@ -6394,7 +6235,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         return d
 
     @classmethod
-    @daskified(_DASKIFIED_VERBOSE)
     def asdata(cls, d, dtype=None, copy=False):
         """Convert the input to a `Data` object.
 
@@ -6521,7 +6361,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         d._set_dask(dx)
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     def cos(self, inplace=False, i=False):
@@ -6581,7 +6420,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     def count(self, axis=None, keepdims=True, split_every=None):
         """Count the non-masked elements of the data.
 
@@ -6643,7 +6481,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         d.override_units(_units_None, inplace=True)
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     def count_masked(self, split_every=None):
         """Count the masked elements of the data.
 
@@ -6679,7 +6516,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self.size - self.count(split_every=split_every)
 
-    @daskified(_DASKIFIED_VERBOSE)
     def cyclic(self, axes=None, iscyclic=True):
         """Get or set the cyclic axes.
 
@@ -6761,7 +6597,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         return old
 
     @property
-    @daskified(_DASKIFIED_VERBOSE)
     def year(self):
         """The year of each date-time value.
 
@@ -6784,7 +6619,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         return YMDhms(self, "year")
 
     @property
-    @daskified(_DASKIFIED_VERBOSE)
     def month(self):
         """The month of each date-time value.
 
@@ -6807,7 +6641,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         return YMDhms(self, "month")
 
     @property
-    @daskified(_DASKIFIED_VERBOSE)
     def day(self):
         """The day of each date-time value.
 
@@ -6830,7 +6663,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         return YMDhms(self, "day")
 
     @property
-    @daskified(_DASKIFIED_VERBOSE)
     def hour(self):
         """The hour of each date-time value.
 
@@ -6853,7 +6685,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         return YMDhms(self, "hour")
 
     @property
-    @daskified(_DASKIFIED_VERBOSE)
     def minute(self):
         """The minute of each date-time value.
 
@@ -6876,7 +6707,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         return YMDhms(self, "minute")
 
     @property
-    @daskified(_DASKIFIED_VERBOSE)
     def second(self):
         """The second of each date-time value.
 
@@ -6898,7 +6728,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return YMDhms(self, "second")
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     def uncompress(self, inplace=False):
         """Uncompress the data.
@@ -6946,7 +6775,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     def unique(self, split_every=None):
         """The unique elements of the data.
 
@@ -7074,7 +6902,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return product(*[range(0, r) for r in self.shape])
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("traceback")
     @_manage_log_level_via_verbosity
     def equals(
@@ -7207,7 +7034,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         else:
             return True
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     def exp(self, inplace=False, i=False):
@@ -7243,7 +7069,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     def insert_dimension(self, position=0, inplace=False):
         """Expand the shape of the data array in place.
@@ -7298,7 +7123,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     @_manage_log_level_via_verbosity
     def halo(
@@ -7774,7 +7598,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         self._set_dask(dx, delete_source=False)
         self.hardmask = False
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     def filled(self, fill_value=None, inplace=False):
         """Replace masked elements with a fill value.
@@ -7953,7 +7776,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
             "setting the log level to 'DEBUG'."
         )
 
-    @daskified(_DASKIFIED_VERBOSE)
     def flat(self, ignore_masked=True):
         """Return a flat iterator over elements of the data array.
 
@@ -8003,7 +7825,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
                 else:
                     yield cf_masked
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     def flatten(self, axes=None, inplace=False):
         """Flatten specified axes of the data.
@@ -8135,7 +7956,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     def floor(self, inplace=False, i=False):
@@ -8169,7 +7989,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         d._set_dask(da.floor(dx))
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     @_deprecated_kwarg_check("i")
     def outerproduct(self, a, inplace=False, i=False):
@@ -8258,7 +8077,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     def change_calendar(self, calendar, inplace=False, i=False):
@@ -8327,7 +8145,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     def override_units(self, units, inplace=False, i=False):
@@ -8372,7 +8189,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         d._Units = Units(units)
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     def override_calendar(self, calendar, inplace=False, i=False):
@@ -8469,7 +8285,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return self._custom["dask"]
 
-    @daskified(_DASKIFIED_VERBOSE)
     def datum(self, *index):
         """Return an element of the data array as a standard Python
         scalar.
@@ -8614,7 +8429,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return cf_masked
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     def masked_invalid(self, inplace=False):
         """Mask the array where invalid values occur (NaN or inf).
@@ -8812,7 +8626,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         d._set_dask(dx)
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     @_deprecated_kwarg_check("i")
     def mid_range(
@@ -8883,7 +8696,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         )
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     def flip(self, axes=None, inplace=False, i=False):
@@ -8943,7 +8755,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     def inspect(self):
         """Inspect the object for debugging.
 
@@ -8971,7 +8782,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         inspect(self)
 
-    @daskified(_DASKIFIED_VERBOSE)
     def isclose(self, y, rtol=None, atol=None):
         """Return where data are element-wise equal within a tolerance.
 
@@ -9048,7 +8858,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
             d.override_units(_units_None, inplace=True)
             return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     def reshape(self, *shape, merge_chunks=True, limit=None, inplace=False):
         """Change the shape of the data without changing its values.
@@ -9116,7 +8925,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         d._set_dask(dx)
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     def rint(self, inplace=False, i=False):
@@ -9152,7 +8960,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         d._set_dask(da.rint(dx))
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     def root_mean_square(
         self,
@@ -9226,7 +9033,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         )
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     def round(self, decimals=0, inplace=False, i=False):
@@ -9469,7 +9275,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return out
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     def swapaxes(self, axis0, axis1, inplace=False, i=False):
@@ -9564,7 +9369,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     @_manage_log_level_via_verbosity
-    @daskified(_DASKIFIED_VERBOSE)
     def where(
         self, condition, x=None, y=None, inplace=False, i=False, verbose=None
     ):
@@ -9836,7 +9640,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     def sin(self, inplace=False, i=False):
@@ -9896,7 +9699,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     def sinh(self, inplace=False):
@@ -9957,7 +9759,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     def cosh(self, inplace=False):
         """Take the hyperbolic cosine of the data element-wise.
@@ -10016,7 +9817,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     def tanh(self, inplace=False):
@@ -10078,7 +9878,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     def log(self, base=None, inplace=False, i=False):
@@ -10118,7 +9917,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     def squeeze(self, axes=None, inplace=False, i=False):
@@ -10223,7 +10021,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         return d
 
     # `arctan2`, AT2 seealso
-    @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     def tan(self, inplace=False, i=False):
@@ -10284,7 +10081,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     def tolist(self):
         """Return the data as a scalar or (nested) list.
 
@@ -10320,7 +10116,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         return self.array.tolist()
 
-    @daskified(_DASKIFIED_VERBOSE)
     def to_memory(self):
         """Bring data on disk into memory.
 
@@ -10332,7 +10127,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
             "Consider using 'Data.persist' instead."
         )
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     def transpose(self, axes=None, inplace=False, i=False):
@@ -10398,7 +10192,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     def trunc(self, inplace=False, i=False):
@@ -10667,7 +10460,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         dx = da.zeros(shape, dtype=dtype, chunks=chunks)
         return cls(dx, units=units, calendar=calendar)
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("out")
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
@@ -10766,7 +10558,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     @_deprecated_kwarg_check("i")
     def range(
@@ -10836,7 +10627,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         )
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     @_deprecated_kwarg_check("i")
     def roll(self, axis, shift, inplace=False, i=False):
@@ -10887,7 +10677,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     @_deprecated_kwarg_check("i")
     def sum(
@@ -10967,7 +10756,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         )
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     def sum_of_squares(
         self,
@@ -11044,7 +10832,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         )
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     def sum_of_weights(
@@ -11143,7 +10930,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     def sum_of_weights2(
@@ -11244,7 +11030,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_deprecated_kwarg_check("i")
     @_inplace_enabled(default=False)
     def std(
@@ -11332,7 +11117,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         d.sqrt(inplace=True)
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     @_deprecated_kwarg_check("i")
     def var(
@@ -11425,7 +11209,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     def section(
         self, axes, stop=None, chunks=False, min_step=1, mode="dictionary"
     ):
@@ -11515,7 +11298,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return _section(self, axes, min_step=min_step)
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     def square(self, dtype=None, inplace=False):
         """Calculate the element-wise square.
@@ -11563,7 +11345,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     def sqrt(self, dtype=None, inplace=False):
         """Calculate the non-negative square root.
@@ -11646,7 +11427,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """Alias for `datetime_array`"""
         return self.datetime_array
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     @_deprecated_kwarg_check("i")
     def maximum(
@@ -11668,7 +11448,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
             i=i,
         )
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     @_deprecated_kwarg_check("i")
     def minimum(
@@ -11690,7 +11469,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
             i=i,
         )
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     @_deprecated_kwarg_check("i")
     def sd(
@@ -11716,7 +11494,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
             i=i,
         )
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     @_deprecated_kwarg_check("i")
     def standard_deviation(
@@ -11742,7 +11519,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
             i=i,
         )
 
-    @daskified(_DASKIFIED_VERBOSE)
     @_inplace_enabled(default=False)
     @_deprecated_kwarg_check("i")
     def variance(

--- a/cf/data/mixin/arraymixin.py
+++ b/cf/data/mixin/arraymixin.py
@@ -6,4 +6,5 @@ class ArrayMixin:
     """
 
     def __array_function__(self, func, types, args, kwargs):
+        """Implement the `numpy` ``__array_function__`` protocol."""
         return NotImplemented


### PR DESCRIPTION
A few changes to help `test_docstring.py` pass. In particular, the `@daskified` decorators weren't playing nicely with the test, so I've removed them. They have been very useful, but I think they are no longer needed given how far along we are.
