### PR TITLE
dask: Update docstring substitutions

### DIFF
--- a/cf/data/array/cfanetcdfarray.py
+++ b/cf/data/array/cfanetcdfarray.py
@@ -104,12 +104,9 @@ class CFANetCDFArray(NetCDFArray):
                 The calendar of the aggregated data. Set to `None` to
                 indicate the CF default calendar, if applicable.
 
-            source: optional
-                Initialise the array from the given object.
+            {{init source: optional}}
 
-                {{init source}}
-
-            {{deep copy}}
+            {{init copy: `bool`, optional}}
 
             instructions: `str`, optional
                 The ``aggregated_data`` attribute value found on the

--- a/cf/data/array/fullarray.py
+++ b/cf/data/array/fullarray.py
@@ -47,12 +47,9 @@ class FullArray(Array):
                 will be set to `None` during the first `__getitem__`
                 call.
 
-            source: optional
-                Initialise the array from the given object.
+            {{init source: optional}}
 
-                {{init source}}
-
-            {{deep copy}}
+            {{init copy: `bool`, optional}}
 
         """
         super().__init__(source=source, copy=copy)

--- a/cf/data/array/umarray.py
+++ b/cf/data/array/umarray.py
@@ -92,12 +92,9 @@ class UMArray(FileArray):
                 unset then the calendar will be set during the first
                 `__getitem__` call.
 
-            source: optional
-                Initialise the array from the given object.
+            {{init source: optional}}
 
-                {{init source}}
-
-            {{deep copy}}
+            {{init copy: `bool`, optional}}
 
         """
         super().__init__(source=source, copy=copy)

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -253,11 +253,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
 
                 .. versionadded:: 3.0.5
 
-            source: optional
-                Initialise the data values and metadata (such as
-                units, mask hardness, etc.) from the data of
-                *source*. All other arguments, with the exception of
-                *copy*, are ignored.
+            {{init source: optional}}
 
             hardmask: `bool`, optional
                 If False then the mask is soft. By default the mask is
@@ -268,9 +264,7 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
                 given by the *array* parameter are re-interpreted as
                 date-time objects. By default they are not.
 
-            copy: `bool`, optional
-                If False then do not deep copy input parameters prior to
-                initialisation. By default arguments are deep copied.
+            {{init copy: `bool`, optional}}
 
             {{chunks: `int`, `tuple`, `dict` or `str`, optional}}
 

--- a/cf/data/fragment/missingfragmentarray.py
+++ b/cf/data/fragment/missingfragmentarray.py
@@ -61,12 +61,9 @@ class MissingFragmentArray(FragmentArray):
 
             {{aggregated_calendar: `str` or `None`, optional}}
 
-            source: optional
-                Initialise the array from the given object.
+            {{init source: optional}}
 
-                {{init source}}
-
-            {{deep copy}}
+            {{init copy: `bool`, optional}}
 
         """
         if source is not None:

--- a/cf/data/fragment/netcdffragmentarray.py
+++ b/cf/data/fragment/netcdffragmentarray.py
@@ -62,12 +62,9 @@ class NetCDFFragmentArray(FragmentArray):
 
             {{aggregated_calendar: `str` or `None`, optional}}
 
-            source: optional
-                Initialise the array from the given object.
+            {{init source: optional}}
 
-                {{init source}}
-
-            {{deep copy}}
+            {{init copy: `bool`, optional}}
 
         """
         if source is not None:

--- a/cf/data/fragment/umfragmentarray.py
+++ b/cf/data/fragment/umfragmentarray.py
@@ -60,12 +60,9 @@ class UMFragmentArray(FragmentArray):
 
             {{aggregated_calendar: `str` or `None`, optional}}
 
-            source: optional
-                Initialise the array from the given object.
+            {{init source: optional}}
 
-                {{init source}}
-
-            {{deep copy}}
+            {{init copy: `bool`, optional}}
 
         """
         if source is not None:

--- a/cf/field.py
+++ b/cf/field.py
@@ -333,13 +333,9 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                 Properties may also be set after initialisation with the
                 `set_properties` and `set_property` methods.
 
-            source: optional
-                Initialise the properties, data and metadata constructs
-                from those of *source*.
+            {{init source: optional}}
 
-            copy: `bool`, optional
-                If False then do not deep copy input parameters prior to
-                initialisation. By default arguments are deep copied.
+            {{init copy: `bool`, optional}}
 
         """
         super().__init__(


### PR DESCRIPTION
Update docstring substitutions to mirror changes in `cfdm` 1.10.0.2.