### PR TITLE
dask: `Data.datetime_array` bug fix

### DIFF
--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -4515,11 +4515,11 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
                 "because calendar is 'none'"
             )
 
-        units, reftime = units.units.split(" since ")
+        units1, reftime = units.units.split(" since ")
 
         # Convert months and years to days, because cftime won't work
         # otherwise.
-        if units in ("months", "month"):
+        if units1 in ("months", "month"):
             d = self * _month_length
             d.override_units(
                 Units(
@@ -4528,7 +4528,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
                 ),
                 inplace=True,
             )
-        elif units in ("years", "year", "yr"):
+        elif units1 in ("years", "year", "yr"):
             d = self * _year_length
             d.override_units(
                 Units(

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -1647,12 +1647,6 @@ class DataTest(unittest.TestCase):
         e = d.clip(0.003, 0.009, "km")
         self.assertTrue((e.array == b).all())
 
-    @unittest.skipIf(
-        True,
-        "Failing due to 'has_year_zero' differences in actual and expected "
-        "outputs: relates to github.com/Unidata/cftime/issues/233, see also "
-        "NCAS-CMS/cfunits/commit/ca15e7f6db76fe613db740993b4e45115341d865.",
-    )
     def test_Data_months_years(self):
         """Test Data with 'months/years since' units specifications."""
         calendar = "360_day"
@@ -1668,9 +1662,7 @@ class DataTest(unittest.TestCase):
             ]
         )
 
-        self.assertTrue(
-            (d.datetime_array == a).all(), "{}, {}".format(d.datetime_array, a)
-        )
+        self.assertTrue((d.datetime_array == a).all())
 
         calendar = "standard"
         d = cf.Data(
@@ -1684,9 +1676,7 @@ class DataTest(unittest.TestCase):
                 cf.dt(2000, 3, 1, 20, 58, 7, 662446, calendar=calendar),
             ]
         )
-        self.assertTrue(
-            (d.datetime_array == a).all(), "{}, {}".format(d.datetime_array, a)
-        )
+        self.assertTrue((d.datetime_array == a).all())
 
         calendar = "360_day"
         d = cf.Data(
@@ -1699,9 +1689,7 @@ class DataTest(unittest.TestCase):
                 cf.dt(2002, 1, 11, 11, 37, 31, 949357, calendar=calendar),
             ]
         )
-        self.assertTrue(
-            (d.datetime_array == a).all(), "{}, {}".format(d.datetime_array, a)
-        )
+        self.assertTrue((d.datetime_array == a).all())
 
         calendar = "standard"
         d = cf.Data(
@@ -1714,9 +1702,7 @@ class DataTest(unittest.TestCase):
                 cf.dt(2001, 12, 31, 11, 37, 31, 949357, calendar=calendar),
             ]
         )
-        self.assertTrue(
-            (d.datetime_array == a).all(), "{}, {}".format(d.datetime_array, a)
-        )
+        self.assertTrue((d.datetime_array == a).all())
 
         d = cf.Data(
             [1.0, 2],


### PR DESCRIPTION
Fixes #434 

Allows `test_data_months_years` to pass.