### PR TITLE
dask: Deprecate `close`

### DIFF
--- a/cf/abstract/constructlist.py
+++ b/cf/abstract/constructlist.py
@@ -262,7 +262,7 @@ class ConstructList(list, Container, cfdm.Container):
             "close",
             "All files are now automatically closed when not being accessed.",
             version="TODODASKVER",
-            remove_at="5.0.0",
+            removed_at="5.0.0",
         )  # pragma: no cover
 
     def count(self, value):

--- a/cf/abstract/constructlist.py
+++ b/cf/abstract/constructlist.py
@@ -10,6 +10,7 @@ from ..functions import (
     _DEPRECATION_ERROR,
     _DEPRECATION_ERROR_DICT,
     _DEPRECATION_ERROR_KWARGS,
+    _DEPRECATION_ERROR_METHOD,
 )
 from ..mixin_container import Container
 
@@ -244,8 +245,8 @@ class ConstructList(list, Container, cfdm.Container):
     def close(self):
         """Close all files referenced by each construct in the list.
 
-        Note that a closed file will be automatically reopened if its
-        contents are subsequently required.
+        Deprecated at version TODODASKVER. All files are now
+        automatically closed when not being accessed.
 
         :Returns:
 
@@ -256,8 +257,13 @@ class ConstructList(list, Container, cfdm.Container):
         >>> f.close()
 
         """
-        for f in self:
-            f.close()
+        _DEPRECATION_ERROR_METHOD(
+            self,
+            "close",
+            "All files are now automatically closed when not being accessed.",
+            version="TODODASKVER",
+            remove_at="5.0.0",
+        )  # pragma: no cover
 
     def count(self, value):
         """Return the number of occurrences of value.

--- a/cf/constructs.py
+++ b/cf/constructs.py
@@ -140,7 +140,7 @@ class Constructs(cfdm.Constructs):
             "close",
             "All files are now automatically closed when not being accessed.",
             version="TODODASKVER",
-            remove_at="5.0.0",
+            removed_at="5.0.0",
         )  # pragma: no cover
 
     def _filter_by_identity(self, arg, identities, todict, _config):

--- a/cf/constructs.py
+++ b/cf/constructs.py
@@ -2,6 +2,7 @@ import logging
 
 import cfdm
 
+from .functions import _DEPRECATION_ERROR_METHOD
 from .query import Query
 
 logger = logging.getLogger(__name__)
@@ -119,6 +120,9 @@ class Constructs(cfdm.Constructs):
     def close(self):
         """Close all files referenced by the metadata constructs.
 
+        Deprecated at version TODODASKVER. All files are now
+        automatically closed when not being accessed.
+
         Note that a closed file will be automatically reopened if its
         contents are subsequently required.
 
@@ -131,10 +135,13 @@ class Constructs(cfdm.Constructs):
         >>> c.close()
 
         """
-        # TODODASKAPI - is this method still needed?
-
-        for construct in self.filter_by_data().values():
-            construct.close()
+        _DEPRECATION_ERROR_METHOD(
+            self,
+            "close",
+            "All files are now automatically closed when not being accessed.",
+            version="TODODASKVER",
+            remove_at="5.0.0",
+        )  # pragma: no cover
 
     def _filter_by_identity(self, arg, identities, todict, _config):
         """Worker function for `filter_by_identity` and `filter`.

--- a/cf/coordinatereference.py
+++ b/cf/coordinatereference.py
@@ -278,6 +278,9 @@ class CoordinateReference(cfdm.CoordinateReference):
         """Close all files referenced by coordinate conversion term
         values.
 
+        Deprecated at version TODODASKVER. All files are now
+        automatically closed when not being accessed.
+
         :Returns:
 
             `None`
@@ -287,7 +290,13 @@ class CoordinateReference(cfdm.CoordinateReference):
         >>> c.close()
 
         """
-        pass
+        _DEPRECATION_ERROR_METHOD(
+            self,
+            "close",
+            "All files are now automatically closed when not being accessed.",
+            version="TODODASKVER",
+            remove_at="5.0.0",
+        )  # pragma: no cover
 
     @classmethod
     def default_value(cls, term):

--- a/cf/coordinatereference.py
+++ b/cf/coordinatereference.py
@@ -295,7 +295,7 @@ class CoordinateReference(cfdm.CoordinateReference):
             "close",
             "All files are now automatically closed when not being accessed.",
             version="TODODASKVER",
-            remove_at="5.0.0",
+            removed_at="5.0.0",
         )  # pragma: no cover
 
     @classmethod

--- a/cf/domain.py
+++ b/cf/domain.py
@@ -147,7 +147,7 @@ class Domain(mixin.FieldDomain, mixin.Properties, cfdm.Domain):
             "close",
             "All files are now automatically closed when not being accessed.",
             version="TODODASKVER",
-            remove_at="5.0.0",
+            removed_at="5.0.0",
         )  # pragma: no cover
 
     @_inplace_enabled(default=False)

--- a/cf/domain.py
+++ b/cf/domain.py
@@ -127,6 +127,9 @@ class Domain(mixin.FieldDomain, mixin.Properties, cfdm.Domain):
     def close(self):
         """Close all files referenced by the domain construct.
 
+        Deprecated at version TODODASKVER. All files are now
+        automatically closed when not being accessed.
+
         Note that a closed file will be automatically reopened if its
         contents are subsequently required.
 
@@ -139,9 +142,13 @@ class Domain(mixin.FieldDomain, mixin.Properties, cfdm.Domain):
         >>> d.close()
 
         """
-        # TODODASK - is this still needed?
-
-        self.constructs.close()
+        _DEPRECATION_ERROR_METHOD(
+            self,
+            "close",
+            "All files are now automatically closed when not being accessed.",
+            version="TODODASKVER",
+            remove_at="5.0.0",
+        )  # pragma: no cover
 
     @_inplace_enabled(default=False)
     def flip(self, axes=None, inplace=False):

--- a/cf/field.py
+++ b/cf/field.py
@@ -4991,7 +4991,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
             "close",
             "All files are now automatically closed when not being accessed.",
             version="TODODASKVER",
-            remove_at="5.0.0",
+            removed_at="5.0.0",
         )  # pragma: no cover
 
     def iscyclic(self, *identity, **filter_kwargs):

--- a/cf/field.py
+++ b/cf/field.py
@@ -4971,6 +4971,9 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
     def close(self):
         """Close all files referenced by the field construct.
 
+        Deprecated at version TODODASKVER. All files are now
+        automatically closed when not being accessed.
+
         Note that a closed file will be automatically reopened if its
         contents are subsequently required.
 
@@ -4983,10 +4986,13 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
         >>> f.close()
 
         """
-        super().close()
-
-        for construct in self.constructs.filter_by_data(todict=True).values():
-            construct.close()
+        _DEPRECATION_ERROR_METHOD(
+            self,
+            "close",
+            "All files are now automatically closed when not being accessed.",
+            version="TODODASKVER",
+            remove_at="5.0.0",
+        )  # pragma: no cover
 
     def iscyclic(self, *identity, **filter_kwargs):
         """Returns True if the specified axis is cyclic.

--- a/cf/mixin/propertiesdata.py
+++ b/cf/mixin/propertiesdata.py
@@ -2501,6 +2501,9 @@ class PropertiesData(Properties):
     def close(self):
         """Close all files referenced by the construct.
 
+        Deprecated at version TODODASKVER. All files are now
+        automatically closed when not being accessed.
+
         Note that a closed file will be automatically reopened if its
         contents are subsequently required.
 
@@ -2515,9 +2518,13 @@ class PropertiesData(Properties):
         >>> f.close()
 
         """
-        data = self.get_data(None, _fill_value=False)
-        if data is not None:
-            data.close()
+        _DEPRECATION_ERROR_METHOD(
+            self,
+            "close",
+            "All files are now automatically closed when not being accessed.",
+            version="TODODASKVER",
+            remove_at="5.0.0",
+        )  # pragma: no cover
 
     @classmethod
     def concatenate(cls, variables, axis=0, _preserve=True):

--- a/cf/mixin/propertiesdata.py
+++ b/cf/mixin/propertiesdata.py
@@ -2523,7 +2523,7 @@ class PropertiesData(Properties):
             "close",
             "All files are now automatically closed when not being accessed.",
             version="TODODASKVER",
-            remove_at="5.0.0",
+            removed_at="5.0.0",
         )  # pragma: no cover
 
     @classmethod

--- a/cf/mixin/propertiesdatabounds.py
+++ b/cf/mixin/propertiesdatabounds.py
@@ -1272,6 +1272,9 @@ class PropertiesDataBounds(PropertiesData):
     def close(self):
         """Close all files referenced by the construct.
 
+        Deprecated at version TODODASKVER. All files are now
+        automatically closed when not being accessed.
+
         Note that a closed file will be automatically re-opened if its
         contents are subsequently required.
 
@@ -1286,15 +1289,13 @@ class PropertiesDataBounds(PropertiesData):
         >> c.close()
 
         """
-        super().close()
-
-        bounds = self.get_bounds(None)
-        if bounds is not None:
-            bounds.close()
-
-        interior_ring = self.get_interior_ring(None)
-        if interior_ring is not None:
-            interior_ring.close()
+        _DEPRECATION_ERROR_METHOD(
+            self,
+            "close",
+            "All files are now automatically closed when not being accessed.",
+            version="TODODASKVER",
+            remove_at="5.0.0",
+        )  # pragma: no cover
 
     @classmethod
     def concatenate(cls, variables, axis=0, _preserve=True):

--- a/cf/mixin/propertiesdatabounds.py
+++ b/cf/mixin/propertiesdatabounds.py
@@ -1294,7 +1294,7 @@ class PropertiesDataBounds(PropertiesData):
             "close",
             "All files are now automatically closed when not being accessed.",
             version="TODODASKVER",
-            remove_at="5.0.0",
+            removed_at="5.0.0",
         )  # pragma: no cover
 
     @classmethod

--- a/cf/test/test_FieldList.py
+++ b/cf/test/test_FieldList.py
@@ -56,12 +56,6 @@ class FieldTest(unittest.TestCase):
         self.assertIn(g, f)
         self.assertNotIn(34.6, f)
 
-    def test_FieldList_close(self):
-        f = cf.FieldList(self.x)
-        self.assertIsNone(f.close())
-
-        repr(f[0])
-
     def test_FieldList__len__(self):
         f = cf.FieldList(self.x)
 

--- a/cf/test/test_geometry.py
+++ b/cf/test/test_geometry.py
@@ -305,11 +305,6 @@ class DSGTest(unittest.TestCase):
         for i in (0, 1):
             self.assertTrue(f.equals(f.flatten(i), verbose=1))
 
-    def test_geometry_interior_ring_close(self):
-        f = cf.read(self.geometry_interior_ring_file, verbose=0)[0]
-
-        self.assertIsNone(f.close())
-
     def test_geometry_interior_ring_files(self):
         f = cf.read(self.geometry_interior_ring_file, verbose=0)[0]
 


### PR DESCRIPTION
Deprecates `close` methods, and removes the corresponding tests.