### PR TITLE
dask: Fix for cached str-type data elements

### DIFF
--- a/cf/read_write/netcdf/netcdfread.py
+++ b/cf/read_write/netcdf/netcdfread.py
@@ -495,7 +495,13 @@ class NetCDFRead(cfdm.read_write.netcdf.NetCDFRead):
             if np.ma.is_masked(value):
                 value = np.ma.masked
             else:
-                value = value.item()
+                try:
+                    value = value.item()
+                except AttributeError:
+                    # A netCDF string type scalar variable comes out
+                    # as Python str object, which has no 'item'
+                    # method.
+                    pass
 
             elements[element] = value
 


### PR DESCRIPTION
Minor bug fix for the new element caching for `Data.__str__`.
