### PR TITLE
LAMA to Dask: updates to fix CI workflow setup errors

### DIFF
--- a/.github/workflows/dask-migration-testing.yml
+++ b/.github/workflows/dask-migration-testing.yml
@@ -71,20 +71,22 @@ jobs:
         python -m pip install --upgrade pip
         pip --version
         pip list
-    # Install cf-python dependencies, excluding cfdm, pre-testing
-    # We do so with conda which was setup in a previous step.
-    - name: Install dependencies
+    # Install cf-python dependencies, excluding cfunits and cfdm, pre-testing
+    # We do so with conda (and pip) which was setup in a previous step.
+    - name: Install dependencies excluding the NCAS CF Data Tools libraries
       shell: bash -l {0}
       run: |
         conda install -c ncas -c conda-forge udunits2=2.2.25
         conda install -c conda-forge mpich esmpy
         conda install scipy matplotlib dask
         pip install pycodestyle
-    # Install cfdm from main branch, then the cf-python development version
-    # We do so with conda which was setup in a previous step.
-    - name: Install development cfdm and cf-python
+    # Install cfunits and cfdm (from development main branch) separately,
+    # since it is most robust to test a no-dependency installation of cf,
+    # then finally install the cf-python development version.
+    - name: Install NCAS CF Data Tools libs including dev. cfdm and cf-python
       shell: bash -l {0}
       run: |
+        pip install cfunits
         cd ${{ github.workspace }}/cfdm
         pip install -e .
         cd ${{ github.workspace }}/main

--- a/.github/workflows/dask-migration-testing.yml
+++ b/.github/workflows/dask-migration-testing.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
 
     - name: Checkout cf-python
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: main
 
@@ -36,14 +36,14 @@ jobs:
       run: echo Now setting up the environment for the cf-python test suite...
 
     - name: Checkout the current cfdm master to use as the dependency
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: NCAS-CMS/cfdm
         path: cfdm
 
     # Prepare to run the test-suite on different versions of Python 3:
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/dask-migration-testing.yml
+++ b/.github/workflows/dask-migration-testing.yml
@@ -86,6 +86,7 @@ jobs:
     - name: Install NCAS CF Data Tools libs including dev. cfdm and cf-python
       shell: bash -l {0}
       run: |
+        conda install -c ncas -c conda-forge cf-plot
         pip install cfunits
         cd ${{ github.workspace }}/cfdm
         pip install -e .

--- a/.github/workflows/dask-migration-testing.yml
+++ b/.github/workflows/dask-migration-testing.yml
@@ -58,8 +58,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
         channels: ncas, conda-forge
 
-    # Ensure shell is configured with conda activated:
-    - name: Check conda config
+    # Ensure shell is configured with conda and pip correctly activated.
+    - name: Check conda and pip config
       shell: bash -l {0}
       run: |
         echo "*Conda report:*"
@@ -68,9 +68,9 @@ jobs:
         conda config --show-sources
         conda config --show
         echo "*Pip report:*"
-        python -m pip install --upgrade pip
         pip --version
         pip list
+
     # Install cf-python dependencies, excluding cfunits and cfdm, pre-testing
     # We do so with conda (and pip) which was setup in a previous step.
     - name: Install dependencies excluding the NCAS CF Data Tools libraries
@@ -80,18 +80,19 @@ jobs:
         conda install -c conda-forge mpich esmpy
         conda install scipy matplotlib dask
         pip install pycodestyle
+
     # Install cfunits and cfdm (from development main branch) separately,
     # since it is most robust to test a no-dependency installation of cf,
     # then finally install the cf-python development version.
     - name: Install NCAS CF Data Tools libs including dev. cfdm and cf-python
       shell: bash -l {0}
       run: |
-        conda install -c ncas -c conda-forge cf-plot
-        pip install cfunits
+        pip install cf-plot cfunits
         cd ${{ github.workspace }}/cfdm
         pip install -e .
         cd ${{ github.workspace }}/main
         pip install --no-deps -e .
+
     # Make UMRead library
     - name: Make UMRead
       shell: bash -l {0}

--- a/.github/workflows/dask-migration-testing.yml
+++ b/.github/workflows/dask-migration-testing.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Install dependencies excluding the NCAS CF Data Tools libraries
       shell: bash -l {0}
       run: |
-        conda install -c ncas -c conda-forge udunits2=2.2.25
+        conda install -c ncas -c conda-forge cf-plot udunits2=2.2.25
         conda install -c conda-forge mpich esmpy
         conda install scipy matplotlib dask
         pip install pycodestyle
@@ -84,10 +84,10 @@ jobs:
     # Install cfunits and cfdm (from development main branch) separately,
     # since it is most robust to test a no-dependency installation of cf,
     # then finally install the cf-python development version.
-    - name: Install NCAS CF Data Tools libs including dev. cfdm and cf-python
+    - name: Install cfunits then development versions of cfdm and cf-python
       shell: bash -l {0}
       run: |
-        pip install cf-plot cfunits
+        pip install cfunits
         cd ${{ github.workspace }}/cfdm
         pip install -e .
         cd ${{ github.workspace }}/main

--- a/.github/workflows/dask-migration-testing.yml
+++ b/.github/workflows/dask-migration-testing.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Notify about setup
       run: echo Now setting up the environment for the cf-python test suite...
 
-    - name: Checkout the current cfdm master to use as the dependency
+    - name: Checkout the current cfdm main branch to use as the dependency
       uses: actions/checkout@v3
       with:
         repository: NCAS-CMS/cfdm
@@ -62,10 +62,14 @@ jobs:
     - name: Check conda config
       shell: bash -l {0}
       run: |
+        echo "*Conda report:*"
         conda info
         conda list
         conda config --show-sources
         conda config --show
+        echo "*Pip report:*"
+        pip --version
+        pip list
     # Install cf-python dependencies, excluding cfdm, pre-testing
     # We do so with conda which was setup in a previous step.
     - name: Install dependencies
@@ -75,7 +79,7 @@ jobs:
         conda install -c conda-forge mpich esmpy
         conda install scipy matplotlib dask
         pip install pycodestyle
-    # Install cfdm from master branch, then the cf-python development version
+    # Install cfdm from main branch, then the cf-python development version
     # We do so with conda which was setup in a previous step.
     - name: Install development cfdm and cf-python
       shell: bash -l {0}

--- a/.github/workflows/dask-migration-testing.yml
+++ b/.github/workflows/dask-migration-testing.yml
@@ -68,6 +68,7 @@ jobs:
         conda config --show-sources
         conda config --show
         echo "*Pip report:*"
+        python -m pip install --upgrade pip
         pip --version
         pip list
     # Install cf-python dependencies, excluding cfdm, pre-testing
@@ -87,7 +88,7 @@ jobs:
         cd ${{ github.workspace }}/cfdm
         pip install -e .
         cd ${{ github.workspace }}/main
-        pip install -e .
+        pip install --no-deps -e .
     # Make UMRead library
     - name: Make UMRead
       shell: bash -l {0}

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -25,6 +25,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.0
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+    - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
 
     - name: Checkout cf-python
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: main
 
@@ -42,14 +42,14 @@ jobs:
       run: echo Now setting up the environment for the cf-python test suite...
 
     - name: Checkout the current cfdm master to use as the dependency
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: NCAS-CMS/cfdm
         path: cfdm
 
     # Prepare to run the test-suite on different versions of Python 3:
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -138,7 +138,7 @@ jobs:
       # would have to run anyway, it is simplest to add it in this flow.
       # Also, it means code coverage is only generated if the test suite is
       # passing at least for that job, avoiding useless coverage reports.
-      uses: codecov/codecov-action@v1.0.13
+      uses: codecov/codecov-action@v3
       if: |
         matrix.os == 'ubuntu-latest' && matrix.python-version == 3.7
       with:

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Notify about setup
       run: echo Now setting up the environment for the cf-python test suite...
 
-    - name: Checkout the current cfdm master to use as the dependency
+    - name: Checkout the current cfdm main to use as the dependency
       uses: actions/checkout@v3
       with:
         repository: NCAS-CMS/cfdm
@@ -64,18 +64,22 @@ jobs:
         python-version: ${{ matrix.python-version }}
         channels: ncas, conda-forge
 
-    # Ensure shell is configured with conda activated:
-    - name: Check conda config
+    # Ensure shell is configured with conda and pip correctly activated.
+    - name: Check conda and pip config
       shell: bash -l {0}
       run: |
+        echo "*Conda report:*"
         conda info
         conda list
         conda config --show-sources
         conda config --show
+        echo "*Pip report:*"
+        pip --version
+        pip list
 
-    # Install cf-python dependencies, excluding cfdm, pre-testing
-    # We do so with conda which was setup in a previous step.
-    - name: Install dependencies
+    # Install cf-python dependencies, excluding cfunits and cfdm, pre-testing
+    # We do so with conda (and pip) which was setup in a previous step.
+    - name: Install dependencies excluding the NCAS CF Data Tools libraries
       shell: bash -l {0}
       run: |
         conda install -c ncas -c conda-forge udunits2=2.2.25
@@ -83,15 +87,17 @@ jobs:
         conda install scipy matplotlib
         pip install pycodestyle
 
-    # Install cfdm from master branch, then the cf-python development version
-    # We do so with conda which was setup in a previous step.
-    - name: Install development cfdm and cf-python
+    # Install cfunits and cfdm (from development main branch) separately,
+    # since it is most robust to test a no-dependency installation of cf,
+    # then finally install the cf-python development version.
+    - name: Install NCAS CF Data Tools libs including dev. cfdm and cf-python
       shell: bash -l {0}
       run: |
+        pip install cf-plot cfunits
         cd ${{ github.workspace }}/cfdm
         pip install -e .
         cd ${{ github.workspace }}/main
-        pip install -e .
+        pip install --no-deps -e .
 
     # Make UMRead library
     - name: Make UMRead

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -82,7 +82,7 @@ jobs:
     - name: Install dependencies excluding the NCAS CF Data Tools libraries
       shell: bash -l {0}
       run: |
-        conda install -c ncas -c conda-forge udunits2=2.2.25
+        conda install -c ncas -c conda-forge cf-plot udunits2=2.2.25
         conda install -c conda-forge mpich esmpy
         conda install scipy matplotlib
         pip install pycodestyle
@@ -90,10 +90,10 @@ jobs:
     # Install cfunits and cfdm (from development main branch) separately,
     # since it is most robust to test a no-dependency installation of cf,
     # then finally install the cf-python development version.
-    - name: Install NCAS CF Data Tools libs including dev. cfdm and cf-python
+    - name: Install cfunits then development versions of cfdm and cf-python
       shell: bash -l {0}
       run: |
-        pip install cf-plot cfunits
+        pip install cfunits
         cd ${{ github.workspace }}/cfdm
         pip install -e .
         cd ${{ github.workspace }}/main

--- a/.github/workflows/test-source-dist.yml
+++ b/.github/workflows/test-source-dist.yml
@@ -26,7 +26,7 @@ jobs:
     # Need to checkout the repo in order to build the source dist from it,
     # but don't install codebase directly in this case, only test the sdist.
     - name: Checkout cf-python
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: main
 
@@ -35,14 +35,14 @@ jobs:
       run: echo Now setting up the environment for cf-python...
 
     - name: Checkout the current cfdm master to use as the dependency
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: NCAS-CMS/cfdm
         path: cfdm
 
     # Prepare to test the source dist using the given Python version
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test-source-dist.yml
+++ b/.github/workflows/test-source-dist.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Notify about setup
       run: echo Now setting up the environment for cf-python...
 
-    - name: Checkout the current cfdm master to use as the dependency
+    - name: Checkout the current cfdm main to use as the dependency
       uses: actions/checkout@v3
       with:
         repository: NCAS-CMS/cfdm
@@ -57,18 +57,22 @@ jobs:
         python-version: ${{ matrix.python-version }}
         channels: ncas, conda-forge
 
-    # Ensure shell is configured with conda activated:
-    - name: Check conda config
+    # Ensure shell is configured with conda and pip correctly activated.
+    - name: Check conda and pip config
       shell: bash -l {0}
       run: |
+        echo "*Conda report:*"
         conda info
         conda list
         conda config --show-sources
         conda config --show
+        echo "*Pip report:*"
+        pip --version
+        pip list
 
-    # Install cf-python dependencies, excluding cfdm, pre-testing
-    # We do so with conda which was setup in a previous step.
-    - name: Install dependencies
+    # Install cf-python dependencies, excluding cfunits and cfdm, pre-testing
+    # We do so with conda (and pip) which was setup in a previous step.
+    - name: Install dependencies excluding the NCAS CF Data Tools libraries
       shell: bash -l {0}
       run: |
         conda install -c ncas -c conda-forge udunits2=2.2.25
@@ -76,13 +80,14 @@ jobs:
         conda install scipy matplotlib
         pip install pycodestyle
 
-    # Install cfdm from the cfdm development master branch, then all other
-    # dependencies, where we also install cf-python itself but only in order
+    # Install cfunits and cfdm (from development main branch) separately,
+    # since it is most robust to test a no-dependency installation of cf, then
+    # finally install the cf-python development version, but only in order
     # to generate the test_file.nc file for testing, not as the cf to test.
-    # We do so with conda which was setup in a previous step.
     - name: Install development cfdm.
       shell: bash -l {0}
       run: |
+        pip install cf-plot cfunits
         cd ${{ github.workspace }}/cfdm
         pip install -e .
         cd ${{ github.workspace }}/main
@@ -92,7 +97,7 @@ jobs:
         pip install -r requirements.txt
         # Installing cf now but only to be able to run setup_create_field.py
         # next, in order to generate the test_file.nc required to test on
-        pip install -e .
+        pip install --no-deps -e .
 
     # Provide another notification message
     - name: Notify about starting the sdist test

--- a/.github/workflows/test-source-dist.yml
+++ b/.github/workflows/test-source-dist.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Install dependencies excluding the NCAS CF Data Tools libraries
       shell: bash -l {0}
       run: |
-        conda install -c ncas -c conda-forge udunits2=2.2.25
+        conda install -c ncas -c conda-forge cf-plot udunits2=2.2.25
         conda install -c conda-forge mpich esmpy
         conda install scipy matplotlib
         pip install pycodestyle
@@ -84,10 +84,10 @@ jobs:
     # since it is most robust to test a no-dependency installation of cf, then
     # finally install the cf-python development version, but only in order
     # to generate the test_file.nc file for testing, not as the cf to test.
-    - name: Install development cfdm.
+    - name: Install cfunits then development versions of cfdm and cf-python
       shell: bash -l {0}
       run: |
-        pip install cf-plot cfunits
+        pip install cfunits
         cd ${{ github.workspace }}/cfdm
         pip install -e .
         cd ${{ github.workspace }}/main

--- a/setup.py
+++ b/setup.py
@@ -306,6 +306,7 @@ setup(
         "cf",
         "cf.mixin",
         "cf.data",
+        "cf.data.array.abstract",
         "cf.docstring",
         "cf.read_write",
         "cf.read_write.um",

--- a/setup.py
+++ b/setup.py
@@ -306,7 +306,6 @@ setup(
         "cf",
         "cf.mixin",
         "cf.data",
-        "cf.data.abstract",
         "cf.docstring",
         "cf.read_write",
         "cf.read_write.um",


### PR DESCRIPTION
The Actions CI workflows have recently been producing jobs that all fail early (or are cancelled early due to parallel such failures) on the same setup errors, as copied in summary below. This PR aims to test, and then merge, a fix for this, so we can move onto seeing a true pass or fail output.

Despite what the note on the penultimate quoted line says, I am fairly certain this *is* actually a pip-related issue stemming from older versions of `pip` being used because (I was unaware of this before, but after investigation here I now realise) we are pretty behind in terms of versions specified for the so-called 'reusable' workflows which we specify in order to do common Actions jobs tasks such as checking out a repository and setting up Python, etc. By updating to the latest versions of those, notably the latter, I think we will get a `pip` version which won't hit this error. Testing that theory now here via the set of job 'checks' that get run on this PR...

(Whether the version updates fix this issue at hand or not, it is worthwhile to do the update. I'll go in and update all of the other workflow files in a similar way shortly in a separate PR.)


### Log output outlining the setup error in question

```console
Run cd /home/runner/work/cf-python/cf-python/cfdm
Obtaining file:///home/runner/work/cf-python/cf-python/cfdm
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Checking if build backend supports build_editable: started
  Checking if build backend supports build_editable: finished with status 'done'
  Getting requirements to build editable: started
  Getting requirements to build editable: finished with status 'done'
  Preparing editable metadata (pyproject.toml): started
  Preparing editable metadata (pyproject.toml): finished with status 'done'
Collecting netcdf-flattener>=1.2.0
  Downloading netcdf-flattener-1.2.0.tar.gz (26 kB)
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Requirement already satisfied: packaging>=20.0 in /usr/share/miniconda3/envs/cf-latest/lib/python3.8/site-packages (from cfdm==1.10.0.1) (21.3)
Requirement already satisfied: numpy>=1.15 in /usr/share/miniconda3/envs/cf-latest/lib/python3.8/site-packages (from cfdm==1.10.0.1) (1.23.5)
Collecting netCDF4>=1.5.4
  Downloading netCDF4-1.6.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (5.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 5.1/5.1 MB 92.8 MB/s eta 0:00:00
Collecting cftime>=1.6.0
  Downloading cftime-1.6.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.3 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.3/1.3 MB [12](https://github.com/NCAS-CMS/cf-python/actions/runs/3591398929/jobs/6045870873#step:9:13)7.2 MB/s eta 0:00:00
Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in /usr/share/miniconda3/envs/cf-latest/lib/python3.8/site-packages (from packaging>=20.0->cfdm==1.10.0.1) (3.0.9)
Building wheels for collected packages: cfdm, netcdf-flattener
  Building editable for cfdm (pyproject.toml): started
  Building editable for cfdm (pyproject.toml): finished with status 'done'
  Created wheel for cfdm: filename=cfdm-1.10.0.1-0.editable-py3-none-any.whl size=6830 sha256=1d778e6304175f3a884dcdd7735f3989e0d48e1c49484c935416a9ac42a80a91
  Stored in directory: /tmp/pip-ephem-wheel-cache-cjecr_x_/wheels/33/57/e7/a03234108b4035cfc4884dbaf64835d61f145f5e091c1b048b
  Building wheel for netcdf-flattener (setup.py): started
  Building wheel for netcdf-flattener (setup.py): finished with status 'done'
  Created wheel for netcdf-flattener: filename=netcdf_flattener-1.2.0-py3-none-any.whl size=16602 sha256=115[13](https://github.com/NCAS-CMS/cf-python/actions/runs/3591398929/jobs/6045870873#step:9:14)d772a67d3f845da3a8b28d5b570802288b52ce1d2a62b2fe899cb4dd7ee
  Stored in directory: /home/runner/.cache/pip/wheels/3a/5c/01/ecdde7cba02b1abe2ecd807612f4ca9e39927db21e40cb5c6a
Successfully built cfdm netcdf-flattener
Installing collected packages: cftime, netCDF4, netcdf-flattener, cfdm
Successfully installed cfdm-1.10.0.1 cftime-1.6.2 netCDF4-1.6.2 netcdf-flattener-1.2.0
Obtaining file:///home/runner/work/cf-python/cf-python/main
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Checking if build backend supports build_editable: started
  Checking if build backend supports build_editable: finished with status 'done'
  Getting requirements to build editable: started
  Getting requirements to build editable: finished with status 'error'
  error: subprocess-exited-with-error
  
  × Getting requirements to build editable did not run successfully.
  │ exit code: 1
  ╰─> [8 lines of output]
      running egg_info
      creating cf_python.egg-info
      writing cf_python.egg-info/PKG-INFO
      writing dependency_links to cf_python.egg-info/dependency_links.txt
      writing requirements to cf_python.egg-info/requires.txt
      writing top-level names to cf_python.egg-info/top_level.txt
      writing manifest file 'cf_python.egg-info/SOURCES.txt'
      error: package directory 'cf/data/abstract' does not exist
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build editable did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
Error: Process completed with exit code 1.
```
