### PR TITLE
Fix `Field.set_data` checking

### DIFF
--- a/cf/field.py
+++ b/cf/field.py
@@ -9922,7 +9922,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
 
         """
         data = self._Data(data, copy=False)
-
+            
         # Construct new field
         f = _inplace_enabled_define_and_cleanup(self)
 
@@ -9962,15 +9962,29 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
             # --------------------------------------------------------
             # Axes have been set
             # --------------------------------------------------------
+
+            # Check that the input data spans all of the size > 1 axes
+            sizes = set([axis.get_size() for axis in domain_axes.values()])
+            data_shape = set(data.shape)
+            sizes.discard(1)
+            data_shape.discard(1)
+            if data_shape != sizes:                
+                raise ValueError(
+                    "Can't set data: Input data must span all axes that "
+                    "have size greater than 1, as well as optionally "
+                    "spanning any size 1 axes."
+                )
+        
             if isinstance(axes, (str, int, slice)):
-                axes = (axes,)
+                axes = (axes,) 
 
             axes = [f.domain_axis(axis, key=True) for axis in axes]
 
             if len(axes) != data.ndim:
                 raise ValueError(
-                    f"Can't set data: {len(axes)} axes provided, but "
-                    f"{data.ndim} needed"
+                    f"Can't set data: Input data spans {data.ndim} "
+                    f"dimensions, but only {len(axes)} were specified by "
+                    "the 'axes' parameter."
                 )
 
             for axis, size in zip(axes, data.shape):
@@ -9980,8 +9994,9 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                         domain_axes[axis].get_size(None) for axis in axes
                     )
                     raise ValueError(
-                        f"Can't set data: Data shape {data.shape} differs "
-                        f"from shape implied by axes {axes}: {axes_shape}"
+                        f"Can't set data: Input data shape {data.shape} "
+                        f"differs from shape implied by the given axes "
+                        f"{axes}: {axes_shape}"
                     )
 
         elif f.get_data_axes(default=None) is None:

--- a/cf/field.py
+++ b/cf/field.py
@@ -9922,7 +9922,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
 
         """
         data = self._Data(data, copy=False)
-            
+
         # Construct new field
         f = _inplace_enabled_define_and_cleanup(self)
 
@@ -9968,15 +9968,15 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
             data_shape = set(data.shape)
             sizes.discard(1)
             data_shape.discard(1)
-            if data_shape != sizes:                
+            if data_shape != sizes:
                 raise ValueError(
                     "Can't set data: Input data must span all axes that "
                     "have size greater than 1, as well as optionally "
                     "spanning any size 1 axes."
                 )
-        
+
             if isinstance(axes, (str, int, slice)):
-                axes = (axes,) 
+                axes = (axes,)
 
             axes = [f.domain_axis(axis, key=True) for axis in axes]
 

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -2570,27 +2570,6 @@ class FieldTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             f.auxiliary_to_dimension("latitude")
 
-    def test_Field_set_data(self):
-        f = cf.example_field(0)
-
-        # Test 'axes' parameter
-        f.set_data(f.data, axes=["Y", "X"])
-
-        with self.assertRaises(ValueError):
-            f.set_data(f.data.transpose(), axes=["Y", "X"])
-
-        with self.assertRaises(ValueError):
-            f.set_data(f.data, axes=["Y"])
-
-        with self.assertRaises(ValueError):
-            f.set_data(f.data[0], axes=["Y", "X"])
-
-        with self.assertRaises(ValueError):
-            f.set_data(f.data, axes=["T", "X"])
-
-        with self.assertRaises(ValueError):
-            f.set_data(f.data[0], axes=["T", "X"])
-
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -1020,15 +1020,6 @@ class FieldTest(unittest.TestCase):
         with self.assertRaises(Exception):
             g.set_data(cf.Data(9), axes="X")
 
-        g = cf.Field()
-        a = g.set_construct(cf.DomainAxis(9))
-        b = g.set_construct(cf.DomainAxis(10))
-        g.set_data(cf.Data(list(range(9))), axes=a)
-        with self.assertRaises(Exception):
-            g.set_data(cf.Data(list(range(9))), axes=b)
-        with self.assertRaises(Exception):
-            g.set_data(cf.Data(list(range(9))), axes=[b, a])
-
         # Test inplace
         f = self.f.copy()
         d = f.del_data()
@@ -1054,6 +1045,35 @@ class FieldTest(unittest.TestCase):
             g.set_data(cf.Data(numpy.arange(8)))
         with self.assertRaises(Exception):
             g.set_data(cf.Data(numpy.arange(90).reshape(10, 9)))
+
+        # Test 'axes' parameter
+        g = cf.Field()
+        a = g.set_construct(cf.DomainAxis(9))
+        b = g.set_construct(cf.DomainAxis(10))
+        with self.assertRaises(Exception):
+            g.set_data(cf.Data(list(range(9))), axes=a)
+        with self.assertRaises(Exception):
+            g.set_data(cf.Data(list(range(9))), axes=b)
+        with self.assertRaises(Exception):
+            g.set_data(cf.Data(list(range(9))), axes=[b, a])
+
+        f = cf.example_field(0)
+        f.set_data(f.data, axes=["Y", "X"])
+
+        with self.assertRaises(ValueError):
+            f.set_data(f.data.transpose(), axes=["Y", "X"])
+
+        with self.assertRaises(ValueError):
+            f.set_data(f.data, axes=["Y"])
+
+        with self.assertRaises(ValueError):
+            f.set_data(f.data[0], axes=["Y", "X"])
+
+        with self.assertRaises(ValueError):
+            f.set_data(f.data, axes=["T", "X"])
+
+        with self.assertRaises(ValueError):
+            f.set_data(f.data[0], axes=["T", "X"])
 
     def test_Field_get_data_axes(self):
         f = self.f
@@ -2554,24 +2574,23 @@ class FieldTest(unittest.TestCase):
         f = cf.example_field(0)
 
         # Test 'axes' parameter
-        f.set_data(f.data, axes=['Y', 'X'])
+        f.set_data(f.data, axes=["Y", "X"])
 
         with self.assertRaises(ValueError):
-            f.set_data(f.data.transpose(), axes=['Y', 'X'])
+            f.set_data(f.data.transpose(), axes=["Y", "X"])
 
         with self.assertRaises(ValueError):
-            f.set_data(f.data, axes=['Y'])
+            f.set_data(f.data, axes=["Y"])
 
         with self.assertRaises(ValueError):
-            f.set_data(f.data[0], axes=['Y', 'X'])
+            f.set_data(f.data[0], axes=["Y", "X"])
 
         with self.assertRaises(ValueError):
-            f.set_data(f.data, axes=['T', 'X'])
+            f.set_data(f.data, axes=["T", "X"])
 
         with self.assertRaises(ValueError):
-            f.set_data(f.data[0], axes=['T', 'X'])
+            f.set_data(f.data[0], axes=["T", "X"])
 
-        
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -2550,6 +2550,28 @@ class FieldTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             f.auxiliary_to_dimension("latitude")
 
+    def test_Field_set_data(self):
+        f = cf.example_field(0)
+
+        # Test 'axes' parameter
+        f.set_data(f.data, axes=['Y', 'X'])
+
+        with self.assertRaises(ValueError):
+            f.set_data(f.data.transpose(), axes=['Y', 'X'])
+
+        with self.assertRaises(ValueError):
+            f.set_data(f.data, axes=['Y'])
+
+        with self.assertRaises(ValueError):
+            f.set_data(f.data[0], axes=['Y', 'X'])
+
+        with self.assertRaises(ValueError):
+            f.set_data(f.data, axes=['T', 'X'])
+
+        with self.assertRaises(ValueError):
+            f.set_data(f.data[0], axes=['T', 'X'])
+
+        
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())


### PR DESCRIPTION
Tightens up `Field.set_data` checking, preventing some cases that could cause inconsistencies downstream failures - better to trap the failures in set_data. 