### PR TITLE
dask: `convert_reference_time` methods

### DIFF
--- a/cf/mixin/propertiesdata.py
+++ b/cf/mixin/propertiesdata.py
@@ -3184,7 +3184,7 @@ class PropertiesData(Properties):
 
             `{{class}}` or `None`
                 The construct with converted reference time data
-                values, or `None` if the operation was in-place..
+                values, or `None` if the operation was in-place.
 
         **Examples**
 

--- a/cf/mixin/propertiesdata.py
+++ b/cf/mixin/propertiesdata.py
@@ -3190,7 +3190,7 @@ class PropertiesData(Properties):
 
         >>> print(f.array)
         [0 1 2 3]
-        >>> d.Units
+        >>> f.Units
         <Units: months since 2004-1-1>
         >>> print(f.datetime_array)
         [cftime.DatetimeGregorian(2003, 12, 1, 0, 0, 0, 0, has_year_zero=False)

--- a/cf/mixin/propertiesdata.py
+++ b/cf/mixin/propertiesdata.py
@@ -1,10 +1,8 @@
 import logging
-from functools import partial as functools_partial
 from itertools import chain
 
 from numpy import array as numpy_array
 from numpy import result_type as numpy_result_type
-from numpy import vectorize as numpy_vectorize
 
 from ..cfdatetime import dt
 from ..data import Data
@@ -22,7 +20,6 @@ from ..functions import (
 )
 from ..functions import equivalent as cf_equivalent
 from ..functions import inspect as cf_inspect
-from ..timeduration import TimeDuration
 from ..units import Units
 from . import Properties
 
@@ -3129,14 +3126,6 @@ class PropertiesData(Properties):
         "months", which have special definition. See the note and examples
         below for more details.
 
-        For conversions which do not require a change in the date-times
-        implied by the data values, this method will be considerably
-        slower than a simple reassignment of the units. For example, if
-        the original units are ``'days since 2000-12-1'`` then ``c.Units =
-        cf.Units('days since 1901-1-1')`` will give the same result and be
-        considerably faster than ``c.convert_reference_time(cf.Units('days
-        since 1901-1-1'))``.
-
         .. note:: It is recommended that the units "year" and "month" be
                   used with caution, as explained in the following excerpt
                   from the CF conventions: "The Udunits package defines a
@@ -3148,6 +3137,17 @@ class PropertiesData(Properties):
                   365.25 days, and a Gregorian_year is 365.2425 days. For
                   similar reasons the unit ``month``, which is defined to
                   be exactly year/12, should also be used with caution.
+
+        **Performance**
+
+        For conversions which do not require a change in the
+        date-times implied by the data values, this method will be
+        considerably slower than a simple reassignment of the
+        units. For example, if the original units are ``'days since
+        2000-12-1'`` then ``c.Units = cf.Units('days since
+        1901-1-1')`` will give the same result and be considerably
+        faster than ``c.convert_reference_time(cf.Units('days since
+        1901-1-1'))``.
 
         :Parameters:
 
@@ -3183,116 +3183,41 @@ class PropertiesData(Properties):
         :Returns:
 
             `{{class}}` or `None`
-                The construct with converted reference time data values.
+                The construct with converted reference time data
+                values, or `None` if the operation was in-place..
 
         **Examples**
 
         >>> print(f.array)
-        [1  2  3  4]
-        >>> f.Units
-        <Units: months since 2000-1-1>
+        [0 1 2 3]
+        >>> d.Units
+        <Units: months since 2004-1-1>
         >>> print(f.datetime_array)
-        [datetime.datetime(2000, 1, 31, 10, 29, 3, 831197) TODO
-         datetime.datetime(2000, 3, 1, 20, 58, 7, 662441)
-         datetime.datetime(2000, 4, 1, 7, 27, 11, 493645)
-         datetime.datetime(2000, 5, 1, 17, 56, 15, 324889)]
-        >>> f.convert_reference_time(calendar_months=True, inplace=True)
-        >>> print(f.datetime_array)
-        [datetime.datetime(2000, 2, 1, 0, 0) TODOx
-         datetime.datetime(2000, 3, 1, 0, 0)
-         datetime.datetime(2000, 4, 1, 0, 0)
-         datetime.datetime(2000, 5, 1, 0, 0)]
-        >>> print(f.array)
-        [  31.   60.   91.  121.]
-        >>> f.Units
-        <Units: days since 2000-1-1>
+        [cftime.DatetimeGregorian(2003, 12, 1, 0, 0, 0, 0, has_year_zero=False)
+         cftime.DatetimeGregorian(2003, 12, 31, 10, 29, 3, 831223, has_year_zero=False)
+         cftime.DatetimeGregorian(2004, 1, 30, 20, 58, 7, 662446, has_year_zero=False)
+         cftime.DatetimeGregorian(2004, 3, 1, 7, 27, 11, 493670, has_year_zero=False)]
+        >>> g = f.convert_reference_time(calendar_months=True)
+        >>> g.Units
+        <Units: days since 2004-1-1>
+        >>> print(g.datetime_array)
+        [cftime.DatetimeGregorian(2003, 12, 1, 0, 0, 0, 0, has_year_zero=False)
+         cftime.DatetimeGregorian(2004, 1, 1, 0, 0, 0, 0, has_year_zero=False)
+         cftime.DatetimeGregorian(2004, 2, 1, 0, 0, 0, 0, has_year_zero=False)
+         cftime.DatetimeGregorian(2004, 3, 1, 0, 0, 0, 0, has_year_zero=False)]
+        >>> print(g.array)
+        [ 0 31 62 91]
 
         """
-
-        def _convert_reftime_units(value, units, reftime):  # , calendar):
-            """sads.
-
-            :Parameters:
-
-                value: number
-
-                units: `Units`
-
-            :Returns:
-
-                `datetime.datetime` or `cf.Datetime`
-
-            """
-            t = TimeDuration(value, units=units)
-            if value > 0:
-                return t.interval(reftime, end=False)[1]
-            else:
-                return t.interval(reftime, end=True)[0]
-
-        if not self.Units.isreftime:
-            raise ValueError(
-                f"{self.__class__.__name__} must have reference time units, "
-                f"not {self.Units!r}"
-            )
-
-        v = _inplace_enabled_define_and_cleanup(self)
-
-        units0 = self.Units
-
-        if units is None:
-            # By default, set the target units to "days since
-            # <reference time of self.Units>,
-            # calendar=<self.calendar>"
-            units = Units(
-                "days since " + units0.units.split(" since ")[1],
-                calendar=units0._calendar,
-            )
-        elif not getattr(units, "isreftime", False):
-            raise ValueError(
-                f"New units must be reference time units, not {units!r}"
-            )
-
-        if units0._units_since_reftime in _month_units:
-            if calendar_months:
-                units0 = Units(
-                    "calendar_" + units0.units, calendar=units0._calendar
-                )
-            else:
-                units0 = Units(
-                    "days since " + units0.units.split(" since ")[1],
-                    calendar=units0._calendar,
-                )
-                v.Units = units0
-        elif units0._units_since_reftime in _year_units:
-            if calendar_years:
-                units0 = Units(
-                    "calendar_" + units0.units, calendar=units0._calendar
-                )
-            else:
-                units0 = Units(
-                    "days since " + units0.units.split(" since ")[1],
-                    calendar=units0._calendar,
-                )
-                v.Units = units0
-
-        # Not LAMAed!
-        v.set_data(
-            Data(
-                numpy_vectorize(
-                    functools_partial(
-                        _convert_reftime_units,
-                        units=units0._units_since_reftime,
-                        reftime=dt(units0.reftime, calendar=units0._calendar),
-                    ),
-                    otypes=[object],
-                )(v),
-                units=units,
-            )
+        return self._apply_data_oper(
+            _inplace_enabled_define_and_cleanup(self),
+            "convert_reference_time",
+            inplace=inplace,
+            units=units,
+            calendar_months=calendar_months,
+            calendar_years=calendar_years,
         )
 
-        return v
-
-    @_deprecated_kwarg_check("i", version="3.0.0", removed_at="4.0.0")
     @_inplace_enabled(default=False)
     def flatten(self, axes=None, inplace=False):
         """Flatten axes of the data.

--- a/cf/mixin/propertiesdatabounds.py
+++ b/cf/mixin/propertiesdatabounds.py
@@ -1799,7 +1799,7 @@ class PropertiesDataBounds(PropertiesData):
 
             `{{class}}` or `None`
                 The construct with converted reference time data
-                values, or `None` if the operation was in-place..
+                values, or `None` if the operation was in-place.
 
         **Examples**
 

--- a/cf/mixin/propertiesdatabounds.py
+++ b/cf/mixin/propertiesdatabounds.py
@@ -1805,7 +1805,7 @@ class PropertiesDataBounds(PropertiesData):
 
         >>> print(f.array)
         [0 1 2 3]
-        >>> d.Units
+        >>> f.Units
         <Units: months since 2004-1-1>
         >>> print(f.datetime_array)
         [cftime.DatetimeGregorian(2003, 12, 1, 0, 0, 0, 0, has_year_zero=False)

--- a/cf/mixin/propertiesdatabounds.py
+++ b/cf/mixin/propertiesdatabounds.py
@@ -1740,15 +1740,6 @@ class PropertiesDataBounds(PropertiesData):
         were intended but encoded as "months", which have special
         definition. See the note and examples below for more details.
 
-        For conversions which do not require a change in the
-        date-times implied by the data values, this method will be
-        considerably slower than a simple reassignment of the
-        units. For example, if the original units are ``'days since
-        2000-12-1'`` then ``c.Units = cf.Units('days since
-        1901-1-1')`` will give the same result and be considerably
-        faster than ``c.convert_reference_time(cf.Units('days since
-        1901-1-1'))``.
-
         .. note:: It is recommended that the units "year" and "month"
                   be used with caution, as explained in the following
                   excerpt from the CF conventions: "The Udunits
@@ -1761,6 +1752,17 @@ class PropertiesDataBounds(PropertiesData):
                   and a Gregorian_year is 365.2425 days. For similar
                   reasons the unit ``month``, which is defined to be
                   exactly year/12, should also be used with caution.
+
+        **Performance**
+
+        For conversions which do not require a change in the
+        date-times implied by the data values, this method will be
+        considerably slower than a simple reassignment of the
+        units. For example, if the original units are ``'days since
+        2000-12-1'`` then ``c.Units = cf.Units('days since
+        1901-1-1')`` will give the same result and be considerably
+        faster than ``c.convert_reference_time(cf.Units('days since
+        1901-1-1'))``.
 
         :Parameters:
 
@@ -1797,36 +1799,37 @@ class PropertiesDataBounds(PropertiesData):
 
             `{{class}}` or `None`
                 The construct with converted reference time data
-                values.
+                values, or `None` if the operation was in-place..
 
         **Examples**
 
         >>> print(f.array)
-        [1  2  3  4]
-        >>> f.Units
-        <Units: months since 2000-1-1>
+        [0 1 2 3]
+        >>> d.Units
+        <Units: months since 2004-1-1>
         >>> print(f.datetime_array)
-        [datetime.datetime(2000, 1, 31, 10, 29, 3, 831197) TODO
-         datetime.datetime(2000, 3, 1, 20, 58, 7, 662441)
-         datetime.datetime(2000, 4, 1, 7, 27, 11, 493645)
-         datetime.datetime(2000, 5, 1, 17, 56, 15, 324889)]
-        >>> f.convert_reference_time(calendar_months=True, inplace=True)
-        >>> print(f.datetime_array)
-        [datetime.datetime(2000, 2, 1, 0, 0) TODOx
-         datetime.datetime(2000, 3, 1, 0, 0)
-         datetime.datetime(2000, 4, 1, 0, 0)
-         datetime.datetime(2000, 5, 1, 0, 0)]
-        >>> print(f.array)
-        [  31.   60.   91.  121.]
-        >>> f.Units
-        <Units: days since 2000-1-1>
+        [cftime.DatetimeGregorian(2003, 12, 1, 0, 0, 0, 0, has_year_zero=False)
+         cftime.DatetimeGregorian(2003, 12, 31, 10, 29, 3, 831223, has_year_zero=False)
+         cftime.DatetimeGregorian(2004, 1, 30, 20, 58, 7, 662446, has_year_zero=False)
+         cftime.DatetimeGregorian(2004, 3, 1, 7, 27, 11, 493670, has_year_zero=False)]
+        >>> g = f.convert_reference_time(calendar_months=True)
+        >>> g.Units
+        <Units: days since 2004-1-1>
+        >>> print(g.datetime_array)
+        [cftime.DatetimeGregorian(2003, 12, 1, 0, 0, 0, 0, has_year_zero=False)
+         cftime.DatetimeGregorian(2004, 1, 1, 0, 0, 0, 0, has_year_zero=False)
+         cftime.DatetimeGregorian(2004, 2, 1, 0, 0, 0, 0, has_year_zero=False)
+         cftime.DatetimeGregorian(2004, 3, 1, 0, 0, 0, 0, has_year_zero=False)]
+        >>> print(g.array)
+        [ 0 31 62 91]
 
         """
         return self._apply_superclass_data_oper(
             _inplace_enabled_define_and_cleanup(self),
             "convert_reference_time",
             inplace=inplace,
-            i=i,
+            bounds=True,
+            interior_ring=False,
             units=units,
             calendar_months=calendar_months,
             calendar_years=calendar_years,

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -4431,6 +4431,24 @@ class DataTest(unittest.TestCase):
         d = cf.Data.ones((4, 5), chunks=(2, 4))
         self.assertEqual(d.numblocks, (2, 2))
 
+    def test_Data_convert_reference_time(self):
+        """Test `Data.convert_reference_time`"""
+        d = cf.Data([2, 1, 0, -1], units="months since 2003-12-01")
+        e = d.convert_reference_time(calendar_months=True)
+        self.assertEqual(e.Units, cf.Units("days since 2003-12-01"))
+        self.assertTrue((e.array == [62, 31, 0, -30]).all())
+
+        d = cf.Data([2, 1, 0, -1], units="years since 2003-12-01")
+        e = d.convert_reference_time(calendar_years=True)
+        self.assertEqual(e.Units, cf.Units("days since 2003-12-01"))
+        self.assertTrue((e.array == [731, 366, 0, -365]).all())
+
+        d = cf.Data([2, 1, 0, -1], units="days since 2003-12-01")
+        units = cf.Units("hours since 2003-11-30")
+        e = d.convert_reference_time(units)
+        self.assertEqual(e.Units, units)
+        self.assertTrue((e.array == [72, 48, 24, 0]).all())
+
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())

--- a/docs/source/class/cf.Data.rst
+++ b/docs/source/class/cf.Data.rst
@@ -181,6 +181,8 @@ Date-time support
    :toctree: ../attribute/
    :template: attribute.rst
 
+   ~cf.Data.change_calendar
+   ~cf.Data.convert_reference_time
    ~cf.Data.datetime_array
    ~cf.Data.datetime_as_string
    ~cf.Data.day


### PR DESCRIPTION
Moves functionality from `PropertiesData.convert_reference_time` to `cf.data.dask_utils.cf_rt2dt` via `Data.convert_reference_time`.