### PR TITLE
dask: Remove `is_small` and `is_very_small`

### DIFF
--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -55,7 +55,7 @@ from .dask_utils import (
     cf_where,
 )
 from .mixin import DataClassDeprecationsMixin
-from .utils import (  # is_small,; is_very_small,
+from .utils import (
     YMDhms,
     _is_numeric_dtype,
     conform_units,

--- a/cf/data/utils.py
+++ b/cf/data/utils.py
@@ -476,38 +476,6 @@ def chunk_shapes(chunks):
     return product(*chunks)
 
 
-def is_small(array, threshold=None):
-    """We adjust the size of the data here for the potiential of a mask.
-
-    Returns False if size is unknown
-
-    .. versionadded:: 4.0.0
-
-    """
-    # TODODASKAPI - need to define what 'small' is, and consider the API
-    # in general
-
-    if threshold is None:
-        threshold = 2**90  # TODODASK - True for now!
-
-    return array.size * (array.dtype.itemsize + 1) < threshold
-
-
-def is_very_small(array, threshold=None):
-    """TODODASKDOCS.
-
-    .. versionadded:: 4.0.0
-
-    """
-    # TODODASKAPI - need to define what 'very small' is, and consider the
-    # API in general
-
-    if threshold is None:
-        threshold = 0.125 * 2**90  # TODODASK - True for now!
-
-    return is_small(array, threshold)
-
-
 def scalar_masked_array(dtype=float):
     """Return a scalar masked array.
 


### PR DESCRIPTION
Removes functions `is_small` and `is_very_small` from `data/utils.py`, which were envisaged right at the start , but never implemented, and we now know are not  needed