### PR TITLE
Handle the renaming of ESMF Python module

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -20,6 +20,8 @@ version 3.15.0
   (https://github.com/NCAS-CMS/cf-python/issues/626)
 * Removed benign UserWarning from `cf.Field.percentile`
   (https://github.com/NCAS-CMS/cf-python/issues/619)
+* Handled the renaming of the ESMF Python interface from `ESMF` to
+  `esmpy` at version 8.4.0. Both module names are accepted for now.
 * Changed dependency: ``1.10.1.0<=cfdm<1.10.2.0``
 
 ----

--- a/cf/__init__.py
+++ b/cf/__init__.py
@@ -103,7 +103,11 @@ from packaging.version import Version
 import importlib.util
 import platform
 
-_found_ESMF = bool(importlib.util.find_spec("ESMF"))
+# ESMF renamed its Python module to `esmpy` at ESMF version 8.4.0. Allow
+# either for now for backwards compatibility.
+_found_esmpy = bool(
+    importlib.util.find_spec("esmpy") or importlib.util.find_spec("ESMF")
+)
 
 try:
     import netCDF4

--- a/cf/constants.py
+++ b/cf/constants.py
@@ -44,8 +44,8 @@ in cf.
       default directory used by the :mod:`tempfile` module.
 
     REGRID_LOGGING: `bool`
-      Whether or not to enable `ESMF` logging. If it is logging is
-      performed after every call to `ESMF`. By default logging is
+      Whether or not to enable `esmpy` logging. If it is logging is
+      performed after every call to `esmpy`. By default logging is
       disabled.
 
     LOG_LEVEL: `str`

--- a/cf/data/dask_regrid.py
+++ b/cf/data/dask_regrid.py
@@ -137,7 +137,7 @@ def regrid(
             the regridded field is masked.
 
             The default value has been chosen empirically as the
-            smallest value that produces the same masks as ESMF for
+            smallest value that produces the same masks as esmpy for
             the use cases defined in the cf test suite.
 
             **Linear regridding**

--- a/cf/docstring/docstring.py
+++ b/cf/docstring/docstring.py
@@ -65,19 +65,19 @@ _docstring_substitution_definitions = {
     "{{regrid Implementation}}": """**Implementation**
 
         The interpolation is carried out using regridding weights
-        calculated by the `ESMF` package, a Python interface to the
-        Earth System Modeling Framework (ESMF) regridding utility:
-        `https://earthsystemmodeling.org/regrid`_. Outside of `ESMF`,
+        calculated by the `esmpy` package, a Python interface to the
+        Earth System Modeling Framework (esmpy) regridding utility:
+        `https://earthsystemmodeling.org/regrid`_. Outside of `esmpy`,
         these weights are then modified for masked cells (if required)
         and the regridded data are created as the dot product of the
-        weights with the source data. (Note that whilst the `ESMF`
+        weights with the source data. (Note that whilst the `esmpy`
         package is able to also create the regridded data from its
         weights, this feature can't be integrated with the `dask`
         framework that underpins the field's data.)""",
     # regrid Logging
     "{{regrid Logging}}": """**Logging**
 
-        Whether `ESMF` logging is enabled or not is determined by
+        Whether `esmpy` logging is enabled or not is determined by
         `cf.regrid_logging`. If it is logging takes place after every
         call. By default logging is disabled.""",
     # ----------------------------------------------------------------
@@ -392,7 +392,7 @@ _docstring_substitution_definitions = {
                 a point) are skipped, not producing a
                 result. Otherwise an error will be produced if
                 degenerate cells are found, that will be present in
-                the ESMF log files.
+                the esmpy log files.
 
                 For all other regridding methods, degenerate cells are
                 always skipped, regardless of the value of
@@ -431,7 +431,7 @@ _docstring_substitution_definitions = {
                 cell in the regridded field is masked.
 
                 The default value has been chosen empirically as the
-                smallest value that produces the same masks as ESMF
+                smallest value that produces the same masks as esmpy
                 for the use cases defined in the cf test suite.
 
                 Define w_ji as the multiplicative weight that defines

--- a/cf/docstring/docstring.py
+++ b/cf/docstring/docstring.py
@@ -66,7 +66,7 @@ _docstring_substitution_definitions = {
 
         The interpolation is carried out using regridding weights
         calculated by the `esmpy` package, a Python interface to the
-        Earth System Modeling Framework (esmpy) regridding utility:
+        Earth System Modeling Framework (ESMF) regridding utility:
         `https://earthsystemmodeling.org/regrid`_. Outside of `esmpy`,
         these weights are then modified for masked cells (if required)
         and the regridded data are created as the dot product of the

--- a/cf/functions.py
+++ b/cf/functions.py
@@ -536,9 +536,9 @@ class log_level(ConstantAccess, cfdm.log_level):
 
 
 class regrid_logging(ConstantAccess):
-    """Whether or not to enable `ESMF` regridding logging.
+    """Whether or not to enable `esmpy` regridding logging.
 
-    If it is logging is performed after every call to `ESMF`.
+    If it is logging is performed after every call to `esmpy`.
 
     :Parameters:
 
@@ -2978,17 +2978,30 @@ def _section(x, axes=None, stop=None, chunks=False, min_step=1):
     return out
 
 
-def _get_module_info(module, try_except=False):
+def _get_module_info(module, alternative_name=False, try_except=False):
     """Helper function for processing modules for cf.environment."""
     if try_except:
+        module_name = None
         try:
             importlib.import_module(module)
+            module_name = module
         except ImportError:
+            pass  # to avoid a nested try/except which is less clean
+        if alternative_name:  # where a module has a different (e.g. old) name
+            try:
+                importlib.import_module(alternative_name)
+                module_name = alternative_name
+            except ImportError:
+                pass
+
+        if not module_name:
             return ("not available", "")
+    else:
+        module_name = module
 
     return (
-        importlib.import_module(module).__version__,
-        importlib.util.find_spec(module).origin,
+        importlib.import_module(module_name).__version__,
+        importlib.util.find_spec(module_name).origin,
     )
 
 
@@ -3021,7 +3034,7 @@ def environment(display=True, paths=True):
     HDF5 library: 1.10.6
     netcdf library: 4.8.0
     udunits2 library: /home/username/anaconda3/envs/cf-env/lib/libudunits2.so.0
-    ESMF: 8.1.1 /home/username/anaconda3/envs/cf-env/lib/python3.8/site-packages/ESMF/__init__.py
+    esmpy: 8.1.1 /home/username/anaconda3/envs/cf-env/lib/python3.8/site-packages/esmpy/__init__.py
     Python: 3.8.10 /home/username/anaconda3/envs/cf-env/bin/python
     dask: 2022.6.0 /home/username/anaconda3/envs/cf-env/lib/python3.8/site-packages/dask/__init__.py
     netCDF4: 1.5.6 /home/username/anaconda3/envs/cf-env/lib/python3.8/site-packages/netCDF4/__init__.py
@@ -3041,7 +3054,7 @@ def environment(display=True, paths=True):
     HDF5 library: 1.10.6
     netcdf library: 4.8.0
     udunits2 library: libudunits2.so.0
-    ESMF: 8.1.1
+    esmpy: 8.1.1
     Python: 3.8.10
     dask: 2022.6.0
     netCDF4: 1.5.6
@@ -3064,7 +3077,9 @@ def environment(display=True, paths=True):
         "HDF5 library": (netCDF4.__hdf5libversion__, ""),
         "netcdf library": (netCDF4.__netcdf4libversion__, ""),
         "udunits2 library": (ctypes.util.find_library("udunits2"), ""),
-        "ESMF": _get_module_info("ESMF", try_except=True),
+        "esmpy/ESMF": (
+            _get_module_info("esmpy", alternative_name="ESMF", try_except=True)
+        ),
         # Now Python itself
         "Python": (platform.python_version(), sys.executable),
         # Then Dask (cover first from below as it's important under-the-hood)

--- a/cf/functions.py
+++ b/cf/functions.py
@@ -3034,7 +3034,7 @@ def environment(display=True, paths=True):
     HDF5 library: 1.10.6
     netcdf library: 4.8.0
     udunits2 library: /home/username/anaconda3/envs/cf-env/lib/libudunits2.so.0
-    esmpy: 8.1.1 /home/username/anaconda3/envs/cf-env/lib/python3.8/site-packages/esmpy/__init__.py
+    esmpy/ESMF: 8.4.1 /home/username/anaconda3/envs/cf-env/lib/python3.8/site-packages/esmpy/__init__.py
     Python: 3.8.10 /home/username/anaconda3/envs/cf-env/bin/python
     dask: 2022.6.0 /home/username/anaconda3/envs/cf-env/lib/python3.8/site-packages/dask/__init__.py
     netCDF4: 1.5.6 /home/username/anaconda3/envs/cf-env/lib/python3.8/site-packages/netCDF4/__init__.py
@@ -3054,7 +3054,7 @@ def environment(display=True, paths=True):
     HDF5 library: 1.10.6
     netcdf library: 4.8.0
     udunits2 library: libudunits2.so.0
-    esmpy: 8.1.1
+    esmpy/ESMF: 8.4.1
     Python: 3.8.10
     dask: 2022.6.0
     netCDF4: 1.5.6

--- a/cf/regrid/regrid.py
+++ b/cf/regrid/regrid.py
@@ -14,11 +14,22 @@ from .regridoperator import RegridOperator
 # either for now for backwards compatibility.
 esmpy_imported = False
 try:
+    # Take the new name to use.
     import ESMF as esmpy
+
     esmpy_imported = True
 except ImportError:
-    import esmpy
+    pass  # avoid nested try/except...
+try:
+    # Ignore flake8 error about redefining the esmpy variable since that's
+    # deliberate and besides both modules won't be installed at once, but
+    # if so somehow then take the newer one (by nature of the name), esmpy.
+    import esmpy  # noqa: F811
+
     esmpy_imported = True
+except ImportError:
+    pass
+
 
 logger = logging.getLogger(__name__)
 

--- a/cf/regrid/regrid.py
+++ b/cf/regrid/regrid.py
@@ -10,6 +10,8 @@ from ..functions import DeprecationError, regrid_logging
 from ..units import Units
 from .regridoperator import RegridOperator
 
+# ESMF renamed its Python module to `esmpy` at ESMF version 8.4.0. Allow
+# either for now for backwards compatibility.
 esmpy_imported = False
 try:
     import ESMF as esmpy

--- a/cf/test/test_regrid.py
+++ b/cf/test/test_regrid.py
@@ -140,8 +140,7 @@ class RegridTest(unittest.TestCase):
     dst = dst_src[0]
     src = dst_src[1]
 
-    @unittest.skipUnless(esmpy_imported, "Requires esmpy package.")
-    # @unittest.skipUnless(False, "Requires esmpy package.")
+    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_Field_regrid_2d_field(self):
         """2-d regridding with Field destination grid."""
         self.assertFalse(cf.regrid_logging())
@@ -292,7 +291,7 @@ class RegridTest(unittest.TestCase):
             with self.assertRaises(ValueError):
                 src.regrids(dst, method=method).array
 
-    @unittest.skipUnless(esmpy_imported, "Requires esmpy package.")
+    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_Field_regrids_coords(self):
         """Spherical regridding with coords destination grid."""
         dst = self.dst.copy()
@@ -360,7 +359,7 @@ class RegridTest(unittest.TestCase):
         d1 = src.regrids(r)
         self.assertTrue(d1.data.equals(d0.data, atol=atol, rtol=rtol))
 
-    @unittest.skipUnless(esmpy_imported, "Requires esmpy package.")
+    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_Field_regridc_2d_coords(self):
         """2-d Cartesian regridding with coords destination grid."""
         dst = self.dst.copy()
@@ -400,7 +399,7 @@ class RegridTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.src.regrids("foobar", method="conservative")
 
-    @unittest.skipUnless(esmpy_imported, "Requires esmpy package.")
+    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_Field_regrids_domain(self):
         """Spherical regridding with Domain destination grid."""
         dst = self.dst
@@ -422,7 +421,7 @@ class RegridTest(unittest.TestCase):
         d1 = src.regrids(r)
         self.assertTrue(d1.equals(d0, atol=atol, rtol=rtol))
 
-    @unittest.skipUnless(esmpy_imported, "Requires esmpy package.")
+    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_Field_regridc_domain(self):
         """Spherical regridding with Domain destination grid."""
         dst = self.dst
@@ -446,7 +445,7 @@ class RegridTest(unittest.TestCase):
         d1 = src.regridc(r)
         self.assertTrue(d1.equals(d0, atol=atol, rtol=rtol))
 
-    @unittest.skipUnless(esmpy_imported, "Requires esmpy package.")
+    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_Field_regrids_field_operator(self):
         """Spherical regridding with operator destination grid."""
         dst = self.dst
@@ -482,7 +481,7 @@ class RegridTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             dst.regrids(r)
 
-    @unittest.skipUnless(esmpy_imported, "Requires esmpy package.")
+    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_Field_regrids_non_coordinates(self):
         """Check setting of non-coordinate metadata."""
         dst = cf.example_field(1)
@@ -529,7 +528,7 @@ class RegridTest(unittest.TestCase):
         # Cell measures
         self.assertFalse(d1.cell_measures())
 
-    @unittest.skipUnless(esmpy_imported, "Requires esmpy package.")
+    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_Field_regridc_3d_field(self):
         """3-d Cartesian regridding with Field destination grid."""
         methods = list(all_methods)
@@ -630,7 +629,7 @@ class RegridTest(unittest.TestCase):
             with self.assertRaises(ValueError):
                 src.regridc(dst, method=method, axes=axes)
 
-    @unittest.skipUnless(esmpy_imported, "Requires esmpy package.")
+    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_Field_regridc_1d_field(self):
         """1-d Cartesian regridding with Field destination grid."""
         methods = list(all_methods)

--- a/cf/test/test_regrid.py
+++ b/cf/test/test_regrid.py
@@ -13,13 +13,21 @@ import cf
 # either for now for backwards compatibility.
 esmpy_imported = False
 try:
+    # Take the new name to use.
     import ESMF as esmpy
 
     esmpy_imported = True
 except ImportError:
-    import esmpy
+    pass  # avoid nested try/except...
+try:
+    # Ignore flake8 error about redefining the esmpy variable since that's
+    # deliberate and besides both modules won't be installed at once, but
+    # if so somehow then take the newer one (by nature of the name), esmpy.
+    import esmpy  # noqa: F811
 
     esmpy_imported = True
+except ImportError:
+    pass
 
 
 all_methods = (


### PR DESCRIPTION
Close #633. Note the following:

* As discussed, we are allowing either `esmpy` (new name) or `esmf` (old) to be imported for backwards compatibility, for now, as advertised on the new change log entry.
* As part of this, to cater for that, I updated the internal `_get_module_info` function to cater for a possible alternative module name, since that might occur for other modules, but even if not it allows that method to be re-used for this case as it was before. Now `cf.environment` picks up the module under either name, so is listed as `esmpy/ESMF` rather than `ESMF` in the output dict.
* All `ESMF_*` methods (e.g. ) have become `esmpy_*` methods (now `esmpy_regrid_1d`), i.e. the name conversion has also been made on method names. This makes sense to me, because the capitalised old name was defying naming conventions for methods and was ugly and weird in that way, plus now we use the newer name going forward. But please do confirm that this is OK, since it is an API change. (ON a related note, very few of those methods seem to be documented - is that something that needs addressing?)

#### Other issues flagged

*I don't think this is related to this PR, but I need to investigate further.) `test_Field_regrid_2d_field` is currently hanging for me locally (I can't test this on `main` without downgrading my ESMPy and conda hates downgrading anything so it will be a bit tricky to check quickly...). With the PR, all other `test_regrid.py` methods pass and in fact the whole test suite passes other than that when I skip it to stop to hanging, indicating things are fine otherwise.

Please let me know if you see this too! I suspect it could be to do with the newer ESMPy version and I will bump this to a new issue if we see further evidence of that!

Specifically, it hangs (I waited 5 mins or so before assuming that) so I apply:

```diff
diff --git a/cf/test/test_regrid.py b/cf/test/test_regrid.py
index ec4c9a4a0..34317cd7e 100644
--- a/cf/test/test_regrid.py
+++ b/cf/test/test_regrid.py
@@ -140,7 +140,8 @@ class RegridTest(unittest.TestCase):
     dst = dst_src[0]
     src = dst_src[1]
 
-    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
+    @unittest.skipIf(True, "HANGING BUT WHY?")
+    # Unless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_Field_regrid_2d_field(self):
         """2-d regridding with Field destination grid."""
         self.assertFalse(cf.regrid_logging())
```

to skip the hanging test and everything passes:

```console
$ py test_regrid.py 
Run date: 2023-04-26 09:49:42.736762
Platform: Linux-4.15.0-54-generic-x86_64-with-glibc2.10 
HDF5 library: 1.14.0 
netcdf library: 4.9.2 
udunits2 library: /home/sadie/anaconda3/envs/cf-env/lib/libudunits2.so.0 
esmpy/ESMF: 8.4.1 /home/sadie/anaconda3/envs/cf-env/lib/python3.8/site-packages/esmpy/__init__.py
Python: 3.8.16 /home/sadie/anaconda3/envs/cf-env/bin/python
dask: 2023.1.0 /home/sadie/anaconda3/envs/cf-env/lib/python3.8/site-packages/dask/__init__.py
netCDF4: 1.6.3 /home/sadie/anaconda3/envs/cf-env/lib/python3.8/site-packages/netCDF4/__init__.py
psutil: 5.9.4 /home/sadie/anaconda3/envs/cf-env/lib/python3.8/site-packages/psutil/__init__.py
packaging: 23.0 /home/sadie/anaconda3/envs/cf-env/lib/python3.8/site-packages/packaging/__init__.py
numpy: 1.24.2 /home/sadie/anaconda3/envs/cf-env/lib/python3.8/site-packages/numpy/__init__.py
scipy: 1.10.1 /home/sadie/anaconda3/envs/cf-env/lib/python3.8/site-packages/scipy/__init__.py
matplotlib: 3.4.3 /home/sadie/anaconda3/envs/cf-env/lib/python3.8/site-packages/matplotlib/__init__.py
cftime: 1.6.0 /home/sadie/anaconda3/envs/cf-env/lib/python3.8/site-packages/cftime/__init__.py
cfunits: 3.3.5 /home/sadie/cfunits/cfunits/__init__.py
cfplot: 3.1.18 /home/sadie/anaconda3/envs/cf-env/lib/python3.8/site-packages/cfplot/__init__.py
cfdm: 1.10.1.0 /home/sadie/cfdm/cfdm/__init__.py
cf: 3.14.1 /home/sadie/cf-python/cf/__init__.py

test_Field_regrid_2d_field (__main__.RegridTest)
2-d regridding with Field destination grid. ... skipped 'HANGING BUT WHY?'
test_Field_regridc_1d_field (__main__.RegridTest)
1-d Cartesian regridding with Field destination grid. ... ok
test_Field_regridc_2d_coords (__main__.RegridTest)
2-d Cartesian regridding with coords destination grid. ... ok
test_Field_regridc_3d_field (__main__.RegridTest)
3-d Cartesian regridding with Field destination grid. ... ok
test_Field_regridc_domain (__main__.RegridTest)
Spherical regridding with Domain destination grid. ... ok
test_Field_regrids_bad_dst (__main__.RegridTest)
Disallowed destination grid types raise an exception. ... ok
test_Field_regrids_coords (__main__.RegridTest)
Spherical regridding with coords destination grid. ... ok
test_Field_regrids_domain (__main__.RegridTest)
Spherical regridding with Domain destination grid. ... ok
test_Field_regrids_field_operator (__main__.RegridTest)
Spherical regridding with operator destination grid. ... ok
test_Field_regrids_non_coordinates (__main__.RegridTest)
Check setting of non-coordinate metadata. ... ok

----------------------------------------------------------------------
Ran 10 tests in 26.558s

OK (skipped=1)
```