### PR TITLE
Set module in `unittest.main` for all test modules

### DIFF
--- a/cf/test/create_test_files.py
+++ b/cf/test/create_test_files.py
@@ -5299,4 +5299,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/setup_create_field.py
+++ b/cf/test/setup_create_field.py
@@ -209,4 +209,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_AuxiliaryCoordinate.py
+++ b/cf/test/test_AuxiliaryCoordinate.py
@@ -339,4 +339,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_CellMeasure.py
+++ b/cf/test/test_CellMeasure.py
@@ -40,4 +40,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_CellMethod.py
+++ b/cf/test/test_CellMethod.py
@@ -149,4 +149,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_Constructs.py
+++ b/cf/test/test_Constructs.py
@@ -45,4 +45,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print("")
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_CoordinateReference.py
+++ b/cf/test/test_CoordinateReference.py
@@ -292,4 +292,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_Count.py
+++ b/cf/test/test_Count.py
@@ -36,4 +36,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -4415,4 +4415,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_Data_utils.py
+++ b/cf/test/test_Data_utils.py
@@ -289,4 +289,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_Datetime.py
+++ b/cf/test/test_Datetime.py
@@ -155,4 +155,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_DimensionCoordinate.py
+++ b/cf/test/test_DimensionCoordinate.py
@@ -517,4 +517,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_Domain.py
+++ b/cf/test/test_Domain.py
@@ -300,4 +300,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print("")
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_DomainAncillary.py
+++ b/cf/test/test_DomainAncillary.py
@@ -20,4 +20,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_DomainAxis.py
+++ b/cf/test/test_DomainAxis.py
@@ -52,4 +52,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -2483,4 +2483,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print("")
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_FieldAncillary.py
+++ b/cf/test/test_FieldAncillary.py
@@ -76,4 +76,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_FieldList.py
+++ b/cf/test/test_FieldList.py
@@ -477,4 +477,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_Index.py
+++ b/cf/test/test_Index.py
@@ -36,4 +36,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_List.py
+++ b/cf/test/test_List.py
@@ -36,4 +36,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_Maths.py
+++ b/cf/test/test_Maths.py
@@ -278,4 +278,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_Query.py
+++ b/cf/test/test_Query.py
@@ -608,4 +608,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_RegridOperator.py
+++ b/cf/test/test_RegridOperator.py
@@ -51,4 +51,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_TimeDuration.py
+++ b/cf/test/test_TimeDuration.py
@@ -529,4 +529,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_aggregate.py
+++ b/cf/test/test_aggregate.py
@@ -340,4 +340,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_cfa.py
+++ b/cf/test/test_cfa.py
@@ -52,4 +52,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_collapse.py
+++ b/cf/test/test_collapse.py
@@ -668,4 +668,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_decorators.py
+++ b/cf/test/test_decorators.py
@@ -216,4 +216,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_docstring.py
+++ b/cf/test/test_docstring.py
@@ -195,4 +195,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print("")
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_dsg.py
+++ b/cf/test/test_dsg.py
@@ -345,4 +345,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_external.py
+++ b/cf/test/test_external.py
@@ -226,4 +226,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_formula_terms.py
+++ b/cf/test/test_formula_terms.py
@@ -896,4 +896,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print("")
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_functions.py
+++ b/cf/test/test_functions.py
@@ -360,4 +360,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_gathering.py
+++ b/cf/test/test_gathering.py
@@ -297,4 +297,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_general.py
+++ b/cf/test/test_general.py
@@ -182,4 +182,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_geometry.py
+++ b/cf/test/test_geometry.py
@@ -315,4 +315,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_groups.py
+++ b/cf/test/test_groups.py
@@ -413,4 +413,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_pp.py
+++ b/cf/test/test_pp.py
@@ -144,4 +144,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_read_write.py
+++ b/cf/test/test_read_write.py
@@ -883,4 +883,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_regrid.py
+++ b/cf/test/test_regrid.py
@@ -259,4 +259,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print("")
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_style.py
+++ b/cf/test/test_style.py
@@ -84,4 +84,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)

--- a/cf/test/test_subsampling.py
+++ b/cf/test/test_subsampling.py
@@ -246,4 +246,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(verbosity=2)
+    unittest.main(module=__file__.split(".")[0], verbosity=2)


### PR DESCRIPTION
A quick PR to allow wrapping of any, or all, of our test modules by profiling tools etc. (which I realise isn't the best way to gauge performance but still can be useful as an investigation tool) by explicitly setting [the `module` argument to `unittest.main`](https://docs.python.org/3/library/unittest.html#unittest.main) which produces no difference in behaviour when run in the standard/direct way, but enables all of the test methods, rather than none due to the module not being recognised, to be run when the script is wrapped.

To avoid having to set all of the filenames individually to get e.g. `module="test_Data"`, I did a `sed` replacement via `$ find . -type f | xargs sed -i 's/unittest\.main(/unittest\.main(module=__file__\.split("\.")\[0\], /g'` under the `test` directory.

@davidhassell: requesting a review despite this being quite a trivial PR, please confirm whether or not this is going to cause any problems that I might not have foreseen. Thanks.