### PR TITLE
CI: generate & register netCDF test files in workflow

### DIFF
--- a/.github/workflows/dask-migration-testing.yml
+++ b/.github/workflows/dask-migration-testing.yml
@@ -99,15 +99,28 @@ jobs:
       run: |
         cd ${{ github.workspace }}/main/cf/umread_lib/c-lib
         make
+
     # Install the coverage library
     # We do so with conda which was setup in a previous step.
     - name: Install coverage
       shell: bash -l {0}
       run: |
         conda install coverage
+
     # Provide another notification message
     - name: Notify about starting testing
       run: echo Setup complete. Now starting to run the cf-python test suite...
+
+    # Create netCDF files needed for testing. A separate step is required
+    # for this so the files can be registered and recognised first; locally
+    # they are created and used on-the-fly by 'run_tests_and_coverage'.
+    - name: Create netCDF test files, e.g. test_file.nc
+      shell: bash -l {0}
+      run: |
+        cd ${{ github.workspace }}/main/cf/test
+        python create_test_files.py
+        python setup_create_field.py
+        ls -la
 
     # Finally run the relevant tests: firstly test_Data.py...
     - name: Run the test_Data test module

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -117,10 +117,10 @@ jobs:
     - name: Notify about starting testing
       run: echo Setup complete. Now starting to run the cf-python test suite...
 
-    # Create a file needed for testing. A separate step is required for this
-    # so the file can be registered and recognised first. Locally, the file
-    # is created and used on-the-fly by the 'run_tests_and_coverage' script.
-    - name: Create test_file.nc
+    # Create netCDF files needed for testing. A separate step is required
+    # for this so the files can be registered and recognised first; locally
+    # they are created and used on-the-fly by 'run_tests_and_coverage'.
+    - name: Create netCDF test files, e.g. test_file.nc
       shell: bash -l {0}
       run: |
         cd ${{ github.workspace }}/main/cf/test

--- a/.github/workflows/test-source-dist.yml
+++ b/.github/workflows/test-source-dist.yml
@@ -103,10 +103,10 @@ jobs:
     - name: Notify about starting the sdist test
       run: echo Setup complete. Now creating and testing the source dist...
 
-    # Create a file needed for testing. A separate step is required for this
-    # so the file can be registered and recognised first. Locally, the file
-    # is created and used on-the-fly by the 'run_tests_and_coverage' script.
-    - name: Create test_file.nc
+    # Create netCDF files needed for testing. A separate step is required
+    # for this so the files can be registered and recognised first; locally
+    # they are created and used on-the-fly by 'run_tests_and_coverage'.
+    - name: Create netCDF test files, e.g. test_file.nc
       shell: bash -l {0}
       run: |
         cd ${{ github.workspace }}/main/cf/test

--- a/cf/test/create_test_files.py
+++ b/cf/test/create_test_files.py
@@ -5299,4 +5299,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/setup_create_field.py
+++ b/cf/test/setup_create_field.py
@@ -209,4 +209,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_AuxiliaryCoordinate.py
+++ b/cf/test/test_AuxiliaryCoordinate.py
@@ -339,4 +339,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_CellMeasure.py
+++ b/cf/test/test_CellMeasure.py
@@ -40,4 +40,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_CellMethod.py
+++ b/cf/test/test_CellMethod.py
@@ -149,4 +149,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_Constructs.py
+++ b/cf/test/test_Constructs.py
@@ -45,4 +45,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print("")
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_CoordinateReference.py
+++ b/cf/test/test_CoordinateReference.py
@@ -292,4 +292,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_Count.py
+++ b/cf/test/test_Count.py
@@ -36,4 +36,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_Data_utils.py
+++ b/cf/test/test_Data_utils.py
@@ -289,4 +289,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_Datetime.py
+++ b/cf/test/test_Datetime.py
@@ -155,4 +155,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_DimensionCoordinate.py
+++ b/cf/test/test_DimensionCoordinate.py
@@ -517,4 +517,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_Domain.py
+++ b/cf/test/test_Domain.py
@@ -300,4 +300,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print("")
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_DomainAncillary.py
+++ b/cf/test/test_DomainAncillary.py
@@ -20,4 +20,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_DomainAxis.py
+++ b/cf/test/test_DomainAxis.py
@@ -52,4 +52,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -2499,4 +2499,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print("")
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_FieldAncillary.py
+++ b/cf/test/test_FieldAncillary.py
@@ -76,4 +76,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_FieldList.py
+++ b/cf/test/test_FieldList.py
@@ -477,4 +477,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_Index.py
+++ b/cf/test/test_Index.py
@@ -36,4 +36,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_List.py
+++ b/cf/test/test_List.py
@@ -36,4 +36,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_Maths.py
+++ b/cf/test/test_Maths.py
@@ -278,4 +278,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_Query.py
+++ b/cf/test/test_Query.py
@@ -608,4 +608,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_RegridOperator.py
+++ b/cf/test/test_RegridOperator.py
@@ -51,4 +51,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_TimeDuration.py
+++ b/cf/test/test_TimeDuration.py
@@ -529,4 +529,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_aggregate.py
+++ b/cf/test/test_aggregate.py
@@ -340,4 +340,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_cfa.py
+++ b/cf/test/test_cfa.py
@@ -52,4 +52,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_collapse.py
+++ b/cf/test/test_collapse.py
@@ -668,4 +668,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_decorators.py
+++ b/cf/test/test_decorators.py
@@ -216,4 +216,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_docstring.py
+++ b/cf/test/test_docstring.py
@@ -195,4 +195,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print("")
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_external.py
+++ b/cf/test/test_external.py
@@ -226,4 +226,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_formula_terms.py
+++ b/cf/test/test_formula_terms.py
@@ -896,4 +896,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print("")
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_functions.py
+++ b/cf/test/test_functions.py
@@ -360,4 +360,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_general.py
+++ b/cf/test/test_general.py
@@ -182,4 +182,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_geometry.py
+++ b/cf/test/test_geometry.py
@@ -315,4 +315,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_pp.py
+++ b/cf/test/test_pp.py
@@ -144,4 +144,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_read_write.py
+++ b/cf/test/test_read_write.py
@@ -883,4 +883,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_regrid.py
+++ b/cf/test/test_regrid.py
@@ -259,4 +259,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print("")
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)

--- a/cf/test/test_style.py
+++ b/cf/test/test_style.py
@@ -84,4 +84,4 @@ if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())
     cf.environment()
     print()
-    unittest.main(module=__file__.split(".")[0], verbosity=2)
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Fix #495 and whilst doing this effectively revert #524 which was, despite initial appearances, not harmless since it meant the test modules and full suite would not run directly when Python environments were set up in a certain (not contrived though I'm not sure how standard it would be considered) way.
