### PR TITLE
dask: Bug fix to `convert_to_reftime`

### DIFF
--- a/cf/data/utils.py
+++ b/cf/data/utils.py
@@ -162,7 +162,10 @@ def convert_to_reftime(a, units=None, first_value=None):
             else:
                 YMD = "1970-01-01"
 
-            units = Units("days since " + YMD, default_calendar)
+            units = Units(
+                "days since " + YMD,
+                getattr(units, "calendar", default_calendar),
+            )
 
         a = a.map_blocks(
             partial(st2rt, units_in=units, units_out=units), dtype=float

--- a/cf/test/test_Data_utils.py
+++ b/cf/test/test_Data_utils.py
@@ -152,6 +152,16 @@ class DataUtilsTest(unittest.TestCase):
         self.assertTrue((e.compute() == [-99, -1, 0]).all())
         self.assertEqual(u, units)
 
+        d = cf.Data(
+            ["2004-02-29", "2004-02-30", "2004-03-01"], calendar="360_day"
+        )
+        self.assertEqual(d.Units, cf.Units("days since 2004-02-29", "360_day"))
+        self.assertTrue((d.array == [0, 1, 2]).all())
+
+        d = cf.Data(["2004-02-29", "2004-03-01"], dt=True)
+        self.assertEqual(d.Units, cf.Units("days since 2004-02-29"))
+        self.assertTrue((d.array == [0, 1]).all())
+
     def test_Data_Utils_unique_calendars(self):
         """TODO."""
         a = [


### PR DESCRIPTION
Bug fix to get these lines from the `tutorial.rst` working:
```python
   >>> d = cf.Data(['2004-02-29', '2004-02-30', '2004-03-01'], calendar='360_day')
   >>> d.Units
   <Units: days since 2004-02-29 360_day>
   >>> print(d.array)
   [0. 1. 2.]
   >>> print(d.datetime_array)
   [cftime.Datetime360Day(2004-02-29 00:00:00)
    cftime.Datetime360Day(2004-02-30 00:00:00)
    cftime.Datetime360Day(2004-03-01 00:00:00)]
```