### PR TITLE
dask: `Container` inheritance

### DIFF
--- a/cf/data/array/abstract/array.py
+++ b/cf/data/array/abstract/array.py
@@ -1,9 +1,10 @@
 import cfdm
 
+from ....mixin_container import Container
 from ..mixin import ArrayMixin
 
 
-class Array(ArrayMixin, cfdm.Array):
+class Array(ArrayMixin, Container, cfdm.Array):
     """Abstract base class for a container of an underlying array.
 
     The form of the array is defined by the initialization parameters

--- a/cf/data/array/cfanetcdfarray.py
+++ b/cf/data/array/cfanetcdfarray.py
@@ -134,7 +134,7 @@ class CFANetCDFArray(NetCDFArray):
                 aggregated_data = source.get_aggregated_data(copy=False)
             except AttributeError:
                 aggregated_data = {}
-        else:
+        elif filename is not None:
             from CFAPython import CFAFileFormat
             from CFAPython.CFADataset import CFADataset
             from CFAPython.CFAExceptions import CFAException
@@ -182,6 +182,22 @@ class CFANetCDFArray(NetCDFArray):
             )
 
             del cfa
+        else:
+            super().__init__(
+                filename=filename,
+                ncvar=ncvar,
+                varid=varid,
+                group=group,
+                dtype=dtype,
+                mask=mask,
+                units=units,
+                calendar=calendar,
+                copy=copy,
+            )
+
+            fragment_shape = None
+            aggregated_data = None
+            instructions = None
 
         self._set_component("fragment_shape", fragment_shape, copy=False)
         self._set_component("aggregated_data", aggregated_data, copy=False)
@@ -206,6 +222,7 @@ class CFANetCDFArray(NetCDFArray):
         )
 
     def __getitem__(self, indices):
+        """x.__getitem__(indices) <==> x[indices]"""
         return NotImplemented  # pragma: no cover
 
     def _set_fragment(self, var, frag_loc, aggregated_data, cfa_filename):

--- a/cf/data/array/gatheredarray.py
+++ b/cf/data/array/gatheredarray.py
@@ -1,9 +1,12 @@
 import cfdm
 
+from ...mixin_container import Container
 from .mixin import ArrayMixin, CompressedArrayMixin
 
 
-class GatheredArray(CompressedArrayMixin, ArrayMixin, cfdm.GatheredArray):
+class GatheredArray(
+    CompressedArrayMixin, ArrayMixin, Container, cfdm.GatheredArray
+):
     """An underlying gathered array.
 
     Compression by gathering combines axes of a multidimensional array

--- a/cf/data/array/netcdfarray.py
+++ b/cf/data/array/netcdfarray.py
@@ -1,13 +1,14 @@
 import cfdm
 from dask.utils import SerializableLock
 
+from ...mixin_container import Container
 from .mixin import FileArrayMixin
 
 # Global lock for netCDF file access
 _lock = SerializableLock()
 
 
-class NetCDFArray(FileArrayMixin, cfdm.NetCDFArray):
+class NetCDFArray(FileArrayMixin, Container, cfdm.NetCDFArray):
     """An array stored in a netCDF file."""
 
     def __repr__(self):

--- a/cf/data/array/raggedcontiguousarray.py
+++ b/cf/data/array/raggedcontiguousarray.py
@@ -1,10 +1,11 @@
 import cfdm
 
+from ...mixin_container import Container
 from .mixin import ArrayMixin, RaggedArrayMixin
 
 
 class RaggedContiguousArray(
-    RaggedArrayMixin, ArrayMixin, cfdm.RaggedContiguousArray
+    RaggedArrayMixin, ArrayMixin, Container, cfdm.RaggedContiguousArray
 ):
     """An underlying contiguous ragged array.
 

--- a/cf/data/array/raggedindexedarray.py
+++ b/cf/data/array/raggedindexedarray.py
@@ -1,10 +1,11 @@
 import cfdm
 
+from ...mixin_container import Container
 from .mixin import ArrayMixin, RaggedArrayMixin
 
 
 class RaggedIndexedArray(
-    RaggedArrayMixin, ArrayMixin, cfdm.RaggedIndexedArray
+    RaggedArrayMixin, ArrayMixin, Container, cfdm.RaggedIndexedArray
 ):
     """An underlying indexed ragged array.
 

--- a/cf/data/array/raggedindexedcontiguousarray.py
+++ b/cf/data/array/raggedindexedcontiguousarray.py
@@ -1,10 +1,11 @@
 import cfdm
 
+from ...mixin_container import Container
 from .mixin import ArrayMixin, RaggedArrayMixin
 
 
 class RaggedIndexedContiguousArray(
-    RaggedArrayMixin, ArrayMixin, cfdm.RaggedIndexedContiguousArray
+    RaggedArrayMixin, ArrayMixin, Container, cfdm.RaggedIndexedContiguousArray
 ):
     """An underlying indexed contiguous ragged array.
 

--- a/cf/data/array/subsampledarray.py
+++ b/cf/data/array/subsampledarray.py
@@ -1,9 +1,12 @@
 import cfdm
 
+from ...mixin_container import Container
 from .mixin import ArrayMixin, CompressedArrayMixin
 
 
-class SubsampledArray(CompressedArrayMixin, ArrayMixin, cfdm.SubsampledArray):
+class SubsampledArray(
+    CompressedArrayMixin, ArrayMixin, Container, cfdm.SubsampledArray
+):
     """An underlying subsampled array.
 
     For some structured coordinate data (e.g. coordinates describing


### PR DESCRIPTION
* Add missing `Container` mixin class inheritance to array classes. This is needed to pick up the cf docstring substitutions.
* Allow no-arg init of `CFANetCDFArray`

Necessary (but not sufficient) to get `test_docstring.py` to pass. 