### PR TITLE
Set first dask version number

### DIFF
--- a/cf/abstract/constructlist.py
+++ b/cf/abstract/constructlist.py
@@ -245,7 +245,7 @@ class ConstructList(list, Container, cfdm.Container):
     def close(self):
         """Close all files referenced by each construct in the list.
 
-        Deprecated at version TODODASKVER. All files are now
+        Deprecated at version 3.14.0. All files are now
         automatically closed when not being accessed.
 
         :Returns:
@@ -261,7 +261,7 @@ class ConstructList(list, Container, cfdm.Container):
             self,
             "close",
             "All files are now automatically closed when not being accessed.",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 

--- a/cf/cfimplementation.py
+++ b/cf/cfimplementation.py
@@ -49,7 +49,7 @@ class CFImplementation(cfdm.CFDMImplementation):
         Does not attempt to conform cell method nor coordinate
         reference constructs, as that has been handled by `cfdm`.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 

--- a/cf/constructs.py
+++ b/cf/constructs.py
@@ -131,7 +131,7 @@ class Constructs(cfdm.Constructs):
     def close(self):
         """Close all files referenced by the metadata constructs.
 
-        Deprecated at version TODODASKVER. All files are now
+        Deprecated at version 3.14.0. All files are now
         automatically closed when not being accessed.
 
         Note that a closed file will be automatically reopened if its
@@ -150,7 +150,7 @@ class Constructs(cfdm.Constructs):
             self,
             "close",
             "All files are now automatically closed when not being accessed.",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 

--- a/cf/coordinatereference.py
+++ b/cf/coordinatereference.py
@@ -278,7 +278,7 @@ class CoordinateReference(cfdm.CoordinateReference):
         """Close all files referenced by coordinate conversion term
         values.
 
-        Deprecated at version TODODASKVER. All files are now
+        Deprecated at version 3.14.0. All files are now
         automatically closed when not being accessed.
 
         :Returns:
@@ -294,7 +294,7 @@ class CoordinateReference(cfdm.CoordinateReference):
             self,
             "close",
             "All files are now automatically closed when not being accessed.",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 

--- a/cf/data/array/abstract/filearray.py
+++ b/cf/data/array/abstract/filearray.py
@@ -35,15 +35,14 @@ class FileArray(FileArrayMixin, Array):
     def filename(self):
         """The name of the file containing the array.
 
-        Deprecated at version TODODASKVER. Use method `get_filename`
-        instead.
+        Deprecated at version 3.14.0. Use method `get_filename` instead.
 
         """
         _DEPRECATION_ERROR_ATTRIBUTE(
             self,
             "filename",
             message="Use method 'get_filename' instead.",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 
@@ -61,7 +60,7 @@ class FileArray(FileArrayMixin, Array):
     def get_address(self):
         """The address in the file of the variable.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Returns:
 

--- a/cf/data/array/cfanetcdfarray.py
+++ b/cf/data/array/cfanetcdfarray.py
@@ -13,14 +13,14 @@ from .netcdfarray import NetCDFArray
 class CFANetCDFArray(NetCDFArray):
     """A CFA aggregated array stored in a netCDF file.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     """
 
     def __new__(cls, *args, **kwargs):
         """Store fragment array classes.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         """
         instance = super().__new__(cls)
@@ -190,7 +190,7 @@ class CFANetCDFArray(NetCDFArray):
     def __dask_tokenize__(self):
         """Used by `dask.base.tokenize`.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         """
         aggregated_data = self._get_component("instructions", None)
@@ -216,7 +216,7 @@ class CFANetCDFArray(NetCDFArray):
         the fragments and the instructions on how to aggregate them,
         and is updated in-place.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 
@@ -260,7 +260,7 @@ class CFANetCDFArray(NetCDFArray):
     def _subarray_shapes(self, shapes):
         """Create the subarray shapes.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         .. seealso:: `subarrays`
 
@@ -363,7 +363,7 @@ class CFANetCDFArray(NetCDFArray):
     def _subarrays(self, subarray_shapes):
         """Return descriptors for every subarray.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         .. seealso:: `subarray_shapes`
 
@@ -516,7 +516,7 @@ class CFANetCDFArray(NetCDFArray):
         The keys are indices of the CFA fragment dimensions,
         e.g. ``(1, 0, 0 ,0)``.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 
@@ -561,7 +561,7 @@ class CFANetCDFArray(NetCDFArray):
     def get_FragmentArray(self, fragment_format):
         """Return a Fragment class.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 
@@ -587,7 +587,7 @@ class CFANetCDFArray(NetCDFArray):
     def get_fragmented_dimensions(self):
         """Get the positions dimension that have two or more fragments.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Returns:
 
@@ -617,7 +617,7 @@ class CFANetCDFArray(NetCDFArray):
         The fragment dimension sizes are given in the same order as
         the aggregated dimension sizes given by `shape`
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Returns:
 
@@ -630,7 +630,7 @@ class CFANetCDFArray(NetCDFArray):
     def to_dask_array(self, chunks="auto"):
         """Create a dask array with `FragmentArray` chunks.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 

--- a/cf/data/array/fullarray.py
+++ b/cf/data/array/fullarray.py
@@ -163,7 +163,7 @@ class FullArray(Array):
         These are the values set during initialisation, defaulting to
         `None` if either was not set at that time.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Returns:
 
@@ -200,7 +200,7 @@ class FullArray(Array):
     def get_fill_value(self):
         """Return the data array fill value.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Returns:
 

--- a/cf/data/array/gatheredarray.py
+++ b/cf/data/array/gatheredarray.py
@@ -32,7 +32,7 @@ class GatheredArray(CompressedArrayMixin, ArrayMixin, cfdm.GatheredArray):
     def to_dask_array(self, chunks="auto"):
         """Convert the data to a `dask` array.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 

--- a/cf/data/array/mixin/arraymixin.py
+++ b/cf/data/array/mixin/arraymixin.py
@@ -4,14 +4,14 @@ from ....units import Units
 class ArrayMixin:
     """Mixin class for a container of an array.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     """
 
     def __array_function__(self, func, types, args, kwargs):
         """Implement the `numpy` ``__array_function__`` protocol.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         """
         return NotImplemented
@@ -20,7 +20,7 @@ class ArrayMixin:
     def Units(self):
         """The `cf.Units` object containing the units of the array.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         """
         return Units(self.get_units(), self.get_calendar(None))

--- a/cf/data/array/mixin/compressedarraymixin.py
+++ b/cf/data/array/mixin/compressedarraymixin.py
@@ -4,7 +4,7 @@ import dask.array as da
 class CompressedArrayMixin:
     """Mixin class for compressed arrays.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     """
 
@@ -12,7 +12,7 @@ class CompressedArrayMixin:
         """Try to return a dask array that does not support concurrent
         reads.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 

--- a/cf/data/array/mixin/filearraymixin.py
+++ b/cf/data/array/mixin/filearraymixin.py
@@ -4,7 +4,7 @@ import numpy as np
 class FileArrayMixin:
     """Mixin class for an array stored in a file.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     """
 
@@ -15,7 +15,7 @@ class FileArrayMixin:
         This is the kind of array that will result from slicing the
         file array.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         .. seealso:: `dask.array.from_array`
 

--- a/cf/data/array/mixin/raggedarraymixin.py
+++ b/cf/data/array/mixin/raggedarraymixin.py
@@ -4,14 +4,14 @@ from . import CompressedArrayMixin
 class RaggedArrayMixin(CompressedArrayMixin):
     """Mixin class for compressed ragged arrays.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     """
 
     def to_dask_array(self, chunks="auto"):
         """Convert the data to a `dask` array.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 

--- a/cf/data/array/netcdfarray.py
+++ b/cf/data/array/netcdfarray.py
@@ -29,7 +29,7 @@ class NetCDFArray(FileArrayMixin, cfdm.NetCDFArray):
         regardless of the dataset they access, which means that all
         files access coordinates around the same lock.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         """
         filename = self.get_filename(None)

--- a/cf/data/array/subsampledarray.py
+++ b/cf/data/array/subsampledarray.py
@@ -65,7 +65,7 @@ class SubsampledArray(CompressedArrayMixin, ArrayMixin, cfdm.SubsampledArray):
      [305.0 333.75]
      [333.75 360.0]]
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     """
 
@@ -82,7 +82,7 @@ class SubsampledArray(CompressedArrayMixin, ArrayMixin, cfdm.SubsampledArray):
     def to_dask_array(self, chunks="auto"):
         """Convert the data to a `dask` array.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 

--- a/cf/data/array/umarray.py
+++ b/cf/data/array/umarray.py
@@ -70,13 +70,13 @@ class UMArray(FileArray):
                 ``'little_endian'`` or ``'big_endian'``
 
             size: `int`
-                Deprecated at version TODODASKVER. If set will be
+                Deprecated at version 3.14.0. If set will be
                 ignored.
 
                 Number of elements in the uncompressed array.
 
             ndim: `int`
-                Deprecated at version TODODASKVER. If set will be
+                Deprecated at version 3.14.0. If set will be
                 ignored.
 
                 The number of uncompressed array dimensions.
@@ -260,7 +260,7 @@ class UMArray(FileArray):
 
         This includes the lookup header and file offsets.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         .. seealso:: `close`, `open`
 
@@ -298,7 +298,7 @@ class UMArray(FileArray):
         if they have already not been defined, either during {{class}}
         instantiation or by a previous call to `_set_units`.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 
@@ -358,7 +358,7 @@ class UMArray(FileArray):
         """Return `True` if a field satisfies a condition for a STASH
         code to standard name conversion.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 
@@ -408,7 +408,7 @@ class UMArray(FileArray):
         stored in the metadata object. Otherwise it is taken from the
         *version* parameter.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 
@@ -448,7 +448,7 @@ class UMArray(FileArray):
     def file_address(self):
         """The file name and address.
 
-        Deprecated at version TODODASKVER. Use methods `get_filename`
+        Deprecated at version 3.14.0. Use methods `get_filename`
         and `get_address` instead.
 
         :Returns:
@@ -466,7 +466,7 @@ class UMArray(FileArray):
             self,
             "file_address",
             "Use methods 'get_filename' and 'get_address' instead.",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 
@@ -507,7 +507,7 @@ class UMArray(FileArray):
     def fmt(self):
         """The file format of the UM file containing the array.
 
-        Deprecated at version TODODASKVER. Use method `get_fmt`
+        Deprecated at version 3.14.0. Use method `get_fmt`
         instead.
 
         :Returns:
@@ -520,7 +520,7 @@ class UMArray(FileArray):
             self,
             "fmt",
             "Use method 'get_fmt' instead.",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 
@@ -528,7 +528,7 @@ class UMArray(FileArray):
     def byte_ordering(self):
         """The endianness of the data.
 
-        Deprecated at version TODODASKVER. Use method
+        Deprecated at version 3.14.0. Use method
         `get_byte_ordering` instead.
 
         :Returns:
@@ -541,7 +541,7 @@ class UMArray(FileArray):
             self,
             "byte_ordering",
             "Use method 'get_byte_ordering' instead.",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 
@@ -549,7 +549,7 @@ class UMArray(FileArray):
     def word_size(self):
         """Word size in bytes.
 
-        Deprecated at version TODODASKVER. Use method `get_word_size`
+        Deprecated at version 3.14.0. Use method `get_word_size`
         instead.
 
         :Returns:
@@ -562,7 +562,7 @@ class UMArray(FileArray):
             self,
             "word_size",
             "Use method 'get_word_size' instead.",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 
@@ -574,7 +574,7 @@ class UMArray(FileArray):
             f: `umfile_lib.File`
                 The UM or PP dataset to be be closed.
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
         :Returns:
 
@@ -589,7 +589,7 @@ class UMArray(FileArray):
 
         The address is the word offset of the lookup header.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Returns:
 
@@ -602,7 +602,7 @@ class UMArray(FileArray):
     def get_byte_ordering(self):
         """The endianness of the data.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         .. seealso:: `open`
 
@@ -621,7 +621,7 @@ class UMArray(FileArray):
     def get_fmt(self):
         """The file format of the UM file containing the array.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         .. seealso:: `open`
 
@@ -639,7 +639,7 @@ class UMArray(FileArray):
     def get_word_size(self):
         """Word size in bytes.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         .. seealso:: `open`
 

--- a/cf/data/collapse.py
+++ b/cf/data/collapse.py
@@ -17,7 +17,7 @@ from ..docstring import _docstring_substitution_definitions
 class Collapse(metaclass=DocstringRewriteMeta):
     """Container for functions that collapse dask arrays.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     """
 
@@ -30,7 +30,7 @@ class Collapse(metaclass=DocstringRewriteMeta):
 
         See `_docstring_substitutions` for details.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         .. seealso:: `_docstring_substitutions`
 
@@ -48,7 +48,7 @@ class Collapse(metaclass=DocstringRewriteMeta):
 
         See `_docstring_package_depth` for details.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         """
         return 0
@@ -64,7 +64,7 @@ class Collapse(metaclass=DocstringRewriteMeta):
         https://ncas-cms.github.io/cf-python/analysis.html#collapse-methods
         for mathematical definitions.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 
@@ -113,7 +113,7 @@ class Collapse(metaclass=DocstringRewriteMeta):
         https://ncas-cms.github.io/cf-python/analysis.html#collapse-methods
         for mathematical definitions.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 
@@ -161,7 +161,7 @@ class Collapse(metaclass=DocstringRewriteMeta):
         https://ncas-cms.github.io/cf-python/analysis.html#collapse-methods
         for mathematical definitions.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 
@@ -219,7 +219,7 @@ class Collapse(metaclass=DocstringRewriteMeta):
         https://ncas-cms.github.io/cf-python/analysis.html#collapse-methods
         for mathematical definitions.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 
@@ -270,7 +270,7 @@ class Collapse(metaclass=DocstringRewriteMeta):
         https://ncas-cms.github.io/cf-python/analysis.html#collapse-methods
         for mathematical definitions.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 
@@ -317,7 +317,7 @@ class Collapse(metaclass=DocstringRewriteMeta):
         https://ncas-cms.github.io/cf-python/analysis.html#collapse-methods
         for mathematical definitions.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 
@@ -366,7 +366,7 @@ class Collapse(metaclass=DocstringRewriteMeta):
         https://ncas-cms.github.io/cf-python/analysis.html#collapse-methods
         for mathematical definitions.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 
@@ -406,7 +406,7 @@ class Collapse(metaclass=DocstringRewriteMeta):
         https://ncas-cms.github.io/cf-python/analysis.html#collapse-methods
         for mathematical definitions.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 
@@ -461,7 +461,7 @@ class Collapse(metaclass=DocstringRewriteMeta):
         https://ncas-cms.github.io/cf-python/analysis.html#collapse-methods
         for mathematical definitions.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 
@@ -513,7 +513,7 @@ class Collapse(metaclass=DocstringRewriteMeta):
         https://ncas-cms.github.io/cf-python/analysis.html#collapse-methods
         for mathematical definitions.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 
@@ -568,7 +568,7 @@ class Collapse(metaclass=DocstringRewriteMeta):
         https://ncas-cms.github.io/cf-python/analysis.html#collapse-methods
         for mathematical definitions.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 
@@ -629,7 +629,7 @@ class Collapse(metaclass=DocstringRewriteMeta):
         https://ncas-cms.github.io/cf-python/analysis.html#collapse-methods
         for mathematical definitions.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 
@@ -687,7 +687,7 @@ class Collapse(metaclass=DocstringRewriteMeta):
         https://ncas-cms.github.io/cf-python/analysis.html#collapse-methods
         for mathematical definitions.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 
@@ -746,7 +746,7 @@ class Collapse(metaclass=DocstringRewriteMeta):
         https://ncas-cms.github.io/cf-python/analysis.html#collapse-methods
         for mathematical definitions.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 
@@ -791,7 +791,7 @@ class Collapse(metaclass=DocstringRewriteMeta):
     def unique(cls, a, split_every=None):
         """Return unique elements of the data.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 
@@ -910,7 +910,7 @@ def double_precision_dtype(a, default=None, bool_type="i"):
 def mask_small_sample_size(x, N, axis, mtol, original_shape):
     """Mask elements where the sample size is below a threshold.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -968,7 +968,7 @@ def mask_small_sample_size(x, N, axis, mtol, original_shape):
 def sum_weights_chunk(x, weights=None, square=False, N=None, **kwargs):
     """Sum the weights.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -1030,7 +1030,7 @@ def combine_arrays(
 
     See `dask.array.reductions.mean_combine` for an example.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Returns:
 
@@ -1049,7 +1049,7 @@ def combine_arrays(
 def sum_arrays(pairs, key, axis, dtype, computing_meta=False, **kwargs):
     """Alias of `combine_arrays` with ``func=chunk.sum``.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     """
     return combine_arrays(
@@ -1060,7 +1060,7 @@ def sum_arrays(pairs, key, axis, dtype, computing_meta=False, **kwargs):
 def max_arrays(pairs, key, axis, dtype, computing_meta=False, **kwargs):
     """Alias of `combine_arrays` with ``func=chunk.max``.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     """
     return combine_arrays(
@@ -1071,7 +1071,7 @@ def max_arrays(pairs, key, axis, dtype, computing_meta=False, **kwargs):
 def min_arrays(pairs, key, axis, dtype, computing_meta=False, **kwargs):
     """Alias of `combine_arrays` with ``func=chunk.min``.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     """
     return combine_arrays(
@@ -1083,7 +1083,7 @@ def sum_sample_sizes(pairs, axis, computing_meta=False, **kwargs):
     """Alias of `combine_arrays` with ``key="N", func=chunk.sum,
     dtype="i8"``.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     """
     return combine_arrays(
@@ -1106,7 +1106,7 @@ def cf_mean_chunk(x, weights=None, dtype="f8", computing_meta=False, **kwargs):
      This function is passed to `dask.array.reduction` as its *chunk*
      parameter.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -1144,7 +1144,7 @@ def cf_mean_combine(
     This function is passed to `dask.array.reduction` as its *combine*
     parameter.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -1188,7 +1188,7 @@ def cf_mean_agg(
     This function is passed to `dask.array.reduction` as its
     *aggregate* parameter.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -1227,7 +1227,7 @@ def cf_max_chunk(x, dtype=None, computing_meta=False, **kwargs):
     This function is passed to `dask.array.reduction` as its *chunk*
     parameter.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -1257,7 +1257,7 @@ def cf_max_combine(pairs, axis=None, computing_meta=False, **kwargs):
     This function is passed to `dask.array.reduction` as its *combine*
     parameter.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -1291,7 +1291,7 @@ def cf_max_agg(
     This function is passed to `dask.array.reduction` as its
     *aggregate* parameter.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -1338,7 +1338,7 @@ def cf_mid_range_agg(
     This function is passed to `dask.array.reduction` as its
     *aggregate* parameter.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -1378,7 +1378,7 @@ def cf_min_chunk(x, dtype=None, computing_meta=False, **kwargs):
     This function is passed to `dask.array.reduction` as its *chunk*
     parameter.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -1408,7 +1408,7 @@ def cf_min_combine(pairs, axis=None, computing_meta=False, **kwargs):
     This function is passed to `dask.array.reduction` as its *combine*
     parameter.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -1442,7 +1442,7 @@ def cf_min_agg(
     This function is passed to `dask.array.reduction` as its
     *aggregate* parameter.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -1481,7 +1481,7 @@ def cf_range_chunk(x, dtype=None, computing_meta=False, **kwargs):
     This function is passed to `dask.array.reduction` as its *chunk*
     parameter.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -1515,7 +1515,7 @@ def cf_range_combine(
     This function is passed to `dask.array.reduction` as its *combine*
     parameter.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -1551,7 +1551,7 @@ def cf_range_agg(
     This function is passed to `dask.array.reduction` as its
     *aggregate* parameter.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -1591,7 +1591,7 @@ def cf_rms_chunk(x, weights=None, dtype="f8", computing_meta=False, **kwargs):
     This function is passed to `dask.array.reduction` as its *chunk*
     parameter.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -1628,7 +1628,7 @@ def cf_rms_agg(
     This function is passed to `dask.array.reduction` as its
     *aggregate* parameter.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -1667,7 +1667,7 @@ def cf_sample_size_chunk(x, dtype="i8", computing_meta=False, **kwargs):
     This function is passed to `dask.array.reduction` as its *chunk*
     parameter.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -1703,7 +1703,7 @@ def cf_sample_size_combine(
     This function is passed to `dask.array.reduction` as its *combine*
     parameter.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -1738,7 +1738,7 @@ def cf_sample_size_agg(
     This function is passed to `dask.array.reduction` as its
     *aggregate* parameter.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -1777,7 +1777,7 @@ def cf_sum_chunk(x, weights=None, dtype="f8", computing_meta=False, **kwargs):
     This function is passed to `dask.array.reduction` as its *chunk*
     parameter.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -1811,7 +1811,7 @@ def cf_sum_combine(
     This function is passed to `dask.array.reduction` as its *combine*
     parameter.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -1846,7 +1846,7 @@ def cf_sum_agg(
     This function is passed to `dask.array.reduction` as its
     *aggregate* parameter.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -1928,7 +1928,7 @@ def cf_unique_chunk(x, dtype=None, computing_meta=False, **kwargs):
     This function is passed to `dask.array.reduction` as its *chunk*
     parameter.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -1956,7 +1956,7 @@ def cf_unique_agg(pairs, axis=None, computing_meta=False, **kwargs):
 
     It is assumed that the arrays are one-dimensional.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -1995,7 +1995,7 @@ def cf_var_chunk(
     https://en.wikipedia.org/wiki/Pooled_variance#Sample-based_statistics
     for details.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -2067,7 +2067,7 @@ def cf_var_combine(
     This function is passed to `dask.array.reduction` as its *combine*
     parameter.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -2126,7 +2126,7 @@ def cf_var_agg(
     https://en.wikipedia.org/wiki/Weighted_arithmetic_mean#Reliability_weights
     for details.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 

--- a/cf/data/creation.py
+++ b/cf/data/creation.py
@@ -9,7 +9,7 @@ from dask.base import is_dask_collection
 def to_dask(array, chunks, **from_array_options):
     """Create a `dask` array.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -93,7 +93,7 @@ def generate_axis_identifiers(n):
 
     The names are arbitrary and have no semantic meaning.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 

--- a/cf/data/dask_utils.py
+++ b/cf/data/dask_utils.py
@@ -104,7 +104,7 @@ def _da_ma_allclose(x, y, masked_equal=True, rtol=None, atol=None):
 def cf_contains(a, value):
     """Whether or not an array contains a value.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     .. seealso:: `cf.Data.__contains__`
 
@@ -136,7 +136,7 @@ except ImportError:
 def cf_convolve1d(a, window=None, axis=-1, origin=0):
     """Calculate a 1-d convolution along the given axis.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     .. seealso:: `cf.Data.convolution_filter`
 
@@ -185,7 +185,7 @@ def cf_harden_mask(a):
 
     Has no effect if the array is not a masked array.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     .. seealso:: `cf.Data.harden_mask`
 
@@ -219,7 +219,7 @@ def cf_percentile(a, q, axis, method, keepdims=False, mtol=1):
     .. note:: This function correctly sets the mask hardness of the
               output array.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     .. seealso:: `cf.Data.percentile`
 
@@ -348,7 +348,7 @@ def cf_soften_mask(a):
 
     Has no effect if the array is not a masked array.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     .. seealso:: `cf.Data.soften_mask`
 
@@ -384,7 +384,7 @@ def cf_where(array, condition, x, y, hardmask):
     .. note:: This function correctly sets the mask hardness of the
               output array.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     .. seealso:: `cf.Data.where`
 
@@ -482,7 +482,7 @@ def cf_YMDhms(a, attr):
     Only applicable for data with reference time units. The returned
     array will have the same mask hardness as the original array.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     .. seealso:: `~cf.Data.year`, ~cf.Data.month`, `~cf.Data.day`,
                  `~cf.Data.hour`, `~cf.Data.minute`, `~cf.Data.second`
@@ -519,7 +519,7 @@ def cf_YMDhms(a, attr):
 def cf_rt2dt(a, units):
     """Convert an array of reference times to date-time objects.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     .. seealso:: `cf._dt2rt`, `cf.Data._asdatetime`
 
@@ -551,7 +551,7 @@ def cf_rt2dt(a, units):
 def cf_dt2rt(a, units):
     """Convert an array of date-time objects to reference times.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     .. seealso:: `cf._rt2dt`, `cf.Data._asreftime`
 
@@ -585,7 +585,7 @@ def cf_dt2rt(a, units):
 def cf_units(a, from_units, to_units):
     """Convert array values to have different equivalent units.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     .. seealso:: `cf.Data.Units`
 

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -274,7 +274,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
             {{chunks: `int`, `tuple`, `dict` or `str`, optional}}
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
             to_memory: `bool`, optional
                 If True then ensure that the original data are in
@@ -296,7 +296,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
                 If the input *array* is a `dask.array.Array` object
                 then *to_memory* is ignored.
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
             init_options: `dict`, optional
                 Provide optional keyword arguments to methods and
@@ -323,7 +323,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
                  *Parameter example:*
                    ``{'from_array': {'inline_array': True}}``
 
-            chunk: deprecated at version TODODASKVER
+            chunk: deprecated at version 3.14.0
                 Use the *chunks* parameter instead.
 
         **Examples**
@@ -479,7 +479,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
     def dask_compressed_array(self):
         """Returns a dask array of the compressed data.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Returns:
 
@@ -1143,7 +1143,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         then they subspace along each dimension independently. This
         behaviour is similar to Fortran, but different to `numpy`.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         .. seealso:: `__keepdims_indexing__`, `__getitem__`,
                      `__setitem__`,
@@ -1181,7 +1181,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         single-axis index reduces the number of array dimensions by
         1. This behaviour is the same as `numpy`.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         .. seealso:: `__orthogonal_indexing__`, `__getitem__`,
                      `__setitem__`
@@ -1254,7 +1254,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         * Deletes a source array.
         * Deletes cached element values.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Returns:
 
@@ -1267,7 +1267,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
     def _set_dask(self, array, copy=False, conform=True):
         """Set the dask array.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         .. seealso:: `to_dask_array`, `_conform_after_dask_update`,
                      `_del_dask`
@@ -1322,7 +1322,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
     def _del_dask(self, default=ValueError(), conform=True):
         """Remove the dask array.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         .. seealso:: `to_dask_array`, `_conform_after_dask_update`,
                      `_set_dask`
@@ -1392,7 +1392,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
                   `_del_cached_elements` must be called explicitly to
                   ensure consistency.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         .. seealso:: `_del_dask`, `_set_cached_elements`, `_set_dask`
 
@@ -1411,7 +1411,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         Updates *data* in-place to store the given element values
         within its ``custom`` dictionary.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         .. seealso:: `_del_cached_elements`
 
@@ -1916,7 +1916,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
             {{percentile method: `str`, optional}}
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
             {{collapse squeeze: `bool`, optional}}
 
@@ -1932,7 +1932,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
             {{split_every: `int` or `dict`, optional}}
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
             {{inplace: `bool`, optional}}
 
@@ -2057,7 +2057,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
             {{percentile method: `str`, optional}}
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
             squeeze: `bool`, optional
                 If True then all axes over which percentiles are
@@ -2071,11 +2071,11 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
             {{split_every: `int` or `dict`, optional}}
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
             {{inplace: `bool`, optional}}
 
-            interpolation: deprecated at version TODODASKVER
+            interpolation: deprecated at version 3.14.0
                 Use the *method* parameter instead.
 
         :Returns:
@@ -2152,7 +2152,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
                 "percentile",
                 {"interpolation": None},
                 message="Use the 'method' parameter instead.",
-                version="TODODASKVER",
+                version="3.14.0",
                 removed_at="5.0.0",
             )  # pragma: no cover
 
@@ -2267,7 +2267,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         `persist` causes all delayed operations to be computed.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         .. seealso:: `compute`, `array`, `datetime_array`,
                      `dask.array.Array.persist`
@@ -2349,7 +2349,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         `array` causes all delayed operations to be computed.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         .. seealso:: `persist`, `array`, `datetime_array`
 
@@ -2600,13 +2600,13 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
                 Choose which method to use to perform the cumulative
                 sum. See `dask.array.cumsum` for details.
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
             {{inplace: `bool`, optional}}
 
                 .. versionadded:: 3.3.0
 
-            masked_as_zero: deprecated at version TODODASKVER
+            masked_as_zero: deprecated at version 3.14.0
                 See the examples for the new behaviour when there are
                 masked values.
 
@@ -2657,7 +2657,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
                 "cumsum",
                 {"masked_as_zero": None},
                 message="",
-                version="TODODASKVER",
+                version="3.14.0",
                 removed_at="5.0.0",
             )  # pragma: no cover
 
@@ -2680,7 +2680,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
     ):
         """Change the chunk structure of the data.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         .. seealso:: `chunks`, `dask.array.rechunk`
 
@@ -4069,7 +4069,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
     def chunks(self):
         """The chunk sizes for each dimension.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         .. seealso:: `npartitions`, `numblocks`, `rechunk`
 
@@ -4399,7 +4399,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
     def npartitions(self):
         """The total number of chunks.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         .. seealso:: `chunks`, `numblocks`, `rechunk`
 
@@ -4420,7 +4420,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
     def numblocks(self):
         """The number of chunks along each dimension.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         .. seealso:: `chunks`, `npartitions`, `rechunk`
 
@@ -5716,7 +5716,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
             {{split_every: `int` or `dict`, optional}}
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
             {{inplace: `bool`, optional}}
 
@@ -5779,7 +5779,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
             {{split_every: `int` or `dict`, optional}}
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
             {{inplace: `bool`, optional}}
 
@@ -5847,7 +5847,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
             {{split_every: `int` or `dict`, optional}}
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
             {{inplace: `bool`, optional}}
 
@@ -5909,7 +5909,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
             {{split_every: `int` or `dict`, optional}}
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
             {{inplace: `bool`, optional}}
 
@@ -5981,7 +5981,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
             {{split_every: `int` or `dict`, optional}}
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
             {{inplace: `bool`, optional}}
 
@@ -6058,7 +6058,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
             {{split_every: `int` or `dict`, optional}}
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
             {{inplace: `bool`, optional}}
 
@@ -6133,7 +6133,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
             {{split_every: `int` or `dict`, optional}}
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
             {{inplace: `bool`, optional}}
 
@@ -6224,7 +6224,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
             {{split_every: `int` or `dict`, optional}}
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
             {{inplace: `bool`, optional}}
 
@@ -7253,7 +7253,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         return d
 
-    @_deprecated_kwarg_check("size", version="TODODASKVER", removed_at="5.0.0")
+    @_deprecated_kwarg_check("size", version="3.14.0", removed_at="5.0.0")
     @_inplace_enabled(default=False)
     @_manage_log_level_via_verbosity
     def halo(
@@ -7362,7 +7362,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
             {{verbose: `int` or `str` or `None`, optional}}
 
-            size: deprecated at version TODODASKVER
+            size: deprecated at version 3.14.0
                 Use the *depth* parameter instead.
 
         :Returns:
@@ -7447,7 +7447,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
                 "halo",
                 {"size": None},
                 message="Use the 'depth' parameter instead.",
-                version="TODODASKVER",
+                version="3.14.0",
                 removed_at="5.0.0",
             )  # pragma: no cover
 
@@ -7606,7 +7606,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         determined by its `hardmask` property. `harden_mask` sets
         `hardmask` to `True`.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         .. seealso:: `hardmask`, `soften_mask`
 
@@ -7703,7 +7703,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         determined by its `hardmask` property. `soften_mask` sets
         `hardmask` to `False`.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         .. seealso:: `hardmask`, `harden_mask`
 
@@ -8382,7 +8382,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
                      returned dask array is correct, set the
                      *apply_mask_hardness* parameter to True.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 
@@ -8730,7 +8730,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
             {{chunks: `int`, `tuple`, `dict` or `str`, optional}}
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
         :Returns:
 
@@ -8798,7 +8798,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
             {{split_every: `int` or `dict`, optional}}
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
             {{inplace: `bool`, optional}}
 
@@ -9147,7 +9147,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
             {{split_every: `int` or `dict`, optional}}
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
             {{inplace: `bool`, optional}}
 
@@ -9521,7 +9521,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
         :Parameters:
 
-            itemsize: deprecated at version TODODASKVER
+            itemsize: deprecated at version 3.14.0
                 The number of bytes per word of the master data array.
 
         :Returns:
@@ -10010,7 +10010,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         improve performance by reducing the amount of work done in
         later steps.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         .. seealso:: `dask.optimization.cull`
 
@@ -10485,9 +10485,9 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
             {{chunks: `int`, `tuple`, `dict` or `str`, optional}}
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
-            fill_value: deprecated at version TODODASKVER
+            fill_value: deprecated at version 3.14.0
                 Use `set_fill_value` instead.
 
         :Returns:
@@ -10546,7 +10546,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
             {{chunks: `int`, `tuple`, `dict` or `str`, optional}}
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
         :Returns:
 
@@ -10610,7 +10610,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
             {{chunks: `int`, `tuple`, `dict` or `str`, optional}}
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
         :Returns:
 
@@ -10662,7 +10662,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
             {{chunks: `int`, `tuple`, `dict` or `str`, optional}}
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
         :Returns:
 
@@ -10684,7 +10684,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         dx = da.zeros(shape, dtype=dtype, chunks=chunks)
         return cls(dx, units=units, calendar=calendar)
 
-    @_deprecated_kwarg_check("out", version="TODODASKVER", removed_at="5.0.0")
+    @_deprecated_kwarg_check("out", version="3.14.0", removed_at="5.0.0")
     @_deprecated_kwarg_check("i", version="3.0.0", removed_at="4.0.0")
     @_inplace_enabled(default=False)
     def func(
@@ -10706,7 +10706,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
             units: `Units`, optional
 
-            out: deprecated at version TODODASKVER
+            out: deprecated at version 3.14.0
 
             {{inplace: `bool`, optional}}
 
@@ -10815,7 +10815,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
             {{split_every: `int` or `dict`, optional}}
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
             {{inplace: `bool`, optional}}
 
@@ -10980,7 +10980,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
             {{split_every: `int` or `dict`, optional}}
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
             {{inplace: `bool`, optional}}
 
@@ -11058,7 +11058,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
             {{split_every: `int` or `dict`, optional}}
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
             {{inplace: `bool`, optional}}
 
@@ -11142,7 +11142,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
             {{split_every: `int` or `dict`, optional}}
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
             {[inplace: `bool`, optional}}
 
@@ -11240,7 +11240,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
             {{split_every: `int` or `dict`, optional}}
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
             {[inplace: `bool`, optional}}
 
@@ -11338,7 +11338,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
             {{split_every: `int` or `dict`, optional}}
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
             {{inplace: `bool`, optional}}
 
@@ -11425,7 +11425,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
             {{split_every: `int` or `dict`, optional}}
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
             {{inplace: `bool`, optional}}
 
@@ -11503,13 +11503,13 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
                 sectioned.
 
             stop: `int`, optional
-                Deprecated at version TODODASKVER.
+                Deprecated at version 3.14.0.
 
                 Stop after this number of sections and return. If stop is
                 None all sections are taken.
 
             chunks: `bool`, optional
-                Deprecated at version TODODASKVER. Consider using
+                Deprecated at version 3.14.0. Consider using
                 `cf.Data.rechunk` instead.
 
                 If True return sections that are of the maximum possible
@@ -11551,7 +11551,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
                 "section",
                 {"chunks": chunks},
                 message="Consider using Data.rechunk() instead.",
-                version="TODODASKVER",
+                version="3.14.0",
                 removed_at="5.0.0",
             )  # pragma: no cover
 
@@ -11560,7 +11560,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
                 self,
                 "section",
                 {"stop": stop},
-                version="TODODASKVER",
+                version="3.14.0",
                 removed_at="5.0.0",
             )  # pragma: no cover
 
@@ -11570,7 +11570,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
     def square(self, dtype=None, inplace=False):
         """Calculate the element-wise square.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         .. seealso:: `sqrt`, `sum_of_squares`
 
@@ -11617,7 +11617,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
     def sqrt(self, dtype=None, inplace=False):
         """Calculate the non-negative square root.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         .. seealso:: `square`
 
@@ -11863,7 +11863,7 @@ def _collapse(
 ):
     """Collapse data in-place using a given funcion.
 
-     .. versionadded:: TODODASKVER
+     .. versionadded:: 3.14.0
 
      .. seealso:: `_parse_weights`
 
@@ -11975,7 +11975,7 @@ def _collapse(
 def _parse_weights(d, weights, axis=None):
     """Parse the weights input to `_collapse`.
 
-     .. versionadded:: TODODASKVER
+     .. versionadded:: 3.14.0
 
      .. seealso:: `_collapse`
 

--- a/cf/data/fragment/abstract/fragmentarray.py
+++ b/cf/data/fragment/abstract/fragmentarray.py
@@ -7,7 +7,7 @@ from ...array.abstract import FileArray
 class FragmentArray(FileArray):
     """A CFA fragment array.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     """
 
@@ -133,7 +133,7 @@ class FragmentArray(FileArray):
             dimension (similar to the way vector subscripts work in
             Fortran).
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         """
         array = self.get_array()
@@ -149,7 +149,7 @@ class FragmentArray(FileArray):
         instances, and rank-reducing indices (such as an integer or
         scalar array) are disallowed.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 
@@ -215,7 +215,7 @@ class FragmentArray(FileArray):
     def _conform_units(self, array):
         """Conform the array to have the aggregated units.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 
@@ -251,7 +251,7 @@ class FragmentArray(FileArray):
     def aggregated_Units(self):
         """The units of the aggregated data.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Returns:
 
@@ -270,7 +270,7 @@ class FragmentArray(FileArray):
     def get_address(self):
         """The address of the fragment in the file.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Returns:
 
@@ -286,7 +286,7 @@ class FragmentArray(FileArray):
         If the calendar is `None` then the CF default calendar is
         assumed, if applicable.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 
@@ -320,7 +320,7 @@ class FragmentArray(FileArray):
         If the units are `None` then the aggregated array has no
         defined units.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         .. seealso:: `get_aggregated_calendar`
 
@@ -353,7 +353,7 @@ class FragmentArray(FileArray):
     def get_array(self):
         """The fragment array stored in a file.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Returns:
 

--- a/cf/data/fragment/missingfragmentarray.py
+++ b/cf/data/fragment/missingfragmentarray.py
@@ -7,7 +7,7 @@ from .abstract import FragmentArray
 class MissingFragmentArray(FragmentArray):
     """A CFA fragment array that is wholly missing data.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     """
 

--- a/cf/data/fragment/netcdffragmentarray.py
+++ b/cf/data/fragment/netcdffragmentarray.py
@@ -5,7 +5,7 @@ from .abstract import FragmentArray
 class NetCDFFragmentArray(FragmentArray):
     """A CFA fragment array stored in a netCDF file.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     """
 
@@ -131,7 +131,7 @@ class NetCDFFragmentArray(FragmentArray):
         dimensions then the entire array is read into memory before
         the requested subspace of it is returned.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         """
         indices = self._parse_indices(indices)

--- a/cf/data/fragment/umfragmentarray.py
+++ b/cf/data/fragment/umfragmentarray.py
@@ -5,7 +5,7 @@ from .abstract import FragmentArray
 class UMFragmentArray(FragmentArray):
     """A CFA fragment array stored in a UM or PP file.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     """
 

--- a/cf/data/mixin/deprecations.py
+++ b/cf/data/mixin/deprecations.py
@@ -11,7 +11,7 @@ class DataClassDeprecationsMixin:
     def __hash__(self):
         """The built-in function `hash`.
 
-        Deprecated at version TODODASKVER. Consider using the
+        Deprecated at version 3.14.0. Consider using the
         `cf.hash_array` function instead.
 
         Generating the hash temporarily realises the entire array in
@@ -65,7 +65,7 @@ class DataClassDeprecationsMixin:
             self,
             "__hash__",
             message="Consider using 'cf.hash_array' function array instead.",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )
 
@@ -73,25 +73,25 @@ class DataClassDeprecationsMixin:
     def _HDF_chunks(self):
         """The HDF chunksizes.
 
-        Deprecated at version TODODASKVER.
+        Deprecated at version 3.14.0.
 
         DO NOT CHANGE IN PLACE.
 
         """
         _DEPRECATION_ERROR_ATTRIBUTE(
-            self, "_HDF_chunks", version="TODODASKVER", removed_at="5.0.0"
+            self, "_HDF_chunks", version="3.14.0", removed_at="5.0.0"
         )  # pragma: no cover
 
     @_HDF_chunks.setter
     def _HDF_chunks(self, value):
         _DEPRECATION_ERROR_ATTRIBUTE(
-            self, "_HDF_chunks", version="TODODASKVER", removed_at="5.0.0"
+            self, "_HDF_chunks", version="3.14.0", removed_at="5.0.0"
         )  # pragma: no cover
 
     @_HDF_chunks.deleter
     def _HDF_chunks(self):
         _DEPRECATION_ERROR_ATTRIBUTE(
-            self, "_HDF_chunks", version="TODODASKVER", removed_at="5.0.0"
+            self, "_HDF_chunks", version="3.14.0", removed_at="5.0.0"
         )  # pragma: no cover
 
     @property
@@ -116,18 +116,18 @@ class DataClassDeprecationsMixin:
     def in_memory(self):
         """True if the array is retained in memory.
 
-        Deprecated at version TODODASKVER.
+        Deprecated at version 3.14.0.
 
         """
         _DEPRECATION_ERROR_ATTRIBUTE(
-            self, "in_memory", version="TODODASKVER", removed_at="5.0.0"
+            self, "in_memory", version="3.14.0", removed_at="5.0.0"
         )  # pragma: no cover
 
     @property
     def ismasked(self):
         """True if the data array has any masked values.
 
-        Deprecated at version TODODASKVER. Use the `is_masked` attribute
+        Deprecated at version 3.14.0. Use the `is_masked` attribute
         instead.
 
         **Examples**
@@ -144,7 +144,7 @@ class DataClassDeprecationsMixin:
             self,
             "ismasked",
             message="Use the 'is_masked' attribute instead",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 
@@ -152,7 +152,7 @@ class DataClassDeprecationsMixin:
     def isscalar(self):
         """True if the data is a 0-d scalar array.
 
-        Deprecated at version TODODASKVER. Use `d.ndim == 0`` instead.
+        Deprecated at version 3.14.0. Use `d.ndim == 0`` instead.
 
         **Examples**
 
@@ -171,7 +171,7 @@ class DataClassDeprecationsMixin:
             self,
             "isscalar",
             message="Use 'd.ndim == 0' instead",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 
@@ -193,7 +193,7 @@ class DataClassDeprecationsMixin:
 
         """
         _DEPRECATION_ERROR_ATTRIBUTE(
-            self, "ispartitioned", version="TODODASKVER", removed_at="5.0.0"
+            self, "ispartitioned", version="3.14.0", removed_at="5.0.0"
         )  # pragma: no cover
 
     @property
@@ -215,7 +215,7 @@ class DataClassDeprecationsMixin:
     def varray(self):
         """A numpy array view of the data array.
 
-        Deprecated at version TODODASKVER. Data are now stored as `dask`
+        Deprecated at version 3.14.0. Data are now stored as `dask`
         arrays for which, in general, a numpy array view is not
         robust.
 
@@ -241,7 +241,7 @@ class DataClassDeprecationsMixin:
             "varray",
             message="Data are now stored as `dask` arrays for which, "
             "in general, a numpy array view is not robust.",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 
@@ -274,7 +274,7 @@ class DataClassDeprecationsMixin:
         """Return True if the master array is small enough to be
         retained in memory.
 
-        Deprecated at version TODODASKVER.
+        Deprecated at version 3.14.0.
 
         :Parameters:
 
@@ -294,29 +294,29 @@ class DataClassDeprecationsMixin:
         _DEPRECATION_ERROR_METHOD(
             self,
             "fits_in_one_chunk_in_memory",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 
     def close(self):
         """Close all files referenced by the data array.
 
-        Deprecated at version TODODASKVER. All files are now
-        automatically closed when not being accessed.
+        Deprecated at version 3.14.0. All files are now automatically
+        closed when not being accessed.
 
         """
         _DEPRECATION_ERROR_METHOD(
             self,
             "close",
             "All files are now automatically closed when not being accessed.",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 
     def chunk(self, chunksize=None, total=None, omit_axes=None, pmshape=None):
         """Partition the data array.
 
-        Deprecated at version TODODASKVER. Use the `rechunk` method
+        Deprecated at version 3.14.0. Use the `rechunk` method
         instead.
 
         :Parameters:
@@ -347,14 +347,14 @@ class DataClassDeprecationsMixin:
             self,
             "chunk",
             message="Use the 'rechunk' method instead.",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 
     def dumpd(self):
         """Return a serialisation of the data array.
 
-        Deprecated at version TODODASKVER. Consider inspecting the dask
+        Deprecated at version 3.14.0. Consider inspecting the dask
         array returned by `to_dask_array` instead.
 
         .. seealso:: `loadd`, `loads`
@@ -412,15 +412,15 @@ class DataClassDeprecationsMixin:
             "dumpd",
             message="Consider inspecting the dask array returned "
             "by 'to_dask_array' instead.",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 
     def dumps(self):
         """Return a JSON string serialisation of the data array.
 
-        Deprecated at version TODODASKVER. Consider inspecting the dask
-        array returned by `to_dask_array` instead.
+        Deprecated at version 3.14.0. Consider inspecting the dask array
+        returned by `to_dask_array` instead.
 
         """
         _DEPRECATION_ERROR_METHOD(
@@ -428,7 +428,7 @@ class DataClassDeprecationsMixin:
             "dumps",
             message="Consider inspecting the dask array returned "
             "by 'to_dask_array' instead.",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 
@@ -438,7 +438,7 @@ class DataClassDeprecationsMixin:
         The HDF chunk sizes may be used by external code that allows
         `Data` objects to be written to netCDF files.
 
-        Deprecated at version TODODASKVER and is no longer available. Use
+        Deprecated at version 3.14.0 and is no longer available. Use
         the methods `nc_clear_hdf5_chunksizes`, `nc_hdf5_chunksizes`,
         and `nc_set_hdf5_chunksizes` instead.
 
@@ -507,14 +507,14 @@ class DataClassDeprecationsMixin:
             message="Use the methods 'nc_clear_hdf5_chunksizes', "
             "'nc_hdf5_chunksizes', and 'nc_set_hdf5_chunksizes' "
             "instead.",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 
     def loadd(self, d, chunk=True):
         """Reset the data in place from a dictionary serialisation.
 
-        Deprecated at version TODODASKVER. Consider inspecting the dask
+        Deprecated at version 3.14.0. Consider inspecting the dask
         array returned by `to_dask_array` instead.
 
         .. seealso:: `dumpd`, `loads`
@@ -554,14 +554,14 @@ class DataClassDeprecationsMixin:
             "loadd",
             message="Consider inspecting the dask array returned "
             "by 'to_dask_array' instead.",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 
     def loads(self, j, chunk=True):
         """Reset the data in place from a string serialisation.
 
-        Deprecated at version TODODASKVER. Consider inspecting the dask
+        Deprecated at version 3.14.0. Consider inspecting the dask
         array returned by `to_dask_array` instead.
 
         .. seealso:: `dumpd`, `loadd`
@@ -586,14 +586,14 @@ class DataClassDeprecationsMixin:
             "loads",
             message="Consider inspecting the dask array returned "
             "by 'to_dask_array' instead.",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 
     def add_partitions(self, extra_boundaries, pdim):
         """Add partition boundaries.
 
-        Deprecated at version TODODASKVER. Use the `rechunk` method
+        Deprecated at version 3.14.0. Use the `rechunk` method
         instead.
 
         :Parameters:
@@ -617,7 +617,7 @@ class DataClassDeprecationsMixin:
             self,
             "add_partitions",
             message="Use the 'rechunk' method instead.",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 
@@ -626,7 +626,7 @@ class DataClassDeprecationsMixin:
         """Masking of floating-point errors in the results of arithmetic
         operations.
 
-        Deprecated at version TODODASKVER. It is currently not possible
+        Deprecated at version 3.14.0. It is currently not possible
         to control how floating-point errors are handled, due to the
         use of `dask` for handling all array manipulations. This may
         change in the future (see
@@ -690,7 +690,7 @@ class DataClassDeprecationsMixin:
 
         """
         raise DeprecationError(
-            "Data method 'mask_fpe' has been deprecated at version TODODASKVER "
+            "Data method 'mask_fpe' has been deprecated at version 3.14.0 "
             "and is not available.\n\n"
             "It is currently not possible to control how floating-point errors "
             "are handled, due to the use of `dask` for handling all array "
@@ -701,7 +701,7 @@ class DataClassDeprecationsMixin:
     def mask_invalid(self, *args, **kwargs):
         """Mask the array where invalid values occur (NaN or inf).
 
-        Deprecated at version TODODASKVER. Use the method
+        Deprecated at version 3.14.0. Use the method
         `masked_invalid` instead.
 
         .. seealso:: `where`
@@ -733,7 +733,7 @@ class DataClassDeprecationsMixin:
             self,
             "mask_invalid",
             message="Use the method 'masked_invalid' instead.",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 
@@ -741,7 +741,7 @@ class DataClassDeprecationsMixin:
         """Return the partition boundaries for each partition matrix
         dimension.
 
-        Deprecated at version TODODASKVER. Consider using the `chunks`
+        Deprecated at version 3.14.0. Consider using the `chunks`
         attribute instead.
 
         :Returns:
@@ -755,7 +755,7 @@ class DataClassDeprecationsMixin:
             self,
             "partition_boundaries",
             message="Consider using the 'chunks' attribute instead.",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 
@@ -768,7 +768,7 @@ class DataClassDeprecationsMixin:
     def to_disk(self):
         """Store the data array on disk.
 
-        Deprecated at version TODODASKVER.
+        Deprecated at version 3.14.0.
 
         There is no change to partitions whose sub-arrays are already
         on disk.
@@ -783,7 +783,7 @@ class DataClassDeprecationsMixin:
 
         """
         _DEPRECATION_ERROR_METHOD(
-            self, "to_disk", version="TODODASKVER", removed_at="5.0.0"
+            self, "to_disk", version="3.14.0", removed_at="5.0.0"
         )  # pragma: no cover
 
     @staticmethod
@@ -791,7 +791,7 @@ class DataClassDeprecationsMixin:
         """Set how floating-point errors in the results of arithmetic
         operations are handled.
 
-        Deprecated at version TODODASKVER. It is currently not possible
+        Deprecated at version 3.14.0. It is currently not possible
         to control how floating-point errors are handled, due to the
         use of `dask` for handling all array manipulations. This may
         change in the future (see
@@ -929,7 +929,7 @@ class DataClassDeprecationsMixin:
 
         """
         raise DeprecationError(
-            "Data method 'seterr' has been deprecated at version TODODASKVER "
+            "Data method 'seterr' has been deprecated at version 3.14.0 "
             "and is not available.\n\n"
             "It is currently not possible to control how floating-point errors "
             "are handled, due to the use of `dask` for handling all array "
@@ -944,7 +944,7 @@ class DataClassDeprecationsMixin:
         with a Data object. Returns a reconstructed cf.Data object with
         the sections in the original order.
 
-        Deprecated at version TODODASKVER and is no longer available.
+        Deprecated at version 3.14.0 and is no longer available.
 
         :Parameters:
 
@@ -970,7 +970,7 @@ class DataClassDeprecationsMixin:
         """
         raise DeprecationError(
             "Data method 'reconstruct_sectioned_data' has been deprecated "
-            "at version TODODASKVER and is no longer available"
+            "at version 3.14.0 and is no longer available"
         )
 
     @classmethod
@@ -998,6 +998,6 @@ class DataClassDeprecationsMixin:
         """
         raise DeprecationError(
             "Data method 'concatenate_data' has been deprecated at "
-            "version TODODASKVER and is no longer available. Use "
+            "version 3.14.0 and is no longer available. Use "
             "'concatenate' instead."
         )

--- a/cf/data/utils.py
+++ b/cf/data/utils.py
@@ -72,7 +72,7 @@ def _is_numeric_dtype(array):
 def convert_to_datetime(a, units):
     """Convert a dask array of numbers to one of date-time objects.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     .. seealso `convert_to_reftime`
 
@@ -110,7 +110,7 @@ def convert_to_reftime(a, units=None, first_value=None):
     """Convert a dask array of string or object date-times to floating
     point reference times.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     .. seealso `convert_to_datetime`
 
@@ -216,7 +216,7 @@ def convert_to_reftime(a, units=None, first_value=None):
 def first_non_missing_value(a, cached=None, method="index"):
     """Return the first non-missing value of a dask array.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -321,7 +321,7 @@ def first_non_missing_value(a, cached=None, method="index"):
 def unique_calendars(a):
     """Find the unique calendars from a dask array of date-time objects.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -366,7 +366,7 @@ def new_axis_identifier(existing_axes=(), basename="dim"):
 
     The name is arbitrary and has no semantic meaning.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -422,7 +422,7 @@ def new_axis_identifier(existing_axes=(), basename="dim"):
 def chunk_positions(chunks):
     """Find the position of each chunk.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     .. seealso:: `chunk_shapes`
 
@@ -452,7 +452,7 @@ def chunk_positions(chunks):
 def chunk_shapes(chunks):
     """Find the shape of each chunk.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     .. seealso:: `chunk_positions`
 
@@ -482,7 +482,7 @@ def chunk_shapes(chunks):
 def scalar_masked_array(dtype=float):
     """Return a scalar masked array.
 
-     .. versionadded:: TODODASKVER
+     .. versionadded:: 3.14.0
 
      :Parmaeters:
 
@@ -540,7 +540,7 @@ def conform_units(value, units, message=None):
 
     In all other cases *value* is returned unchanged.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     :Parameters:
 
@@ -608,7 +608,7 @@ def YMDhms(d, attr):
     Only applicable for data with reference time units. The returned
     `Data` will have the same mask hardness as the original array.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     .. seealso:: `~cf.Data.year`, ~cf.Data.month`, `~cf.Data.day`,
                  `~cf.Data.hour`, `~cf.Data.minute`, `~cf.Data.second`
@@ -656,7 +656,7 @@ def where_broadcastable(data, x, name):
     *x* are ignored, thereby also ensuring that the shape of the
     result is identical to the shape of *data*.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     .. seealso:: `cf.Data.where`
 

--- a/cf/docstring/docstring.py
+++ b/cf/docstring/docstring.py
@@ -389,7 +389,7 @@ _docstring_substitution_definitions = {
                 overall. If set to False then dask graphs are not
                 culled. See `dask.optimization.cull` for details.
 
-                .. versionadded:: TODODASKVER""",
+                .. versionadded:: 3.14.0""",
     # ----------------------------------------------------------------
     # Method description susbstitutions (4 levels of indentataion)
     # ----------------------------------------------------------------

--- a/cf/domain.py
+++ b/cf/domain.py
@@ -127,7 +127,7 @@ class Domain(mixin.FieldDomain, mixin.Properties, cfdm.Domain):
     def close(self):
         """Close all files referenced by the domain construct.
 
-        Deprecated at version TODODASKVER. All files are now
+        Deprecated at version 3.14.0. All files are now
         automatically closed when not being accessed.
 
         Note that a closed file will be automatically reopened if its
@@ -146,7 +146,7 @@ class Domain(mixin.FieldDomain, mixin.Properties, cfdm.Domain):
             self,
             "close",
             "All files are now automatically closed when not being accessed.",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 

--- a/cf/field.py
+++ b/cf/field.py
@@ -4105,7 +4105,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
     def varray(self):
         """A numpy array view of the data array.
 
-        Deprecated at version TODODASKVER. Data are now stored as
+        Deprecated at version 3.14.0. Data are now stored as
         `dask` arrays for which, in general, a numpy array view is not
         robust.
 
@@ -4136,7 +4136,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
             "varray",
             message="Data are now stored as `dask` arrays for which, "
             "in general, a numpy array view is not robust.",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 
@@ -4969,7 +4969,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
     def close(self):
         """Close all files referenced by the field construct.
 
-        Deprecated at version TODODASKVER. All files are now
+        Deprecated at version 3.14.0. All files are now
         automatically closed when not being accessed.
 
         Note that a closed file will be automatically reopened if its
@@ -4988,7 +4988,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
             self,
             "close",
             "All files are now automatically closed when not being accessed.",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 
@@ -12269,11 +12269,11 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
 
             {{inplace: `bool`, optional}}
 
-            coordinate: deprecated at version TODODASKVER
+            coordinate: deprecated at version 3.14.0
                 Set how the cell coordinate values for the summed axis
                 are defined, relative to the new cell bounds.
 
-            masked_as_zero: deprecated at version TODODASKVER
+            masked_as_zero: deprecated at version 3.14.0
                 See `Data.cumsum` for examples of the new behaviour
                 when there are masked values.
 
@@ -12333,7 +12333,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 "cumsum",
                 {"masked_as_zero": None},
                 message="",
-                version="TODODASKVER",
+                version="3.14.0",
                 removed_at="5.0.0",
             )  # pragma: no cover
 
@@ -12344,7 +12344,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 "cumsum",
                 {"coordinate": None},
                 message="",
-                version="TODODASKVER",
+                version="3.14.0",
                 removed_at="5.0.0",
             )  # pragma: no cover
 
@@ -13318,7 +13318,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
 
             {{verbose: `int` or `str` or `None`, optional}}
 
-            size: deprecated at version TODODASKVER
+            size: deprecated at version 3.14.0
                 Use the *depth* parameter instead.
 
         :Returns:
@@ -13418,7 +13418,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 "halo",
                 {"size": None},
                 message="Use the 'depth' parameter instead.",
-                version="TODODASKVER",
+                version="3.14.0",
                 removed_at="5.0.0",
             )  # pragma: no cover
 
@@ -13594,7 +13594,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
 
             {{percentile method: `str`, optional}}
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
             squeeze: `bool`, optional
                 If True then all size 1 axes are removed from the returned
@@ -13620,7 +13620,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                   datum if more than 25% of its input array elements are
                   missing data: ``mtol=0.25``.
 
-            interpolation: deprecated at version TODODASKVER
+            interpolation: deprecated at version 3.14.0
                 Use the *method* parameter instead.
 
         :Returns:
@@ -13728,7 +13728,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 "percentile",
                 {"interpolation": None},
                 message="Use the 'method' parameter instead.",
-                version="TODODASKVER",
+                version="3.14.0",
                 removed_at="5.0.0",
             )  # pragma: no cover
 
@@ -14239,7 +14239,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
         iaxes = self._axis_positions(axis, parse=False)
         if iaxes:
             # TODODASK - remove these two lines when multiaxis rolls
-            #            are allowed at TODODASKVER
+            #            are allowed at 3.14.0
             iaxis = iaxes[0]
             shift = shift[0]
 

--- a/cf/functions.py
+++ b/cf/functions.py
@@ -264,15 +264,15 @@ def configuration(
             current value.
 
         of_fraction: `float` or `Constant`, optional
-            Deprecated at version TODODASKVER and is no longer
+            Deprecated at version 3.14.0 and is no longer
             available.
 
         collapse_parallel_mode: `int` or `Constant`, optional
-            Deprecated at version TODODASKVER and is no longer
+            Deprecated at version 3.14.0 and is no longer
             available.
 
         free_memory_factor: `float` or `Constant`, optional
-            Deprecated at version TODODASKVER and is no longer
+            Deprecated at version 3.14.0 and is no longer
             available.
 
     :Returns:
@@ -593,7 +593,7 @@ class collapse_parallel_mode(ConstantAccess):
     """Which mode to use when collapse is run in parallel. There are
     three possible modes:
 
-    Deprecated at version TODODASKVER and is no longer available.
+    Deprecated at version 3.14.0 and is no longer available.
 
     0.  This attempts to maximise parallelism, possibly at the expense
         of extra communication. This is the default mode.
@@ -637,7 +637,7 @@ class collapse_parallel_mode(ConstantAccess):
     def _parse(cls, arg):
         """Parse a new constant value.
 
-        Deprecated at version TODODASKVER and is no longer available.
+        Deprecated at version 3.14.0 and is no longer available.
 
         .. versionaddedd:: 3.8.0
 
@@ -657,7 +657,7 @@ class collapse_parallel_mode(ConstantAccess):
         """
         # TODODASKAPI
         _DEPRECATION_ERROR_FUNCTION(
-            "collapse_parallel_mode", version="TODODASKVER", removed_at="5.0.0"
+            "collapse_parallel_mode", version="3.14.0", removed_at="5.0.0"
         )  # pragma: no cover
 
 
@@ -854,7 +854,7 @@ class of_fraction(ConstantAccess):
     """The amount of concurrently open files above which files
     containing data arrays may be automatically closed.
 
-    Deprecated at version TODODASKVER and is no longer available.
+    Deprecated at version 3.14.0 and is no longer available.
 
     The amount is expressed as a fraction of the maximum possible
     number of concurrently open files.
@@ -904,7 +904,7 @@ class of_fraction(ConstantAccess):
     def _parse(cls, arg):
         """Parse a new constant value.
 
-        Deprecated at version TODODASKVER and is no longer available.
+        Deprecated at version 3.14.0 and is no longer available.
 
         .. versionaddedd:: 3.8.0
 
@@ -924,14 +924,14 @@ class of_fraction(ConstantAccess):
         """
         # TODODASKAPI
         _DEPRECATION_ERROR_FUNCTION(
-            "of_fraction", version="TODODASKVER", removed_at="5.0.0"
+            "of_fraction", version="3.14.0", removed_at="5.0.0"
         )  # pragma: no cover
 
 
 class free_memory_factor(ConstantAccess):
     """Set the fraction of memory kept free as a temporary workspace.
 
-    Deprecated at version TODODASKVER and is no longer available.
+    Deprecated at version 3.14.0 and is no longer available.
 
     Users should set the free memory factor through cf.set_performance
     so that the upper limit to the chunksize is recalculated
@@ -957,7 +957,7 @@ class free_memory_factor(ConstantAccess):
     def _parse(cls, arg):
         """Parse a new constant value.
 
-        Deprecated at version TODODASKVER and is no longer available.
+        Deprecated at version 3.14.0 and is no longer available.
 
         .. versionaddedd:: 3.8.0
 
@@ -977,7 +977,7 @@ class free_memory_factor(ConstantAccess):
         """
         # TODODASKAPI
         _DEPRECATION_ERROR_FUNCTION(
-            "free_memory_factor", version="TODODASKVER", removed_at="5.0.0"
+            "free_memory_factor", version="3.14.0", removed_at="5.0.0"
         )  # pragma: no cover
 
 
@@ -1168,7 +1168,7 @@ def fm_threshold():
     """The amount of memory which is kept free as a temporary work
     space.
 
-    Deprecated at version TODODASKVER and is no longer available.
+    Deprecated at version 3.14.0 and is no longer available.
 
     :Returns:
 
@@ -1183,14 +1183,14 @@ def fm_threshold():
     """
     # TODODASKAPI
     _DEPRECATION_ERROR_FUNCTION(
-        "fm_threshold", version="TODODASKVER", removed_at="5.0.0"
+        "fm_threshold", version="3.14.0", removed_at="5.0.0"
     )  # pragma: no cover
 
 
 def set_performance(chunksize=None, free_memory_factor=None):
     """Tune performance of parallelisation.
 
-    Deprecated at version TODODASKVER and is no longer available.
+    Deprecated at version 3.14.0 and is no longer available.
 
     Sets the chunksize and free memory factor. By just providing the
     chunksize it can be changed to a smaller value than an upper
@@ -1224,19 +1224,19 @@ def set_performance(chunksize=None, free_memory_factor=None):
     """
     # TODODASKAPI
     _DEPRECATION_ERROR_FUNCTION(
-        "set_performance", version="TODODASKVER", removed_at="5.0.0"
+        "set_performance", version="3.14.0", removed_at="5.0.0"
     )  # pragma: no cover
 
 
 def min_total_memory():
     """The minimum total memory across nodes.
 
-    Deprecated at version TODODASKVER and is no longer available.
+    Deprecated at version 3.14.0 and is no longer available.
 
     """
     # TODODASKAPI
     _DEPRECATION_ERROR_FUNCTION(
-        "min_total_memory", version="TODODASKVER", removed_at="5.0.0"
+        "min_total_memory", version="3.14.0", removed_at="5.0.0"
     )  # pragma: no cover
 
 
@@ -1261,12 +1261,12 @@ def RTOL(*new_rtol):
 def FREE_MEMORY_FACTOR(*new_free_memory_factor):
     """Alias for `cf.free_memory_factor`.
 
-    Deprecated at version TODODASKVER and is no longer available.
+    Deprecated at version 3.14.0 and is no longer available.
 
     """
     # TODODASKAPI
     _DEPRECATION_ERROR_FUNCTION(
-        "FREE_MEMORY_FACTOR", version="TODODASKVER", removed_at="5.0.0"
+        "FREE_MEMORY_FACTOR", version="3.14.0", removed_at="5.0.0"
     )  # pragma: no cover
 
 
@@ -1283,24 +1283,24 @@ def CHUNKSIZE(*new_chunksize):
 def SET_PERFORMANCE(*new_set_performance):
     """Alias for `cf.set_performance`.
 
-    Deprecated at version TODODASKVER and is no longer available.
+    Deprecated at version 3.14.0 and is no longer available.
 
     """
     # TODODASKAPI
     _DEPRECATION_ERROR_FUNCTION(
-        "SET_PERFORMANCE", version="TODODASKVER", removed_at="5.0.0"
+        "SET_PERFORMANCE", version="3.14.0", removed_at="5.0.0"
     )  # pragma: no cover
 
 
 def OF_FRACTION(*new_of_fraction):
     """Alias for `cf.of_fraction`.
 
-    Deprecated at version TODODASKVER and is no longer available.
+    Deprecated at version 3.14.0 and is no longer available.
 
     """
     # TODODASKAPI
     _DEPRECATION_ERROR_FUNCTION(
-        "OF_FRACTION", version="TODODASKVER", removed_at="5.0.0"
+        "OF_FRACTION", version="3.14.0", removed_at="5.0.0"
     )  # pragma: no cover
 
 
@@ -1312,12 +1312,12 @@ def REGRID_LOGGING(*new_regrid_logging):
 def COLLAPSE_PARALLEL_MODE(*new_collapse_parallel_mode):
     """Alias for `cf.collapse_parallel_mode`.
 
-    Deprecated at version TODODASKVER and is no longer available.
+    Deprecated at version 3.14.0 and is no longer available.
 
     """
     # TODODASKAPI
     _DEPRECATION_ERROR_FUNCTION(
-        "COLLAPSE_PARALLEL_MODE", version="TODODASKVER", removed_at="5.0.0"
+        "COLLAPSE_PARALLEL_MODE", version="3.14.0", removed_at="5.0.0"
     )  # pragma: no cover
 
 
@@ -1329,12 +1329,12 @@ def RELAXED_IDENTITIES(*new_relaxed_identities):
 def MIN_TOTAL_MEMORY(*new_min_total_memory):
     """Alias for `cf.min_total_memory`.
 
-    Deprecated at version TODODASKVER and is no longer available.
+    Deprecated at version 3.14.0 and is no longer available.
 
     """
     # TODODASKAPI
     _DEPRECATION_ERROR_FUNCTION(
-        "MIN_TOTAL_MEMORY", version="TODODASKVER", removed_at="5.0.0"
+        "MIN_TOTAL_MEMORY", version="3.14.0", removed_at="5.0.0"
     )  # pragma: no cover
 
 
@@ -1351,12 +1351,12 @@ def TOTAL_MEMORY(*new_total_memory):
 def FM_THRESHOLD(*new_fm_threshold):
     """Alias for `cf.fm_threshold`.
 
-    Deprecated at version TODODASKVER and is no longer available.
+    Deprecated at version 3.14.0 and is no longer available.
 
     """
     # TODODASKAPI
     _DEPRECATION_ERROR_FUNCTION(
-        "FM_THRESHOLD", version="TODODASKVER", removed_at="5.0.0"
+        "FM_THRESHOLD", version="3.14.0", removed_at="5.0.0"
     )  # pragma: no cover
 
 
@@ -1440,7 +1440,7 @@ def open_files_threshold_exceeded():
     """Return True if the total number of open files is greater than the
     current threshold.
 
-    Deprecated at version TODODASKVER and is no longer available.
+    Deprecated at version 3.14.0 and is no longer available.
 
     The threshold is defined as a fraction of the maximum possible number
     of concurrently open files (an operating system dependent amount). The
@@ -1472,7 +1472,7 @@ def open_files_threshold_exceeded():
     # TODODASKAPI
     _DEPRECATION_ERROR_FUNCTION(
         "open_files_threshold_exceeded",
-        version="TODODASKVER",
+        version="3.14.0",
         removed_at="5.0.0",
     )  # pragma: no cover
 
@@ -1480,7 +1480,7 @@ def open_files_threshold_exceeded():
 def close_files(file_format=None):
     """Close open files containing sub-arrays of data arrays.
 
-    Deprecated at version TODODASKVER and is no longer available.
+    Deprecated at version 3.14.0 and is no longer available.
 
     By default all such files are closed, but this may be restricted
     to files of a particular format.
@@ -1513,7 +1513,7 @@ def close_files(file_format=None):
     """
     # TODODASKAPI
     _DEPRECATION_ERROR_FUNCTION(
-        "close_files", version="TODODASKVER", removed_at="5.0.0"
+        "close_files", version="3.14.0", removed_at="5.0.0"
     )  # pragma: no cover
 
 
@@ -1521,7 +1521,7 @@ def close_one_file(file_format=None):
     """Close an arbitrary open file containing a sub-array of a data
     array.
 
-    Deprecated at version TODODASKVER and is no longer available.
+    Deprecated at version 3.14.0 and is no longer available.
 
     By default a file of arbitrary format is closed, but the choice
     may be restricted to files of a particular format.
@@ -1563,7 +1563,7 @@ def close_one_file(file_format=None):
     """
     # TODODASKAPI
     _DEPRECATION_ERROR_FUNCTION(
-        "close_one_file", version="TODODASKVER", removed_at="5.0.0"
+        "close_one_file", version="3.14.0", removed_at="5.0.0"
     )  # pragma: no cover
 
 
@@ -1571,7 +1571,7 @@ def open_files(file_format=None):
     """Return the open files containing sub-arrays of master data
     arrays.
 
-    Deprecated at version TODODASKVER and is no longer available.
+    Deprecated at version 3.14.0 and is no longer available.
 
     By default all such files are returned, but the selection may be
     restricted to files of a particular format.
@@ -1608,7 +1608,7 @@ def open_files(file_format=None):
     """
     # TODODASKAPI
     _DEPRECATION_ERROR_FUNCTION(
-        "open_files", version="TODODASKVER", removed_at="5.0.0"
+        "open_files", version="3.14.0", removed_at="5.0.0"
     )  # pragma: no cover
 
 
@@ -1739,7 +1739,7 @@ def indices_shape(indices, full_shape, keepdims=True):
     Boolean `dask` arrays will be computed, and `dask` arrays with
     unknown size will have their chunk sizes computed.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     .. seealso:: `cf.parse_indices`
 
@@ -2614,7 +2614,7 @@ def hash_array(array, algorithm=hashlib.sha1):
             Constructor function for the desired hash algorithm,
             e.g. `hashlib.md5`, `hashlib.sha256`, etc.
 
-            .. versionadded:: TODODASKVER
+            .. versionadded:: 3.14.0
 
     :Returns:
 
@@ -2862,13 +2862,13 @@ def _section(x, axes=None, stop=None, chunks=False, min_step=1):
             passed. By default it is False.
 
         stop: `int`, optional
-            Deprecated at version TODODASKVER.
+            Deprecated at version 3.14.0.
 
             Stop after taking this number of sections and return. If
             stop is None all sections are taken.
 
         chunks: `bool`, optional
-            Deprecated at version TODODASKVER. Consider using
+            Deprecated at version 3.14.0. Consider using
             `cf.Data.rechunk` instead.
 
             If True return sections that are of the maximum possible
@@ -2903,13 +2903,13 @@ def _section(x, axes=None, stop=None, chunks=False, min_step=1):
     if stop is not None:
         raise DeprecationError(
             "The 'stop' keyword of cf._section() was deprecated at "
-            "version TODODASKVER and is no longer available"
+            "version 3.14.0 and is no longer available"
         )
 
     if chunks:
         raise DeprecationError(
             "The 'chunks' keyword of cf._section() was deprecated at "
-            "version TODODASKVER and is no longer available. Consider using "
+            "version 3.14.0 and is no longer available. Consider using "
             "cf.Data.rechunk instead."
         )
 

--- a/cf/interpolationparameter.py
+++ b/cf/interpolationparameter.py
@@ -25,7 +25,7 @@ class InterpolationParameter(
     subarea dimension name, if required, are set on the
     corresponding tie point index variable.
 
-    .. versionadded:: TODODASKVER
+    .. versionadded:: 3.14.0
 
     .. seealso:: `TiePointIndex`
 

--- a/cf/mixin/fielddomain.py
+++ b/cf/mixin/fielddomain.py
@@ -2124,7 +2124,7 @@ class FieldDomain:
                 dimension or auxiliary coordinate construct
                 identifiers.
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
         :Returns:
 

--- a/cf/mixin/propertiesdata.py
+++ b/cf/mixin/propertiesdata.py
@@ -1601,7 +1601,7 @@ class PropertiesData(Properties):
     def mask_invalid(self, inplace=False, i=False):
         """Mask the array where invalid values occur.
 
-        Deprecated at version TODODASKVER. Use the method
+        Deprecated at version 3.14.0. Use the method
         `masked_invalid` instead.
 
         Note that:
@@ -1666,7 +1666,7 @@ class PropertiesData(Properties):
             self,
             "mask_invalid",
             message="Use the method 'masked_invalid' instead.",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 
@@ -1926,7 +1926,7 @@ class PropertiesData(Properties):
 
         `persist` causes all delayed operations to be computed.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         .. seealso:: `array`, `datetime_array`,
                      `dask.array.Array.persist`
@@ -2397,7 +2397,7 @@ class PropertiesData(Properties):
             "varray",
             message="Data are now stored as `dask` arrays for which, "
             "in general, a numpy array view is not robust.",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 
@@ -2544,7 +2544,7 @@ class PropertiesData(Properties):
     def close(self):
         """Close all files referenced by the construct.
 
-        Deprecated at version TODODASKVER. All files are now
+        Deprecated at version 3.14.0. All files are now
         automatically closed when not being accessed.
 
         Note that a closed file will be automatically reopened if its
@@ -2565,7 +2565,7 @@ class PropertiesData(Properties):
             self,
             "close",
             "All files are now automatically closed when not being accessed.",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 
@@ -4537,7 +4537,7 @@ class PropertiesData(Properties):
     def to_dask_array(self):
         """Convert the data to a `dask` array.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         .. seealso:: `cf.Data.to_dask_array`
 
@@ -5033,7 +5033,7 @@ class PropertiesData(Properties):
 
             {{verbose: `int` or `str` or `None`, optional}}
 
-            size: deprecated at version TODODASKVER
+            size: deprecated at version 3.14.0
                 Use the *depth* parameter instead.
 
         :Returns:
@@ -5053,7 +5053,7 @@ class PropertiesData(Properties):
                 "halo",
                 {"size": None},
                 message="Use the 'depth' parameter instead.",
-                version="TODODASKVER",
+                version="3.14.0",
                 removed_at="5.0.0",
             )  # pragma: no cover
 

--- a/cf/mixin/propertiesdatabounds.py
+++ b/cf/mixin/propertiesdatabounds.py
@@ -1272,7 +1272,7 @@ class PropertiesDataBounds(PropertiesData):
     def close(self):
         """Close all files referenced by the construct.
 
-        Deprecated at version TODODASKVER. All files are now
+        Deprecated at version 3.14.0. All files are now
         automatically closed when not being accessed.
 
         Note that a closed file will be automatically re-opened if its
@@ -1293,7 +1293,7 @@ class PropertiesDataBounds(PropertiesData):
             self,
             "close",
             "All files are now automatically closed when not being accessed.",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 
@@ -2034,7 +2034,7 @@ class PropertiesDataBounds(PropertiesData):
     def mask_invalid(self, inplace=False, i=False):
         """Mask the array where invalid values occur.
 
-        Deprecated at version TODODASKVER. Use the method
+        Deprecated at version 3.14.0. Use the method
         `masked_invalid` instead.
 
         Note that:
@@ -2099,7 +2099,7 @@ class PropertiesDataBounds(PropertiesData):
             self,
             "mask_invalid",
             message="Use the method 'masked_invalid' instead.",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 
@@ -2436,7 +2436,7 @@ class PropertiesDataBounds(PropertiesData):
 
             {{verbose: `int` or `str` or `None`, optional}}
 
-            size: deprecated at version TODODASKVER
+            size: deprecated at version 3.14.0
                 Use the *depth* parameter instead.
 
         :Returns:
@@ -2456,7 +2456,7 @@ class PropertiesDataBounds(PropertiesData):
                 "halo",
                 {"size": None},
                 message="Use the 'depth' parameter instead.",
-                version="TODODASKVER",
+                version="3.14.0",
                 removed_at="5.0.0",
             )  # pragma: no cover
 
@@ -3727,7 +3727,7 @@ class PropertiesDataBounds(PropertiesData):
 
         `persist` causes all delayed operations to be computed.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         .. seealso:: `array`, `datetime_array`,
                      `dask.array.Array.persist`

--- a/cf/query.py
+++ b/cf/query.py
@@ -763,7 +763,7 @@ class Query:
     def iscontains(self):
         """Return True if the query is a "cell contains" condition.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         .. seealso:: `cf.contains`
 

--- a/cf/read_write/netcdf/netcdfread.py
+++ b/cf/read_write/netcdf/netcdfread.py
@@ -226,7 +226,7 @@ class NetCDFRead(cfdm.read_write.netcdf.NetCDFRead):
     def _is_cfa_variable(self, ncvar):
         """Return True if *ncvar* is a CFA variable.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 
@@ -266,7 +266,7 @@ class NetCDFRead(cfdm.read_write.netcdf.NetCDFRead):
             # TODOCFA: Modify this message for v4.0.0.
             raise ValueError(
                 "The reading of CFA-0.4 files was permanently disabled at "
-                "version TODODASKVER. However, CFA-0.4 functionality is "
+                "version 3.14.0. However, CFA-0.4 functionality is "
                 "still available at version 3.13.1. "
                 "The reading and writing of CFA-0.6 files will become "
                 "available at version 4.0.0."
@@ -298,7 +298,7 @@ class NetCDFRead(cfdm.read_write.netcdf.NetCDFRead):
             ncdimensions: sequence of `str`, optional
                 The netCDF dimensions spanned by the array.
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
             units: `str`, optional
                 The units of *array*. By default, or if `None`, it is
@@ -392,7 +392,7 @@ class NetCDFRead(cfdm.read_write.netcdf.NetCDFRead):
         retrieved from *data* (which would require a whole dask chunk
         to be read to get each single value).
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 
@@ -514,7 +514,7 @@ class NetCDFRead(cfdm.read_write.netcdf.NetCDFRead):
     def _parse_chunks(self, ncvar):
         """Parse the dask chunks.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 

--- a/cf/read_write/netcdf/netcdfwrite.py
+++ b/cf/read_write/netcdf/netcdfwrite.py
@@ -410,7 +410,7 @@ class NetCDFWrite(cfdm.read_write.netcdf.NetCDFWrite):
         Specifically, checks array for out-of-range values, as
         defined by the valid_[min|max|range] attributes.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 
@@ -435,7 +435,7 @@ class NetCDFWrite(cfdm.read_write.netcdf.NetCDFWrite):
     def _filled_string_array(self, array, fill_value=""):
         """Fill a string array.
 
-        .. versionadded:: TODODASKVER
+        .. versionadded:: 3.14.0
 
         :Parameters:
 
@@ -459,7 +459,7 @@ class NetCDFWrite(cfdm.read_write.netcdf.NetCDFWrite):
 #    def _convert_dtype(self, array, new_dtype=None):
 #        """Convert the data type of a numpy array.
 #
-#        .. versionadded:: TODODASKVER
+#        .. versionadded:: 3.14.0
 #
 #        :Parameters:
 #

--- a/cf/read_write/read.py
+++ b/cf/read_write/read.py
@@ -609,7 +609,7 @@ def read(
                           UM fields files, for which the chunking is
                           pre-determined by the file format.
 
-                .. versionadded:: TODODASKVER
+                .. versionadded:: 3.14.0
 
         domain: `bool`, optional
             If True then return only the domain constructs that are
@@ -650,7 +650,7 @@ def read(
         select_options: deprecated at version 3.0.0
             Use methods on the returned `FieldList` instead.
 
-        chunk: deprecated at version TODODASKVER
+        chunk: deprecated at version 3.14.0
             Use the *chunks* parameter instead.
 
     :Returns:
@@ -733,7 +733,7 @@ def read(
             "cf.read",
             {"chunk": chunk},
             "Use keyword 'chunks' instead.",
-            version="TODODASKVER",
+            version="3.14.0",
             removed_at="5.0.0",
         )  # pragma: no cover
 

--- a/cf/read_write/write.py
+++ b/cf/read_write/write.py
@@ -615,7 +615,7 @@ def write(
               constructs: ``omit_data=['domain_ancillary',
               'cell_measure']``.
 
-            .. versionadded:: TODODASKVER
+            .. versionadded:: 3.14.0
 
         HDF_chunksizes: deprecated at version 3.0.0
             HDF chunk sizes may be set for individual constructs prior


### PR DESCRIPTION
Replaced all occurences of `TODODASKVER` with `3.14.0`, using:

```console
$ cd cf
$ grep -IR TODODASKVER | grep -v html | wc -l
347
$ find . -type f -name "*.py" | xargs sed -i "s/TODODASKVER/3.14.0/g"
$ grep -IR TODODASKVER | grep -v html | wc -l
0
```