### PR TITLE
LAMA to Dask: update `cf.environment` with new dependencies

### DIFF
--- a/cf/functions.py
+++ b/cf/functions.py
@@ -2984,38 +2984,44 @@ def environment(display=True, paths=True):
     **Examples**
 
     >>> cf.environment()
-    Platform: Linux-5.4.0-58-generic-x86_64-with-debian-bullseye-sid
-    HDF5 library: 1.10.5
-    netcdf library: 4.6.3
-    udunits2 library: libudunits2.so.0
-    python: 3.7.0 /home/space/anaconda3/bin/python
-    netCDF4: 1.5.4 /home/space/anaconda3/lib/python3.7/site-packages/netCDF4/__init__.py
-    cftime: 1.3.0 /home/space/anaconda3/lib/python3.7/site-packages/cftime/__init__.py
-    numpy: 1.18.4 /home/space/anaconda3/lib/python3.7/site-packages/numpy/__init__.py
-    psutil: 5.4.7 /home/space/anaconda3/lib/python3.7/site-packages/psutil/__init__.py
-    scipy: 1.1.1 /home/space/anaconda3/lib/python3.7/site-packages/scipy/__init__.py
-    matplotlib: 3.1.1 /home/space/anaconda3/lib/python3.7/site-packages/matplotlib/__init__.py
-    ESMF: 8.0.0 /home/space/anaconda3/lib/python3.7/site-packages/ESMF/__init__.py
-    cfdm: 1.8.8.0 /home/space/anaconda3/lib/python3.7/site-packages/cfdm/__init__.py
-    cfunits: 3.3.1 /home/space/anaconda3/lib/python3.7/site-packages/cfunits/__init__.py
-    cfplot: 3.0.0 /home/space/anaconda3/lib/python3.7/site-packages/cfplot/__init__.py
-    cf: 3.8.0 /home/space/anaconda3/lib/python3.7/site-packages/cf/__init__.py
+    Platform: Linux-4.15.0-54-generic-x86_64-with-glibc2.10
+    HDF5 library: 1.10.6
+    netcdf library: 4.8.0
+    udunits2 library: /home/username/anaconda3/envs/cf-env/lib/libudunits2.so.0
+    ESMF: 8.1.1 /home/username/anaconda3/envs/cf-env/lib/python3.8/site-packages/ESMF/__init__.py
+    Python: 3.8.10 /home/username/anaconda3/envs/cf-env/bin/python
+    dask: 2022.6.0 /home/username/anaconda3/envs/cf-env/lib/python3.8/site-packages/dask/__init__.py
+    netCDF4: 1.5.6 /home/username/anaconda3/envs/cf-env/lib/python3.8/site-packages/netCDF4/__init__.py
+    psutil: 5.9.0 /home/username/anaconda3/envs/cf-env/lib/python3.8/site-packages/psutil/__init__.py
+    packaging: 21.3 /home/username/anaconda3/envs/cf-env/lib/python3.8/site-packages/packaging/__init__.py
+    numpy: 1.22.2 /home/username/anaconda3/envs/cf-env/lib/python3.8/site-packages/numpy/__init__.py
+    scipy: 1.8.0 /home/username/anaconda3/envs/cf-env/lib/python3.8/site-packages/scipy/__init__.py
+    matplotlib: 3.4.3 /home/username/anaconda3/envs/cf-env/lib/python3.8/site-packages/matplotlib/__init__.py
+    cftime: 1.6.0 /home/username/anaconda3/envs/cf-env/lib/python3.8/site-packages/cftime/__init__.py
+    cfunits: 3.3.5 /home/username/cfunits/cfunits/__init__.py
+    cfplot: 3.1.18 /home/username/anaconda3/envs/cf-env/lib/python3.8/site-packages/cfplot/__init__.py
+    cfdm: 1.10.0.1 /home/username/cfdm/cfdm/__init__.py
+    cf: 3.14.0b0 /home/username/cf-python/cf/__init__.py
+
     >>> cf.environment(paths=False)
-    HDF5 library: 1.10.5
-    netcdf library: 4.6.3
+    Platform: Linux-4.15.0-54-generic-x86_64-with-glibc2.10
+    HDF5 library: 1.10.6
+    netcdf library: 4.8.0
     udunits2 library: libudunits2.so.0
-    Python: 3.7.0
-    netCDF4: 1.5.4
-    cftime: 1.3.0
-    numpy: 1.18.4
-    psutil: 5.4.7
-    scipy: 1.1.0
-    matplotlib: 2.2.3
-    ESMF: 8.0.0
-    cfdm: 1.8.8.0
-    cfunits: 3.3.1
-    cfplot: 3.0.38
-    cf: 3.8.0
+    ESMF: 8.1.1
+    Python: 3.8.10
+    dask: 2022.6.0
+    netCDF4: 1.5.6
+    psutil: 5.9.0
+    packaging: 21.3
+    numpy: 1.22.2
+    scipy: 1.8.0
+    matplotlib: 3.4.3
+    cftime: 1.6.0
+    cfunits: 3.3.5
+    cfplot: 3.1.18
+    cfdm: 1.10.0.1
+    cf: 3.14.0b0
 
     """
     dependency_version_paths_mapping = {

--- a/cf/functions.py
+++ b/cf/functions.py
@@ -3019,21 +3019,27 @@ def environment(display=True, paths=True):
 
     """
     dependency_version_paths_mapping = {
+        # Platform first, then use an ordering to group libraries as follows...
         "Platform": (platform.platform(), ""),
+        # Underlying C and Fortran based libraries first
         "HDF5 library": (netCDF4.__hdf5libversion__, ""),
         "netcdf library": (netCDF4.__netcdf4libversion__, ""),
         "udunits2 library": (ctypes.util.find_library("udunits2"), ""),
+        "ESMF": _get_module_info("ESMF", try_except=True),
+        # Now Python itself
         "Python": (platform.python_version(), sys.executable),
+        # Then Python libraries not related to CF
         "netCDF4": _get_module_info("netCDF4"),
-        "cftime": _get_module_info("cftime"),
-        "numpy": _get_module_info("numpy"),
         "psutil": _get_module_info("psutil"),
+        "numpy": _get_module_info("numpy"),
         "scipy": _get_module_info("scipy", try_except=True),
         "matplotlib": _get_module_info("matplotlib", try_except=True),
-        "ESMF": _get_module_info("ESMF", try_except=True),
-        "cfdm": _get_module_info("cfdm"),
+        # Finally the CF related Python libraries, with the cf version last
+        # as it is the most relevant (cfdm penultimate for similar reason)
+        "cftime": _get_module_info("cftime"),
         "cfunits": _get_module_info("cfunits"),
         "cfplot": _get_module_info("cfplot", try_except=True),
+        "cfdm": _get_module_info("cfdm"),
         "cf": (__version__, _os_path_abspath(__file__)),
     }
     string = "{0}: {1!s}"

--- a/cf/functions.py
+++ b/cf/functions.py
@@ -3000,8 +3000,8 @@ def environment(display=True, paths=True):
     cftime: 1.6.0 /home/username/anaconda3/envs/cf-env/lib/python3.8/site-packages/cftime/__init__.py
     cfunits: 3.3.5 /home/username/cfunits/cfunits/__init__.py
     cfplot: 3.1.18 /home/username/anaconda3/envs/cf-env/lib/python3.8/site-packages/cfplot/__init__.py
-    cfdm: 1.10.0.1 /home/username/cfdm/cfdm/__init__.py
-    cf: 3.14.0b0 /home/username/cf-python/cf/__init__.py
+    cfdm: 1.10.0.1 /home/username/anaconda3/envs/cf-env/lib/python3.8/site-packages/cfdm/__init__.py
+    cf: 3.14.0 /home/username/anaconda3/envs/cf-env/lib/python3.8/site-packages/cf/__init__.py
 
     >>> cf.environment(paths=False)
     Platform: Linux-4.15.0-54-generic-x86_64-with-glibc2.10
@@ -3021,7 +3021,7 @@ def environment(display=True, paths=True):
     cfunits: 3.3.5
     cfplot: 3.1.18
     cfdm: 1.10.0.1
-    cf: 3.14.0b0
+    cf: 3.14.0
 
     """
     dependency_version_paths_mapping = {

--- a/cf/functions.py
+++ b/cf/functions.py
@@ -3028,9 +3028,12 @@ def environment(display=True, paths=True):
         "ESMF": _get_module_info("ESMF", try_except=True),
         # Now Python itself
         "Python": (platform.python_version(), sys.executable),
+        # Then Dask (cover first from below as it's important under-the-hood)
+        "dask": _get_module_info("dask"),
         # Then Python libraries not related to CF
         "netCDF4": _get_module_info("netCDF4"),
         "psutil": _get_module_info("psutil"),
+        "packaging": _get_module_info("packaging"),
         "numpy": _get_module_info("numpy"),
         "scipy": _get_module_info("scipy", try_except=True),
         "matplotlib": _get_module_info("matplotlib", try_except=True),


### PR DESCRIPTION
Upgrade `cf.environment` to be ready and correct for `3.14.0`, by:

* adding the two new dependency libraries (i.e. relative additions to `requirements.txt`) to the output, which notably includes `dask`, the package information on which might prove very useful with inevitable bug reports that will come in for the `.0` release!
* reordering a few libraries in the output listing, such that any C/Fortran underlying libraries are given first, then the NCAS CF Tools libraries at the very end (see comments on the corresponding dictionary summarising this).
