### PR TITLE
dask: `Data.__setitem__` ancillary masks

### DIFF
--- a/cf/data/array/netcdfarray.py
+++ b/cf/data/array/netcdfarray.py
@@ -36,4 +36,4 @@ class NetCDFArray(FileArrayMixin, cfdm.NetCDFArray):
         if filename is None:
             return False
 
-        return _lock 
+        return _lock

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -1112,10 +1112,10 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
             shifts = [-shift for shift in shifts]
             self.roll(shift=shifts, axis=roll_axes, inplace=True)
 
+        # Reset the original array values at locations that are
+        # excluded from the assignment by True values in auxiliary
+        # masks
         if ancillary_mask:
-            # Reset the original array values at locations that are
-            # excluded from the assignment by True values in the
-            # auxiliary masks
             indices = tuple(indices)
             original_self = original_self[indices]
             reset = self[indices]

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -1016,6 +1016,8 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
             pass
         else:
             if isinstance(arg, str) and arg == "mask":
+                # The indicies include an ancillary mask that defines
+                # elements which are protected from assignment
                 original_self = self.copy()
                 ancillary_mask = indices[1]
                 indices = indices[2:]

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -1016,7 +1016,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
             pass
         else:
             if isinstance(arg, str) and arg == "mask":
-                # The indicies include an ancillary mask that defines
+                # The indices include an ancillary mask that defines
                 # elements which are protected from assignment
                 original_self = self.copy()
                 ancillary_mask = indices[1]

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -1113,7 +1113,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
             self.roll(shift=shifts, axis=roll_axes, inplace=True)
 
         # Reset the original array values at locations that are
-        # excluded from the assignment by True values in auxiliary
+        # excluded from the assignment by True values in any ancillary
         # masks
         if ancillary_mask:
             indices = tuple(indices)

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -1518,6 +1518,17 @@ class DataTest(unittest.TestCase):
         d[[2, 4, 6, 8], 0, [1, 2, 3, 4]] = value
         self.assertEqual(np.count_nonzero(d.where(d < 0, 1, 0)), value.size)
 
+        # Test ancillary masked assignment
+        a = np.ma.arange(90).reshape(9, 10)
+        d = cf.Data(a.copy())
+
+        mask = cf.Data.full((3, 4), False)
+        mask[-1, [0, 1]] = True
+        n_set = int(mask.size - mask.sum())
+
+        d[("mask", (mask,), slice(1, 4), slice(2, 6))] = -99
+        self.assertEqual(np.count_nonzero(d.where(d < 0, 1, 0)), n_set)
+
     def test_Data_outerproduct(self):
         """Test the `outerproduct` Data method."""
         a = np.arange(12).reshape(4, 3)

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -2467,18 +2467,18 @@ class FieldTest(unittest.TestCase):
     def test_Field_set_construct_conform(self):
         """Test the 'conform' parameter of Field.set_construct."""
         f = cf.example_field(0)
-        cm = cf.CellMethod('T', 'maximum')
-        self.assertEqual(cm.get_axes(), ('T',))
+        cm = cf.CellMethod("T", "maximum")
+        self.assertEqual(cm.get_axes(), ("T",))
 
         key = f.set_construct(cm)
-        cm2 = f.cell_method('method:maximum')
-        taxis = f.domain_axis('T', key=True)
+        cm2 = f.cell_method("method:maximum")
+        taxis = f.domain_axis("T", key=True)
         self.assertEqual(cm2.get_axes(), (taxis,))
 
         f.del_construct(key)
         f.set_construct(cm, conform=False)
-        cm2 = f.cell_method('method:maximum')
-        self.assertEqual(cm2.get_axes(), ('T',))
+        cm2 = f.cell_method("method:maximum")
+        self.assertEqual(cm2.get_axes(), ("T",))
 
     def test_Field_persist(self):
         """Test the `persist` Field method."""


### PR DESCRIPTION
Gets this line to work in `tutorial.rst`: 
```python
    >>> t[t.indices(latitude=cf.wi(51, 53))] = -99
```