### PR TITLE
dask: Catch `NotImplemented` resulting from arithmetic

### DIFF
--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -1290,7 +1290,8 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         """
         if array is NotImplemented:
             logger.warning(
-                "NotImplemented has been set in the place of a dask array."
+                "WARNING: NotImplemented has been set in the place of a "
+                "dask array."
                 "\n\n"
                 "This could occur if any sort of exception is raised "
                 "by a function that is run on chunks (via, for "
@@ -3359,6 +3360,11 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
             result = getattr(dx0, equiv_method)(dx1)
         else:
             result = getattr(dx0, method)(dx1)
+
+        if result is NotImplemented:
+            raise TypeError(
+                f"Unsupported operands for {method}: {self!r} and {other!r}"
+            )
 
         # Set axes when other has more dimensions than self
         axes = None

--- a/cf/test/test_Data.py
+++ b/cf/test/test_Data.py
@@ -2154,7 +2154,6 @@ class DataTest(unittest.TestCase):
                 else:
                     message = "Failed in {!r}**{!r}".format(d, x)
                     self.assertTrue((d**x).all(), message)
-        # --- End: for
 
         for a0 in arrays:
             d = cf.Data(a0, "metre")
@@ -2357,6 +2356,10 @@ class DataTest(unittest.TestCase):
                         cf.Data(a0.__truediv__(x.datum()), ""), verbose=1
                     )
                 )
+
+            d = cf.Data([1, 2])
+            with self.assertRaises(TypeError):
+                d + ("foo",)
 
     def test_Data_BROADCASTING(self):
         """Test broadcasting of arrays in binary Data operations."""

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -709,7 +709,7 @@ class FieldTest(unittest.TestCase):
         self.assertTrue(a.equals(b, verbose=2))
         self.assertTrue(b.equals(a, verbose=2))
 
-        with self.assertRaises(Exception):
+        with self.assertRaises(TypeError):
             f + ("a string",)
 
     def test_Field__mul__(self):


### PR DESCRIPTION
Prevent this:
```python
>>>  import cf
>>> d = cf.Data([1, 2, 3])
>>>  e = d + ('sdf',)
NotImplemented has been set in the place of a dask array.

This could occur if any sort of exception is raised by a function that is run on chunks (via, for instance, da.map_blocks or
dask.array.core.elemwise). Such a function could get run at definition time in order to ascertain suitability (such as
data type casting, broadcasting, etc.). Note that the exception may be difficult to diagnose, as dask will have silently
trapped it and returned NotImplemented (for instance, see dask.array.core.elemwise). Print statements in a local copy
of dask are possibly the way to go if the cause of the error is not obvious.

>>>
```
replacing it with raising a `TypeError`, which is what numpy and Dask do. 