### PR TITLE
Fix bug that raises an exception when using the `equal` or `exist` keyword of `cf.aggregate` 

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -6,8 +6,9 @@ version 3.14.0
 * New method: `cf.Field.get_original_filenames`
   (https://github.com/NCAS-CMS/cf-python/issues/448)
 * New method: `cf.Field.to_dask_array`
-* Fixed bug that raised an exception when using the ``equal`` keyword
-  of `cf.aggregate` (https://github.com/NCAS-CMS/cf-python/issues/499)
+* Fixed bug that raised an exception when using the ``equal`` or
+  ``exist`` keyword of `cf.aggregate`
+  (https://github.com/NCAS-CMS/cf-python/issues/499)
 * Changed dependency: ``1.10.0.1<=cfdm<1.10.1.0``
 * New dependency: ``dask>=2022.6.0``
 

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -6,6 +6,8 @@ version 3.14.0
 * New method: `cf.Field.get_original_filenames`
   (https://github.com/NCAS-CMS/cf-python/issues/448)
 * New method: `cf.Field.to_dask_array`
+* Fixed bug that raised an exception when using the ``equal`` keyword
+  of `cf.aggregate` (https://github.com/NCAS-CMS/cf-python/issues/499)
 * Changed dependency: ``1.10.0.1<=cfdm<1.10.1.0``
 * New dependency: ``dask>=2022.6.0``
 
@@ -18,8 +20,8 @@ version 3.13.1
 
 * Upgrade to allow cf to work with Python 3.10
   (https://github.com/NCAS-CMS/cf-python/issues/419)
-* Fix bug when setting coordinate bounds with different units to their
-  parent coordinates
+* Fixed bug when setting coordinate bounds with different units to
+  their parent coordinates
   (https://github.com/NCAS-CMS/cf-python/issues/417)
 * Fixed bug that created incorrect hybrid height levels when reading
   UM fields that also have pseudolevels
@@ -35,10 +37,10 @@ version 3.13.0
 
 **2022-06-23**
 
-* Fix bug in `cf.read` when reading PP or fields files for which the
+* Fixed bug in `cf.read` when reading PP or fields files for which the
   ``um`` keyword has been set, but without the ``'version'`` key
   (https://github.com/NCAS-CMS/cf-python/issues/306)
-* Fix bug when setting the CFA "base" option to an empty string in
+* Fixed bug when setting the CFA "base" option to an empty string in
   `cf.write` (https://github.com/NCAS-CMS/cf-python/issues/346)
 * Fixed failure from `cf.write` when writing identical (auxiliary)
   coordinates to different data variables in different groups

--- a/cf/aggregate.py
+++ b/cf/aggregate.py
@@ -684,8 +684,9 @@ class _Meta:
             self.properties = ()
         else:
             properties = f.properties()
-            for p in ignore:
-                properties.pop(p, None)
+            if ignore:
+                for p in ignore:
+                    properties.pop(p, None)
 
             if equal:
                 eq = dict(

--- a/cf/field.py
+++ b/cf/field.py
@@ -4554,9 +4554,6 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
     def title(self):
         self.del_property("title")
 
-    # ----------------------------------------------------------------
-    # Methods
-    # ----------------------------------------------------------------
     def cell_area(
         self,
         radius="earth",

--- a/cf/test/test_aggregate.py
+++ b/cf/test/test_aggregate.py
@@ -296,6 +296,45 @@ class aggregateTest(unittest.TestCase):
         g = cf.aggregate([a, b, c, d], equal_all=True)
         self.assertEqual(len(g), 2)
 
+        d.del_property("foo")
+
+        g = cf.aggregate([a, b, c, d])
+        self.assertEqual(len(g), 1)
+
+        g = cf.aggregate([a, b, c, d], equal=["foo"])
+        self.assertEqual(len(g), 3)
+
+        g = cf.aggregate([a, b, c, d], equal_all=True)
+        self.assertEqual(len(g), 3)
+
+    def test_aggregate_exist_exist_all(self):
+        f = cf.example_field(0)
+        f.set_property("foo", "bar")
+        a, b, c, d = f[0], f[1], f[2:4], f[4]
+
+        c.set_property("foo", "baz")
+        d.set_property("foo", "baz")
+
+        g = cf.aggregate([a, b, c, d])
+        self.assertEqual(len(g), 1)
+
+        g = cf.aggregate([a, b, c, d], exist=["foo"])
+        self.assertEqual(len(g), 1)
+
+        g = cf.aggregate([a, b, c, d], exist_all=True)
+        self.assertEqual(len(g), 1)
+
+        d.del_property("foo")
+
+        g = cf.aggregate([a, b, c, d])
+        self.assertEqual(len(g), 1)
+
+        g = cf.aggregate([a, b, c, d], exist=["foo"])
+        self.assertEqual(len(g), 2)
+
+        g = cf.aggregate([a, b, c, d], exist_all=True)
+        self.assertEqual(len(g), 2)
+
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())

--- a/cf/test/test_aggregate.py
+++ b/cf/test/test_aggregate.py
@@ -279,6 +279,23 @@ class aggregateTest(unittest.TestCase):
         )
         self.assertEqual(len(a), 1)
 
+    def test_aggregate_equal_equal_all(self):
+        f = cf.example_field(0)
+        f.set_property("foo", "bar")
+        a, b, c, d = f[0], f[1], f[2:4], f[4]
+
+        c.set_property("foo", "baz")
+        d.set_property("foo", "baz")
+
+        g = cf.aggregate([a, b, c, d])
+        self.assertEqual(len(g), 1)
+
+        g = cf.aggregate([a, b, c, d], equal=["foo"])
+        self.assertEqual(len(g), 2)
+
+        g = cf.aggregate([a, b, c, d], equal_all=True)
+        self.assertEqual(len(g), 2)
+
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())


### PR DESCRIPTION
Fixes #499 