### PR TITLE
dask: Force from_array lock=False for nested arrays in compressed chunks

### DIFF
--- a/cf/data/array/mixin/__init__.py
+++ b/cf/data/array/mixin/__init__.py
@@ -1,3 +1,4 @@
 from .arraymixin import ArrayMixin
+from .compressedarraymixin import CompressedArrayMixin
 from .filearraymixin import FileArrayMixin
 from .raggedarraymixin import RaggedArrayMixin

--- a/cf/data/array/mixin/compressedarraymixin.py
+++ b/cf/data/array/mixin/compressedarraymixin.py
@@ -1,0 +1,46 @@
+import dask.array as da
+
+
+class CompressedArrayMixin:
+    """Mixin class for compressed arrays.
+
+    .. versionadded:: TODODASKVER
+
+    """
+
+    def _lock_file_read(self, array):
+        """Try to return a dask array the does not support concurrent
+        reads.
+
+        .. versionadded:: TODODASKVER
+
+        :Parameters:
+
+            array: array_like
+                The array to
+
+        :Returns"
+
+            `dask.array.Array` or array_like
+                The new `dask` array, or the orginal array if it
+                couldn't be ascertained how to form the `dask` array.
+
+        """
+        try:
+            chunks = array.chunks
+        except AttributeError:
+            chunks = "auto"
+
+        try:
+            array = array.source()
+        except (ValueError, AttributeError):
+            pass
+
+        try:
+            array.get_filename()
+        except AttributeError:
+            pass
+        else:
+            array = da.from_array(array, chunks=chunks, lock=True)
+
+        return array

--- a/cf/data/array/mixin/compressedarraymixin.py
+++ b/cf/data/array/mixin/compressedarraymixin.py
@@ -9,7 +9,7 @@ class CompressedArrayMixin:
     """
 
     def _lock_file_read(self, array):
-        """Try to return a dask array the does not support concurrent
+        """Try to return a dask array that does not support concurrent
         reads.
 
         .. versionadded:: TODODASKVER

--- a/cf/data/array/mixin/compressedarraymixin.py
+++ b/cf/data/array/mixin/compressedarraymixin.py
@@ -17,7 +17,7 @@ class CompressedArrayMixin:
         :Parameters:
 
             array: array_like
-                The array to
+                The array to process.
 
         :Returns"
 

--- a/cf/data/array/mixin/raggedarraymixin.py
+++ b/cf/data/array/mixin/raggedarraymixin.py
@@ -1,4 +1,7 @@
-class RaggedArrayMixin:
+from . import CompressedArrayMixin
+
+
+class RaggedArrayMixin(CompressedArrayMixin):
     """Mixin TODODASKDOCS class for a container of an array.
 
     .. versionadded:: TODODASKVER
@@ -43,6 +46,16 @@ class RaggedArrayMixin:
         compressed_dimensions = self.compressed_dimensions()
         conformed_data = self.conformed_data()
         compressed_data = conformed_data["data"]
+
+        # If possible, convert the compressed data to a dask array
+        # that doesn't support concurrent reads. This prevents
+        # "compute called by compute" failures problems at compute
+        # time.
+        #
+        # TODO: This won't be necessary if this is refactored so that
+        #       the compressed data is part of the same dask graph as
+        #       the compressed subarrays.
+        compressed_data = self._lock_file_read(compressed_data)
 
         # Get the (cfdm) subarray class
         Subarray = self.get_Subarray()

--- a/cf/data/creation.py
+++ b/cf/data/creation.py
@@ -103,12 +103,11 @@ def to_dask(array, chunks, default_chunks=False, **from_array_options):
 
         return array
 
-    try:
-        return array.to_dask_array(chunks=chunks)
-    except TypeError:
-        return array.to_dask_array()
-    except AttributeError:
-        pass
+    if hasattr(array, "to_dask_array"):
+        try:
+            return array.to_dask_array(chunks=chunks)
+        except TypeError:
+            return array.to_dask_array()
 
     if not isinstance(
         array, (np.ndarray, list, tuple, memoryview) + np.ScalarType
@@ -118,11 +117,7 @@ def to_dask(array, chunks, default_chunks=False, **from_array_options):
         array = np.asanyarray(array)
 
     kwargs = from_array_options
-    lock = getattr(array, "_dask_lock", False)
-    if lock:
-        lock = get_lock()
-
-    kwargs.setdefault("lock", lock)
+    kwargs.setdefault("lock", getattr(array, "_dask_lock", False))
     kwargs.setdefault("meta", getattr(array, "_dask_meta", None))
 
     try:

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -442,8 +442,10 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
                 except AttributeError:
                     pass
 
-            # Save the input compressed array, as this will contain
-            # extra information, such as a count or index variable.
+        if self._is_abstract_Array_subclass(array):
+            # Save the input array in case it's useful later. For
+            # compressed input arrays this will contain extra information,
+            # such as a count or index variable.
             self._set_Array(array)
 
         # Cast the input data as a dask array

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -4415,4 +4415,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_dsg.py
+++ b/cf/test/test_dsg.py
@@ -345,4 +345,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_gathering.py
+++ b/cf/test/test_gathering.py
@@ -297,4 +297,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_groups.py
+++ b/cf/test/test_groups.py
@@ -284,7 +284,6 @@ class GroupsTest(unittest.TestCase):
         f.compress("indexed_contiguous", inplace=True)
         f.data.get_count().nc_set_variable("count")
         f.data.get_index().nc_set_variable("index")
-
         cf.write(f, ungrouped_file, verbose=1)
         g = cf.read(ungrouped_file)[0]
         self.assertTrue(f.equals(g, verbose=2))
@@ -413,4 +412,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_subsampling.py
+++ b/cf/test/test_subsampling.py
@@ -246,4 +246,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)


### PR DESCRIPTION
The recent change to the default dask file lock (#518) causes problems with compressed data: It's currently set up so that the each dask chunk has to compute another dask array. It does this nested compute with the synchronous scheduler - which it seemed to like - but now that `lock=False` it doesn't like it at all. 

The solution (well, hack) I have come up with involves redefining the other dask array with `da.from_array(..., lock=True)` and then all is well.

This is not great, and all of these compressed `to_dask_array` methods should really, if possible, integrate the other dask array into a single dask graph. That's one for later (post 3.14.0).