### PR TITLE
PP/UM files: Fix incomplete rotated pole coordinate reference constructs & coping with missing units

### DIFF
--- a/cf/read_write/um/umread.py
+++ b/cf/read_write/um/umread.py
@@ -2170,7 +2170,8 @@ class UMField:
 
         :Returns:
 
-            `None`
+            `list`
+                The keys of the auxiliary coordinates.
 
         """
         BDX = self.bdx

--- a/cf/read_write/um/umread.py
+++ b/cf/read_write/um/umread.py
@@ -987,9 +987,11 @@ class UMField:
                 # Create UNROTATED, 2-D LATITUDE and LONGITUDE
                 # auxiliary coordinates
                 # ----------------------------------------------------
-                self.latitude_longitude_2d_aux_coordinates(
-                    yc, xc
-                )  # , rotated_pole)
+                aux_keys = self.latitude_longitude_2d_aux_coordinates(yc, xc)
+
+                self.implementation.set_coordinate_reference_coordinates(
+                    ref, [ykey, xkey] + aux_keys
+                )
 
             # --------------------------------------------------------
             # Create a RADIATION WAVELENGTH dimension coordinate
@@ -1845,7 +1847,7 @@ class UMField:
         recs = self.recs
 
         um_Units = self.um_Units
-        units = um_Units.units
+        units = getattr(um_Units, "units", None)
         calendar = getattr(um_Units, "calendar", None)
 
         data_type_in_file = self.data_type_in_file
@@ -2232,6 +2234,7 @@ class UMField:
 
         axes = [_axis["y"], _axis["x"]]
 
+        keys = []
         for axiscode, array, bounds in zip(
             (10, 11), (lat, lon), (lat_bounds, lon_bounds)
         ):
@@ -2245,9 +2248,12 @@ class UMField:
             )
             ac = self.coord_names(ac, axiscode)
 
-            self.implementation.set_auxiliary_coordinate(
+            key = self.implementation.set_auxiliary_coordinate(
                 self.field, ac, axes=axes, copy=False
             )
+            keys.append(key)
+
+        return keys
 
     def model_level_number_coordinate(self, aux=False):
         """model_level_number dimension or auxiliary coordinate.


### PR DESCRIPTION
Fixes #571

Adds the coordinate keys to the coordinate reference, and allows for missing units in the stash2standardname table.