### PR TITLE
Nuked __query_*__ conditions

### DIFF
--- a/docs/source/class/cf.AuxiliaryCoordinate.rst
+++ b/docs/source/class/cf.AuxiliaryCoordinate.rst
@@ -676,9 +676,6 @@ Special
    ~cf.AuxiliaryCoordinate.__str__
    ~cf.AuxiliaryCoordinate.__array__
    ~cf.AuxiliaryCoordinate.__data__
-   ~cf.AuxiliaryCoordinate.__query_set__
-   ~cf.AuxiliaryCoordinate.__query_wi__
-   ~cf.AuxiliaryCoordinate.__query_wo__
 
 Deprecated
 ----------

--- a/docs/source/class/cf.Bounds.rst
+++ b/docs/source/class/cf.Bounds.rst
@@ -587,9 +587,6 @@ Special
    ~cf.Bounds.__str__
    ~cf.Bounds.__array__
    ~cf.Bounds.__data__
-   ~cf.Bounds.__query_set__
-   ~cf.Bounds.__query_wi__
-   ~cf.Bounds.__query_wo__
 
 Deprecated
 ----------

--- a/docs/source/class/cf.CellMeasure.rst
+++ b/docs/source/class/cf.CellMeasure.rst
@@ -604,9 +604,6 @@ Special
    ~cf.CellMeasure.__str__
    ~cf.CellMeasure.__array__
    ~cf.CellMeasure.__data__
-   ~cf.CellMeasure.__query_set__
-   ~cf.CellMeasure.__query_wi__
-   ~cf.CellMeasure.__query_wo__
    
 Deprecated
 ----------

--- a/docs/source/class/cf.Count.rst
+++ b/docs/source/class/cf.Count.rst
@@ -587,9 +587,6 @@ Special
    ~cf.Count.__str__
    ~cf.Count.__array__
    ~cf.Count.__data__
-   ~cf.Count.__query_set__
-   ~cf.Count.__query_wi__
-   ~cf.Count.__query_wo__
    
 Deprecated
 ----------

--- a/docs/source/class/cf.Data.rst
+++ b/docs/source/class/cf.Data.rst
@@ -752,9 +752,6 @@ Special
    ~cf.Data.__repr__
    ~cf.Data.__setitem__ 
    ~cf.Data.__str__
-   ~cf.Data.__query_set__
-   ~cf.Data.__query_wi__
-   ~cf.Data.__query_wo__
 
 Deprecated
 ----------

--- a/docs/source/class/cf.DimensionCoordinate.rst
+++ b/docs/source/class/cf.DimensionCoordinate.rst
@@ -684,9 +684,6 @@ Special
    ~cf.DimensionCoordinate.__str__
    ~cf.DimensionCoordinate.__array__
    ~cf.DimensionCoordinate.__data__
-   ~cf.DimensionCoordinate.__query_set__
-   ~cf.DimensionCoordinate.__query_wi__
-   ~cf.DimensionCoordinate.__query_wo__
 
 Deprecated
 ----------

--- a/docs/source/class/cf.DomainAncillary.rst
+++ b/docs/source/class/cf.DomainAncillary.rst
@@ -632,9 +632,6 @@ Special
    ~cf.DomainAncillary.__str__
    ~cf.DomainAncillary.__array__
    ~cf.DomainAncillary.__data__
-   ~cf.DomainAncillary.__query_set__
-   ~cf.DomainAncillary.__query_wi__
-   ~cf.DomainAncillary.__query_wo__
 
 Deprecated
 ----------

--- a/docs/source/class/cf.FieldAncillary.rst
+++ b/docs/source/class/cf.FieldAncillary.rst
@@ -578,9 +578,6 @@ Special
    ~cf.FieldAncillary.__str__
    ~cf.FieldAncillary.__array__
    ~cf.FieldAncillary.__data__
-   ~cf.FieldAncillary.__query_set__
-   ~cf.FieldAncillary.__query_wi__
-   ~cf.FieldAncillary.__query_wo__
 
 Deprecated
 ----------

--- a/docs/source/class/cf.Index.rst
+++ b/docs/source/class/cf.Index.rst
@@ -589,9 +589,6 @@ Special
    ~cf.Index.__str__
    ~cf.Index.__array__
    ~cf.Index.__data__
-   ~cf.Index.__query_set__
-   ~cf.Index.__query_wi__
-   ~cf.Index.__query_wo__
 
 Deprecated
 ----------

--- a/docs/source/class/cf.List.rst
+++ b/docs/source/class/cf.List.rst
@@ -575,9 +575,6 @@ Special
    ~cf.List.__str__
    ~cf.List.__array__
    ~cf.List.__data__
-   ~cf.List.__query_set__
-   ~cf.List.__query_wi__
-   ~cf.List.__query_wo__
 
 Deprecated
 ----------


### PR DESCRIPTION
Nuked old `__query_*__` conditions (`__query_set__`, `__query_wi__`, `__query_wo__`) in accordance with the new version.
