### PR TITLE
LAMA to Dask: misc. fixes for a passing `test_aggregate`

### DIFF
--- a/cf/aggregate.py
+++ b/cf/aggregate.py
@@ -146,7 +146,33 @@ class _Meta:
 
             f: `Field` or `Domain`
 
-            {{verbose: `int` or `str` or `None`, optional}}
+            verbose: `int` or `str` or `None`, optional
+                If an integer from ``-1`` to ``3``, or an equivalent
+                string equal ignoring case to one of:
+
+                * ``'DISABLE'`` (``0``)
+                * ``'WARNING'`` (``1``)
+                * ``'INFO'`` (``2``)
+                * ``'DETAIL'`` (``3``)
+                * ``'DEBUG'`` (``-1``)
+
+                set for the duration of the method call only as the
+                minimum cut-off for the verboseness level of displayed
+                output (log) messages, regardless of the
+                globally-configured `cf.log_level`. Note that
+                increasing numerical value corresponds to increasing
+                verbosity, with the exception of ``-1`` as a special
+                case of maximal and extreme verbosity.
+
+                Otherwise, if `None` (the default value), output
+                messages will be shown according to the value of the
+                `cf.log_level` setting.
+
+                Overall, the higher a non-negative integer or
+                equivalent string that is set (up to a maximum of
+                ``3``/``'DETAIL'``) for increasing verbosity, the more
+                description that is printed to convey information
+                about the operation.
 
             relaxed_units: `bool`, optional
                 If True then assume that field and metadata constructs
@@ -162,9 +188,15 @@ class _Meta:
                 that aggregation may occur. By default such field
                 constructs are not aggregatable.
 
-            {{rtol: number, optional}}
+            rtol: number, optional
+                The tolerance on relative differences between real
+                numbers. The default value is set by the
+                `cf.rtol` function.
 
-            {{atol: number, optional}}
+            atol: number, optional
+                The tolerance on absolute differences between real
+                numbers. The default value is set by the
+                `cf.atol` function.
 
             dimension: (sequence of) `str`, optional
                 Create new axes for each input field which has one or
@@ -1575,19 +1607,15 @@ def aggregate(
             should only be used in cases for which it is known that the
             non-aggregating axes are in fact already entirely consistent.
 
-        atol: float, optional
-            The absolute tolerance for all numerical comparisons. The
-            tolerance is a non-negative, typically very small number. Two
-            numbers, x and y, are considered the same if :math:`|x-y| \le
-            atol + rtol*|y|`. By default the value returned by the `atol`
-            function is used.
+        atol: number, optional
+            The tolerance on absolute differences between real
+            numbers. The default value is set by the
+            `cf.atol` function.
 
-        rtol: float, optional
-            The relative tolerance for all numerical comparisons. The
-            tolerance is a non-negative, typically very small number. Two
-            numbers, x and y, are considered the same if :math:`|x-y| \le
-            atol + rtol*|y|`. By default the value returned by the `rtol`
-            function is used.
+        rtol: number, optional
+            The tolerance on relative differences between real
+            numbers. The default value is set by the
+            `cf.rtol` function.
 
         no_overlap:
             Use the *overlap* parameter instead.

--- a/cf/aggregate.py
+++ b/cf/aggregate.py
@@ -146,26 +146,42 @@ class _Meta:
 
             f: `Field` or `Domain`
 
-            verbose: `int` or `str` or `None`, optional
-                See the `aggregate` function for details.
+            {{verbose: `int` or `str` or `None`, optional}}
 
             relaxed_units: `bool`, optional
-                See the `aggregate` function for details.
+                If True then assume that field and metadata constructs
+                with the same identity but missing units actually have
+                equivalent (but unspecified) units, so that aggregation
+                may occur. By default such field constructs are not
+                aggregatable.
 
             allow_no_identity: `bool`, optional
-                See the `aggregate` function for details.
+                If True then assume that field and metadata constructs with
+                no identity (see the *relaxed_identities* parameter) actually
+                have the same (but unspecified) identity, so that aggregation
+                may occur. By default such field constructs are not
+                aggregatable.
 
-            rtol: `float`, optional
-                See the `aggregate` function for details.
+            {{rtol: number, optional}}
 
-            atol: `float`, optional
-                See the `aggregate` function for details.
+            {{atol: number, optional}}
 
             dimension: (sequence of) `str`, optional
-                See the `aggregate` function for details.
+                Create new axes for each input field which has one or more of
+                the given properties. For each CF property name specified, if
+                an input field has the property then, prior to aggregation, a
+                new axis is created with an auxiliary coordinate whose datum
+                is the property's value and the property itself is deleted
+                from that field.
 
             copy: `bool` optional
-                See the `aggregate` function for details.
+                If False then do not copy fields prior to aggregation.
+                Setting this option to False may change input fields in place,
+                and the output fields may not be independent of the
+                inputs. However, if it is known that the input fields are
+                never to accessed again (such as in this case: ``f =
+                cf.aggregate(f)``) then setting *copy* to False can reduce the
+                time taken for aggregation.
 
         """
         self._bool = False

--- a/cf/aggregate.py
+++ b/cf/aggregate.py
@@ -156,32 +156,32 @@ class _Meta:
                 aggregatable.
 
             allow_no_identity: `bool`, optional
-                If True then assume that field and metadata constructs with
-                no identity (see the *relaxed_identities* parameter) actually
-                have the same (but unspecified) identity, so that aggregation
-                may occur. By default such field constructs are not
-                aggregatable.
+                If True then assume that field and metadata constructs
+                with no identity (see the *relaxed_identities* parameter)
+                actually have the same (but unspecified) identity, so
+                that aggregation may occur. By default such field
+                constructs are not aggregatable.
 
             {{rtol: number, optional}}
 
             {{atol: number, optional}}
 
             dimension: (sequence of) `str`, optional
-                Create new axes for each input field which has one or more of
-                the given properties. For each CF property name specified, if
-                an input field has the property then, prior to aggregation, a
-                new axis is created with an auxiliary coordinate whose datum
-                is the property's value and the property itself is deleted
-                from that field.
+                Create new axes for each input field which has one or
+                more of the given properties. For each CF property name
+                specified, if an input field has the property then, prior
+                to aggregation, a new axis is created with an auxiliary
+                coordinate whose datum is the property's value and the
+                property itself is deleted from that field.
 
             copy: `bool` optional
                 If False then do not copy fields prior to aggregation.
-                Setting this option to False may change input fields in place,
-                and the output fields may not be independent of the
-                inputs. However, if it is known that the input fields are
-                never to accessed again (such as in this case: ``f =
-                cf.aggregate(f)``) then setting *copy* to False can reduce the
-                time taken for aggregation.
+                Setting this option to False may change input fields in
+                place, and the output fields may not be independent of
+                the inputs. However, if it is known that the input
+                fields are never to accessed again (such as in this case:
+                ``f = cf.aggregate(f)``) then setting *copy* to False can
+                reduce the time taken for aggregation.
 
         """
         self._bool = False

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -7063,7 +7063,10 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
                 atol=float(atol),
             )
         elif not self_is_numeric and not other_is_numeric:
-            data_comparison = da.all(self_dx == other_dx)
+            # Apply bool() since the output may be numeric and we need a
+            # Boolean result to avoid casting error ("... can't be cast using
+            # casting='same_kind'")
+            data_comparison = bool(da.all(self_dx == other_dx))
         else:  # one is numeric and other isn't => not equal (incompat. dtype)
             logger.info(
                 f"{self.__class__.__name__}: Different data types:"

--- a/cf/test/test_aggregate.py
+++ b/cf/test/test_aggregate.py
@@ -40,8 +40,7 @@ class aggregateTest(unittest.TestCase):
             g.extend([f[i] for i in range(7, f.shape[0])])
 
             g0 = g.copy()
-            # TODODASK SB: reinstate once fixed!
-            # self.assertTrue(g.equals(g0, verbose=-1), "g != g0")
+            self.assertTrue(g.equals(g0, verbose=-1), "g != g0")
 
             with warnings.catch_warnings():
                 # Suppress noise throughout the test fixture from:
@@ -66,10 +65,9 @@ class aggregateTest(unittest.TestCase):
                 "h[0].shape = " + repr(h[0].shape) + " != (10, 9)",
             )
 
-            # TODODASK SB: reinstate once fixed!
-            # self.assertTrue(
-            #     g.equals(g0, verbose=2), "g != itself after aggregation"
-            # )
+            self.assertTrue(
+                g.equals(g0, verbose=2), "g != itself after aggregation"
+            )
 
             self.assertTrue(h[0].equals(f, verbose=2), "h[0] != f")
 
@@ -81,11 +79,10 @@ class aggregateTest(unittest.TestCase):
                 i.equals(h, verbose=2), "The second aggregation != the first"
             )
 
-            # TODODASK SB: reinstate once fixed!
-            # self.assertTrue(
-            #     g.equals(g0, verbose=2),
-            #     "g != itself after the second aggregation",
-            # )
+            self.assertTrue(
+                g.equals(g0, verbose=2),
+                "g != itself after the second aggregation",
+            )
 
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", category=FutureWarning)
@@ -95,11 +92,10 @@ class aggregateTest(unittest.TestCase):
                 i.equals(h, verbose=2), "The third aggregation != the first"
             )
 
-            # TODODASK SB: reinstate once fixed!
-            # self.assertTrue(
-            #     g.equals(g0, verbose=2),
-            #     "g !=itself after the third aggregation",
-            # )
+            self.assertTrue(
+                g.equals(g0, verbose=2),
+                "g !=itself after the third aggregation",
+            )
 
             self.assertEqual(
                 i[0].shape, (10, 9), "i[0].shape is " + repr(i[0].shape)
@@ -118,11 +114,10 @@ class aggregateTest(unittest.TestCase):
                 i.equals(h, verbose=2), "The fourth aggregation != the first"
             )
 
-            # TODODASK SB: reinstate once fixed!
-            # self.assertTrue(
-            #     g.equals(g0, verbose=2),
-            #     "g != itself after the fourth aggregation",
-            # )
+            self.assertTrue(
+                g.equals(g0, verbose=2),
+                "g != itself after the fourth aggregation",
+            )
 
             self.assertEqual(
                 i[0].shape, (10, 9), "i[0].shape is " + repr(i[0].shape)

--- a/cf/test/test_aggregate.py
+++ b/cf/test/test_aggregate.py
@@ -22,158 +22,145 @@ class aggregateTest(unittest.TestCase):
         os.path.dirname(os.path.abspath(__file__)), "file2.nc"
     )
 
-    chunk_sizes = (100000, 300, 34)
-    original_chunksize = cf.chunksize()
-
     def test_basic_aggregate(self):
-        for chunksize in self.chunk_sizes:
-            cf.chunksize(chunksize)
+        f = cf.read(self.filename, squeeze=True)[0]
 
-            f = cf.read(self.filename, squeeze=True)[0]
+        g = cf.FieldList(f[0])
+        g.append(f[1:3])
+        g.append(f[3])
+        g[-1].flip(0, inplace=True)
+        g.append(f[4:7])
+        g[-1].flip(0, inplace=True)
+        g.extend([f[i] for i in range(7, f.shape[0])])
 
-            g = cf.FieldList(f[0])
-            g.append(f[1:3])
-            g.append(f[3])
-            g[-1].flip(0, inplace=True)
-            g.append(f[4:7])
-            g[-1].flip(0, inplace=True)
-            g.extend([f[i] for i in range(7, f.shape[0])])
+        g0 = g.copy()
+        self.assertTrue(g.equals(g0, verbose=-1), "g != g0")
 
-            g0 = g.copy()
-            self.assertTrue(g.equals(g0, verbose=-1), "g != g0")
+        with warnings.catch_warnings():
+            # Suppress noise throughout the test fixture from:
+            #
+            #   ~/cf-python/cf/__init__.py:1459: FutureWarning: elementwise
+            #   comparison failed; returning scalar instead, but in the
+            #   future will perform elementwise comparison
+            #
+            # TODO: it is not clear where the above emerges from, e.g.
+            # since __init__ file ref'd does not have that many lines.
+            # It seems like this warning arises from NumPy comparisons
+            # done at some point in (only) some aggregate calls (see e.g:
+            # https://github.com/numpy/numpy/issues/6784).
+            warnings.filterwarnings("ignore", category=FutureWarning)
+            h = cf.aggregate(g, verbose=2)
 
-            with warnings.catch_warnings():
-                # Suppress noise throughout the test fixture from:
-                #
-                #   ~/cf-python/cf/__init__.py:1459: FutureWarning: elementwise
-                #   comparison failed; returning scalar instead, but in the
-                #   future will perform elementwise comparison
-                #
-                # TODO: it is not clear where the above emerges from, e.g.
-                # since __init__ file ref'd does not have that many lines.
-                # It seems like this warning arises from NumPy comparisons
-                # done at some point in (only) some aggregate calls (see e.g:
-                # https://github.com/numpy/numpy/issues/6784).
-                warnings.filterwarnings("ignore", category=FutureWarning)
-                h = cf.aggregate(g, verbose=2)
+        self.assertEqual(len(h), 1)
 
-            self.assertEqual(len(h), 1)
+        self.assertEqual(
+            h[0].shape,
+            (10, 9),
+            "h[0].shape = " + repr(h[0].shape) + " != (10, 9)",
+        )
 
-            self.assertEqual(
-                h[0].shape,
-                (10, 9),
-                "h[0].shape = " + repr(h[0].shape) + " != (10, 9)",
+        self.assertTrue(
+            g.equals(g0, verbose=2), "g != itself after aggregation"
+        )
+
+        self.assertTrue(h[0].equals(f, verbose=2), "h[0] != f")
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=FutureWarning)
+            i = cf.aggregate(g, verbose=2)
+
+        self.assertTrue(
+            i.equals(h, verbose=2), "The second aggregation != the first"
+        )
+
+        self.assertTrue(
+            g.equals(g0, verbose=2),
+            "g != itself after the second aggregation",
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=FutureWarning)
+            i = cf.aggregate(g, verbose=2, axes="grid_latitude")
+
+        self.assertTrue(
+            i.equals(h, verbose=2), "The third aggregation != the first"
+        )
+
+        self.assertTrue(
+            g.equals(g0, verbose=2),
+            "g !=itself after the third aggregation",
+        )
+
+        self.assertEqual(
+            i[0].shape, (10, 9), "i[0].shape is " + repr(i[0].shape)
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=FutureWarning)
+            i = cf.aggregate(
+                g,
+                verbose=2,
+                axes="grid_latitude",
+                donotchecknonaggregatingaxes=1,
             )
 
-            self.assertTrue(
-                g.equals(g0, verbose=2), "g != itself after aggregation"
-            )
+        self.assertTrue(
+            i.equals(h, verbose=2), "The fourth aggregation != the first"
+        )
 
-            self.assertTrue(h[0].equals(f, verbose=2), "h[0] != f")
+        self.assertTrue(
+            g.equals(g0, verbose=2),
+            "g != itself after the fourth aggregation",
+        )
 
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", category=FutureWarning)
-                i = cf.aggregate(g, verbose=2)
+        self.assertEqual(
+            i[0].shape, (10, 9), "i[0].shape is " + repr(i[0].shape)
+        )
 
-            self.assertTrue(
-                i.equals(h, verbose=2), "The second aggregation != the first"
-            )
+        q, t = cf.read(self.file)
+        c = cf.read(self.file2)[0]
 
-            self.assertTrue(
-                g.equals(g0, verbose=2),
-                "g != itself after the second aggregation",
-            )
+        d = cf.aggregate([c, t], verbose=1, relaxed_identities=True)
+        e = cf.aggregate([t, c], verbose=1, relaxed_identities=True)
 
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", category=FutureWarning)
-                i = cf.aggregate(g, verbose=2, axes="grid_latitude")
+        self.assertEqual(len(d), 1)
+        self.assertEqual(len(e), 1)
+        self.assertEqual(d[0].shape, (3,) + t.shape)
+        self.assertTrue(d[0].equals(e[0], verbose=2))
 
-            self.assertTrue(
-                i.equals(h, verbose=2), "The third aggregation != the first"
-            )
+        x = cf.read(["file.nc", "file2.nc"], aggregate=False)
+        self.assertEqual(len(x), 3)
 
-            self.assertTrue(
-                g.equals(g0, verbose=2),
-                "g !=itself after the third aggregation",
-            )
+        x = cf.read(
+            ["file.nc", "file2.nc"], aggregate={"relaxed_identities": True}
+        )
+        self.assertEqual(len(x), 2)
 
-            self.assertEqual(
-                i[0].shape, (10, 9), "i[0].shape is " + repr(i[0].shape)
-            )
+        del t.standard_name
+        del c.standard_name
+        x = cf.aggregate([c, t], verbose=1)
+        self.assertEqual(len(x), 2)
 
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", category=FutureWarning)
-                i = cf.aggregate(
-                    g,
-                    verbose=2,
-                    axes="grid_latitude",
-                    donotchecknonaggregatingaxes=1,
-                )
-
-            self.assertTrue(
-                i.equals(h, verbose=2), "The fourth aggregation != the first"
-            )
-
-            self.assertTrue(
-                g.equals(g0, verbose=2),
-                "g != itself after the fourth aggregation",
-            )
-
-            self.assertEqual(
-                i[0].shape, (10, 9), "i[0].shape is " + repr(i[0].shape)
-            )
-
-            q, t = cf.read(self.file)
-            c = cf.read(self.file2)[0]
-
-            d = cf.aggregate([c, t], verbose=1, relaxed_identities=True)
-            e = cf.aggregate([t, c], verbose=1, relaxed_identities=True)
-
-            self.assertEqual(len(d), 1)
-            self.assertEqual(len(e), 1)
-            self.assertEqual(d[0].shape, (3,) + t.shape)
-            self.assertTrue(d[0].equals(e[0], verbose=2))
-
-            x = cf.read(["file.nc", "file2.nc"], aggregate=False)
-            self.assertEqual(len(x), 3)
-
-            x = cf.read(
-                ["file.nc", "file2.nc"], aggregate={"relaxed_identities": True}
-            )
-            self.assertEqual(len(x), 2)
-
-            del t.standard_name
-            del c.standard_name
-            x = cf.aggregate([c, t], verbose=1)
-            self.assertEqual(len(x), 2)
-
-            t.long_name = "qwerty"
-            c.long_name = "qwerty"
-            x = cf.aggregate([c, t], field_identity="long_name")
-            self.assertEqual(len(x), 1)
-
-        cf.chunksize(self.original_chunksize)
+        t.long_name = "qwerty"
+        c.long_name = "qwerty"
+        x = cf.aggregate([c, t], field_identity="long_name")
+        self.assertEqual(len(x), 1)
 
     def test_aggregate_exist_equal_ignore_opts(self):
         # TODO: extend the option-checking coverage so all options and all
         # reasonable combinations of them are tested. For now, this is
         # testing options that previously errored due to a bug.
-        for chunksize in self.chunk_sizes:
-            cf.chunksize(chunksize)
+        f = cf.read(self.filename, squeeze=True)[0]
 
-            f = cf.read(self.filename, squeeze=True)[0]
+        # Use f as-is: simple test that aggregate works and does not
+        # change anything with the given options:
+        g = cf.aggregate(f, exist_all=True)[0]
+        self.assertEqual(g, f)
+        h = cf.aggregate(f, equal_all=True)[0]
+        self.assertEqual(h, f)
 
-            # Use f as-is: simple test that aggregate works and does not
-            # change anything with the given options:
-            g = cf.aggregate(f, exist_all=True)[0]
-            self.assertEqual(g, f)
-            h = cf.aggregate(f, equal_all=True)[0]
-            self.assertEqual(h, f)
-
-            with self.assertRaises(ValueError):  # contradictory options
-                cf.aggregate(f, exist_all=True, equal_all=True)
-
-        cf.chunksize(self.original_chunksize)
+        with self.assertRaises(ValueError):  # contradictory options
+            cf.aggregate(f, exist_all=True, equal_all=True)
 
     def test_aggregate_verbosity(self):
         f0 = cf.example_field(0)

--- a/cf/test/test_aggregate.py
+++ b/cf/test/test_aggregate.py
@@ -40,7 +40,8 @@ class aggregateTest(unittest.TestCase):
             g.extend([f[i] for i in range(7, f.shape[0])])
 
             g0 = g.copy()
-            self.assertTrue(g.equals(g0, verbose=-1), "g != g0")
+            # TODODASK SB: reinstate once fixed!
+            # self.assertTrue(g.equals(g0, verbose=-1), "g != g0")
 
             with warnings.catch_warnings():
                 # Suppress noise throughout the test fixture from:
@@ -65,9 +66,10 @@ class aggregateTest(unittest.TestCase):
                 "h[0].shape = " + repr(h[0].shape) + " != (10, 9)",
             )
 
-            self.assertTrue(
-                g.equals(g0, verbose=2), "g != itself after aggregation"
-            )
+            # TODODASK SB: reinstate once fixed!
+            # self.assertTrue(
+            #     g.equals(g0, verbose=2), "g != itself after aggregation"
+            # )
 
             self.assertTrue(h[0].equals(f, verbose=2), "h[0] != f")
 
@@ -79,10 +81,11 @@ class aggregateTest(unittest.TestCase):
                 i.equals(h, verbose=2), "The second aggregation != the first"
             )
 
-            self.assertTrue(
-                g.equals(g0, verbose=2),
-                "g != itself after the second aggregation",
-            )
+            # TODODASK SB: reinstate once fixed!
+            # self.assertTrue(
+            #     g.equals(g0, verbose=2),
+            #     "g != itself after the second aggregation",
+            # )
 
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", category=FutureWarning)
@@ -92,10 +95,11 @@ class aggregateTest(unittest.TestCase):
                 i.equals(h, verbose=2), "The third aggregation != the first"
             )
 
-            self.assertTrue(
-                g.equals(g0, verbose=2),
-                "g !=itself after the third aggregation",
-            )
+            # TODODASK SB: reinstate once fixed!
+            # self.assertTrue(
+            #     g.equals(g0, verbose=2),
+            #     "g !=itself after the third aggregation",
+            # )
 
             self.assertEqual(
                 i[0].shape, (10, 9), "i[0].shape is " + repr(i[0].shape)
@@ -114,10 +118,11 @@ class aggregateTest(unittest.TestCase):
                 i.equals(h, verbose=2), "The fourth aggregation != the first"
             )
 
-            self.assertTrue(
-                g.equals(g0, verbose=2),
-                "g != itself after the fourth aggregation",
-            )
+            # TODODASK SB: reinstate once fixed!
+            # self.assertTrue(
+            #     g.equals(g0, verbose=2),
+            #     "g != itself after the fourth aggregation",
+            # )
 
             self.assertEqual(
                 i[0].shape, (10, 9), "i[0].shape is " + repr(i[0].shape)


### PR DESCRIPTION
Towards #182, confirms that `cf.aggregate` works under the new "Dask way" with no modifications, with `test_basic_aggregate` failing instead due to specific issues elsewhere, namely:

* an issue with data comparison by `Data.equals`;
* an issue with construct comparison leading to field copies not being recognised as equal.

(Note to tidy up previous investigation/debugging branches, I created a fresh branch and re-applied commits to break down the fixes to specific parts.)