### PR TITLE
Move test to `ppTest`

### DIFF
--- a/cf/test/test_pp.py
+++ b/cf/test/test_pp.py
@@ -51,6 +51,21 @@ class ppTest(unittest.TestCase):
 
     chunk_sizes = (800000, 80000)
 
+    def test_PP_read_um(self):
+        p = cf.read("wgdos_packed.pp")[0]
+        p0 = cf.read(
+            "wgdos_packed.pp",
+            um={
+                "fmt": "PP",
+                "endian": "little",
+                "word_size": 4,
+                "version": 4.5,
+                "height_at_top_of_model": 23423.65,
+            },
+        )[0]
+
+        self.assertTrue(p.equals(p0, verbose=2))
+
     def test_load_stash2standard_name(self):
         f = cf.read(self.ppfile)[0]
         self.assertEqual(f.identity(), "eastward_wind")

--- a/cf/test/test_read_write.py
+++ b/cf/test/test_read_write.py
@@ -640,21 +640,6 @@ class read_writeTest(unittest.TestCase):
         self.assertTrue(domain_axes["domainaxis0"].nc_is_unlimited())
         self.assertTrue(domain_axes["domainaxis2"].nc_is_unlimited())
 
-    def test_read_pp(self):
-        p = cf.read("wgdos_packed.pp")[0]
-        p0 = cf.read(
-            "wgdos_packed.pp",
-            um={
-                "fmt": "PP",
-                "endian": "big",
-                "word_size": 4,
-                "version": 4.5,
-                "height_at_top_of_model": 23423.65,
-            },
-        )[0]
-
-        self.assertTrue(p.equals(p0, verbose=2))
-
     def test_read_CDL(self):
         subprocess.run(
             " ".join(["ncdump", self.filename, ">", tmpfile]),


### PR DESCRIPTION
Fix up the PP read test from `test_read_write.py` and move it to its spiritual home in `test_pp.py`.