### PR TITLE
dask: Reinstate netCDF lock

### DIFF
--- a/cf/data/array/netcdfarray.py
+++ b/cf/data/array/netcdfarray.py
@@ -1,5 +1,7 @@
 import cfdm
 
+from dask.utils import SerializableLock
+
 from .mixin import FileArrayMixin
 
 
@@ -18,10 +20,18 @@ class NetCDFArray(FileArrayMixin, cfdm.NetCDFArray):
     def _dask_lock(self):
         """Set the lock for use in `dask.array.from_array`.
 
-        Returns `True` because concurrent reads are not currently
-        supported by the netCDF-C library.
+        Returns a lock object (unless no file name has been set)
+        because concurrent reads are not currently supported by the
+        netCDF-C library. The lock object will be the same for all
+        `NetCDFArray` instances with this file name, which means that
+        all file access coordinates around the same lock.
 
         .. versionadded:: TODODASKVER
 
         """
-        return True
+        filename = array.get_filename(None)
+        if filename is None:
+            return False
+        
+        return SerializableLock(filename)
+        

--- a/cf/data/array/netcdfarray.py
+++ b/cf/data/array/netcdfarray.py
@@ -18,7 +18,7 @@ class NetCDFArray(FileArrayMixin, cfdm.NetCDFArray):
     def _dask_lock(self):
         """Set the lock for use in `dask.array.from_array`.
 
-        Returns `true` because concurrent reads are not currently
+        Returns `True` because concurrent reads are not currently
         supported by the netCDF-C library.
 
         .. versionadded:: TODODASKVER

--- a/cf/data/array/netcdfarray.py
+++ b/cf/data/array/netcdfarray.py
@@ -23,7 +23,7 @@ class NetCDFArray(FileArrayMixin, cfdm.NetCDFArray):
         which case `False` is returned) because concurrent reads are
         not currently supported by the netCDF-C library. The lock
         object will be the same for all `NetCDFArray` instances with
-        this file name, which means that all file access coordinates
+        this file name, which means that all files access coordinates
         around the same lock.
 
         .. versionadded:: TODODASKVER

--- a/cf/data/array/netcdfarray.py
+++ b/cf/data/array/netcdfarray.py
@@ -1,5 +1,4 @@
 import cfdm
-
 from dask.utils import SerializableLock
 
 from .mixin import FileArrayMixin
@@ -20,18 +19,18 @@ class NetCDFArray(FileArrayMixin, cfdm.NetCDFArray):
     def _dask_lock(self):
         """Set the lock for use in `dask.array.from_array`.
 
-        Returns a lock object (unless no file name has been set)
-        because concurrent reads are not currently supported by the
-        netCDF-C library. The lock object will be the same for all
-        `NetCDFArray` instances with this file name, which means that
-        all file access coordinates around the same lock.
+        Returns a lock object (unless no file name has been set, in
+        which case `False` is returned) because concurrent reads are
+        not currently supported by the netCDF-C library. The lock
+        object will be the same for all `NetCDFArray` instances with
+        this file name, which means that all file access coordinates
+        around the same lock.
 
         .. versionadded:: TODODASKVER
 
         """
-        filename = array.get_filename(None)
+        filename = self.get_filename(None)
         if filename is None:
             return False
-        
+
         return SerializableLock(filename)
-        

--- a/cf/data/array/netcdfarray.py
+++ b/cf/data/array/netcdfarray.py
@@ -3,6 +3,9 @@ from dask.utils import SerializableLock
 
 from .mixin import FileArrayMixin
 
+# Global lock for netCDF file access
+_lock = SerializableLock()
+
 
 class NetCDFArray(FileArrayMixin, cfdm.NetCDFArray):
     """An array stored in a netCDF file."""
@@ -22,9 +25,9 @@ class NetCDFArray(FileArrayMixin, cfdm.NetCDFArray):
         Returns a lock object (unless no file name has been set, in
         which case `False` is returned) because concurrent reads are
         not currently supported by the netCDF-C library. The lock
-        object will be the same for all `NetCDFArray` instances with
-        this file name, which means that all files access coordinates
-        around the same lock.
+        object will be the same for all `NetCDFArray` instances,
+        regardless of the dataset they access, which means that all
+        file access coordinates around the same lock.
 
         .. versionadded:: TODODASKVER
 
@@ -33,4 +36,4 @@ class NetCDFArray(FileArrayMixin, cfdm.NetCDFArray):
         if filename is None:
             return False
 
-        return SerializableLock(filename)
+        return _lock 

--- a/cf/data/array/netcdfarray.py
+++ b/cf/data/array/netcdfarray.py
@@ -13,3 +13,15 @@ class NetCDFArray(FileArrayMixin, cfdm.NetCDFArray):
 
         """
         return super().__repr__().replace("<", "<CF ", 1)
+
+    @property
+    def _dask_lock(self):
+        """Set the lock for use in `dask.array.from_array`.
+
+        Returns `true` because concurrent reads are not currently
+        supported by the netCDF-C library.
+
+        .. versionadded:: TODODASKVER
+
+        """
+        return True

--- a/cf/data/array/netcdfarray.py
+++ b/cf/data/array/netcdfarray.py
@@ -27,7 +27,7 @@ class NetCDFArray(FileArrayMixin, cfdm.NetCDFArray):
         not currently supported by the netCDF-C library. The lock
         object will be the same for all `NetCDFArray` instances,
         regardless of the dataset they access, which means that all
-        file access coordinates around the same lock.
+        files access coordinates around the same lock.
 
         .. versionadded:: TODODASKVER
 

--- a/cf/data/creation.py
+++ b/cf/data/creation.py
@@ -114,9 +114,8 @@ def to_dask(array, chunks, default_chunks=False, **from_array_options):
         # so convert it to a numpy array.
         array = np.asanyarray(array)
 
-        
     kwargs = from_array_options
-    kwargs.setdefault("lock", getattr(array, "_dask_lock", False)
+    kwargs.setdefault("lock", getattr(array, "_dask_lock", False))
     kwargs.setdefault("meta", getattr(array, "_dask_meta", None))
 
     try:
@@ -125,6 +124,7 @@ def to_dask(array, chunks, default_chunks=False, **from_array_options):
         # Try again with 'chunks=-1', in case the failure was due to
         # not being able to use auto rechunking with object dtype.
         return da.from_array(array, chunks=-1, **kwargs)
+
 
 @lru_cache(maxsize=32)
 def generate_axis_identifiers(n):

--- a/cf/data/creation.py
+++ b/cf/data/creation.py
@@ -6,76 +6,44 @@ import numpy as np
 from dask.base import is_dask_collection
 
 
-def convert_to_builtin_type(x):
-    """Convert a non-JSON-encodable object to a JSON-encodable built-in
-    type.
-
-    Possible conversions are:
-
-    ================  =======  ================================
-    Input             Output   `numpy` data-types covered
-    ================  =======  ================================
-    `numpy.bool_`     `bool`   bool
-    `numpy.integer`   `int`    int, int8, int16, int32, int64,
-                               uint8, uint16, uint32, uint64
-    `numpy.floating`  `float`  float, float16, float32, float64
-    ================  =======  ================================
-
-    .. versionadded:: 4.0.0
-
-    :Parameters:
-
-        x:
-            TODO
-
-    :Returns:
-
-            TODO
-
-    **Examples**
-
-    >>> type(_convert_to_netCDF_datatype(numpy.bool_(True)))
-    bool
-    >>> type(_convert_to_netCDF_datatype(numpy.array([1.0])[0]))
-    double
-    >>> type(_convert_to_netCDF_datatype(numpy.array([2])[0]))
-    int
-
-    """
-    if isinstance(x, np.bool_):
-        return bool(x)
-
-    if isinstance(x, np.integer):
-        return int(x)
-
-    if isinstance(x, np.floating):
-        return float(x)
-
-    raise TypeError(f"{type(x)!r} object is not JSON serializable: {x!r}")
-
-
-def to_dask(array, chunks, default_chunks=False, **from_array_options):
-    """TODODASKDOCS.
+def to_dask(array, chunks, **from_array_options):
+    """Create a `dask` array.
 
     .. versionadded:: TODODASKVER
 
     :Parameters:
 
         array: array_like
-            TODODASKDOCS.
+            The array to be converted to a `dask` array. Examples of
+            valid types include `numpy` arrays, `dask` arrays, `Array`
+            subclasses, `list`, `tuple`, scalars.
 
         chunks: `int`, `tuple`, `dict` or `str`, optional
-            Specify the chunking of the returned dask array.
-
-            Any value accepted by the *chunks* parameter of the
+            Specify the chunking of the returned dask array.  Any
+            value accepted by the *chunks* parameter of the
             `dask.array.from_array` function is allowed.
 
-        dask_from_array_options: `dict`
+            Ignored if *array* is a `dask` array, which already
+            defines its own chunks.
+
+            Might get automatically modified if *array* is a
+            compressed `Array` subclass.
+
+        from_array_options: `dict`, optional
             Keyword arguments to be passed to `dask.array.from_array`.
+
+            If *from_array_options* has no ``'lock'`` key then the
+            `lock` keyword is set to the `_dask_lock` attribute of
+            *array* or, if there is no such attribute, `False`.
+
+            If *from_array_options* has no ``'meta'`` key then the
+            `meta` keyword is set to the `_dask_meta` attribute of
+            *array* or, if there is no such attribute, `None`.
 
     :Returns:
 
         `dask.array.Array`
+            The `dask` array representation of the array.
 
     **Examples**
 
@@ -92,13 +60,6 @@ def to_dask(array, chunks, default_chunks=False, **from_array_options):
 
     """
     if is_dask_collection(array):
-        if default_chunks is not False and chunks != default_chunks:
-            raise ValueError(
-                "Can't define chunks for dask input arrays. Consider "
-                "rechunking the dask array before initialisation, "
-                "or rechunking the `Data` after initialisation."
-            )
-
         return array
 
     if hasattr(array, "to_dask_array"):
@@ -128,7 +89,7 @@ def to_dask(array, chunks, default_chunks=False, **from_array_options):
 
 @lru_cache(maxsize=32)
 def generate_axis_identifiers(n):
-    """Return new, unique axis identifiers for a given number of axes.
+    """Return new axis identifiers for a given number of axes.
 
     The names are arbitrary and have no semantic meaning.
 
@@ -142,15 +103,15 @@ def generate_axis_identifiers(n):
     :Returns:
 
         `list`
-            The new axis idenfifiers.
+            The new axis identifiers.
 
     **Examples**
 
-    >>> generate_axis_identifiers(0)
+    >>> cf.data.creation.generate_axis_identifiers(0)
     []
-    >>> generate_axis_identifiers(1)
+    >>> cf.data.creation.generate_axis_identifiers(1)
     ['dim0']
-    >>> generate_axis_identifiers(3)
+    >>> cf.data.creation.generate_axis_identifiers(3)
     ['dim0', 'dim1', 'dim2']
 
     """

--- a/cf/data/creation.py
+++ b/cf/data/creation.py
@@ -4,7 +4,6 @@ from functools import lru_cache
 import dask.array as da
 import numpy as np
 from dask.base import is_dask_collection
-from dask.utils import SerializableLock
 
 
 def convert_to_builtin_type(x):
@@ -116,22 +115,8 @@ def to_dask(array, chunks, default_chunks=False, **from_array_options):
         array = np.asanyarray(array)
 
         
-    # Set a lock if required
-    lock = getattr(array, "_dask_lock", False)
-    if lock is True:
-        # The input array has requested a lock, but not specified what
-        # it should be => so set a lock that coordinates all access to
-        # this file, even across multiple dask arrays.
-        try:
-            filename = array.get_filename(None)
-        except AttributeError:
-            pass
-        else:
-            if filename is not None:
-                lock = SerializableLock(filename)
-        
     kwargs = from_array_options
-    kwargs.setdefault("lock", lock)
+    kwargs.setdefault("lock", getattr(array, "_dask_lock", False)
     kwargs.setdefault("meta", getattr(array, "_dask_meta", None))
 
     try:

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -420,14 +420,6 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
             compressed = ""
 
         if compressed:
-            # The input data is compressed
-            if chunks != _DEFAULT_CHUNKS:
-                # TODODASK: Is this restriction necessary?
-                raise ValueError(
-                    "Can't define chunks for compressed input arrays. "
-                    "Consider rechunking after initialisation."
-                )
-
             if init_options.get("from_array"):
                 raise ValueError(
                     "Can't define 'from_array' initialisation options "
@@ -456,9 +448,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
                 "options. Use the 'chunks' parameter instead."
             )
 
-        array = to_dask(
-            array, chunks, default_chunks=_DEFAULT_CHUNKS, **kwargs
-        )
+        array = to_dask(array, chunks, **kwargs)
 
         # Find out if we have an array of date-time objects
         if units.isreftime:

--- a/cf/test/test_read_write.py
+++ b/cf/test/test_read_write.py
@@ -883,4 +883,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)


### PR DESCRIPTION
It turns out that removing the concurrency lock for opening netCDF files is not (yet) safe in the netCDF-C library, so we should put it back for now. I had thought that separate opens/closes would be OK, but not so. This may be fixed in future version of netCDF-C. See, e.g. https://github.com/Unidata/netcdf4-python/issues/844 and https://github.com/pydata/xarray/issues/4100.

_Edit:_ The `test_Field_collapse` are still segfaulting intermittently, but less frequently with this. I think it may be due to the fact that each `from_array` call is creating its own lock, so its still possible for concurrent accesses that originate from the same file, e.g. `f + f.copy()`. The answer could be to create a common lock object and coordinate all access to a particular file around that. 

_Edit:_ Following this change`test_Field_collapse` (with the concatenate fixes from another PR) didn't segfault 18 times in row before I stopped counting - record!

_Edit:_ I deleted the three functions from `creation.py` because they're not ever used, and were only there because I thought they would be useful over a year ago, when I didn't really know what I was doing.