### PR TITLE
dask: Remove `FileArrayMixin._dask_lock`

### DIFF
--- a/cf/data/array/mixin/filearraymixin.py
+++ b/cf/data/array/mixin/filearraymixin.py
@@ -9,21 +9,15 @@ class FileArrayMixin:
     """
 
     @property
-    def _dask_lock(self):
-        """TODODASKDOCS.
-
-        Concurrent reads are assumed to be not supported.
-
-        .. versionadded:: TODODASKVER
-
-        """
-        return True
-
-    @property
     def _dask_meta(self):
-        """TODODASKDOCS.
+        """The metadata for the containing dask array.
+
+        This is the kind of array that will result from slicing the
+        file array.
 
         .. versionadded:: TODODASKVER
+
+        .. seealso:: `dask.array.from_array`
 
         """
         return np.array((), dtype=self.dtype)


### PR DESCRIPTION
Remove `FileArrayMixin._dask_lock`. The property was returning `True`, which created a lock on chunk reads in `data.creation.to_dask`, preventing concurrent reads from data on disk and effectively creating turning off parallelism by forcing sequential behaviour.

In the absence of a `_dask_lock`, the lock passed to `dask.array.from_array` is `False`, which allows concurrent reads.