### PR TITLE
Fix bug when reading single level (e.g. surface) UM files

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -18,6 +18,8 @@ version 3.15.0
 * Fixed bug in `cf.Field.compute_vertical_coordinates` that retained
   incorrect bounds properties
   (https://github.com/NCAS-CMS/cf-python/issues/626)
+* Fixed bug in when reading single level (e.g. surface) UM files
+  (https://github.com/NCAS-CMS/cf-python/issues/641)
 * Removed benign UserWarning from `cf.Field.percentile`
   (https://github.com/NCAS-CMS/cf-python/issues/619)
 * Handled the renaming of the ESMF Python interface from `ESMF` to

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -18,7 +18,7 @@ version 3.15.0
 * Fixed bug in `cf.Field.compute_vertical_coordinates` that retained
   incorrect bounds properties
   (https://github.com/NCAS-CMS/cf-python/issues/626)
-* Fixed bug in when reading single level (e.g. surface) UM files
+* Fixed bug when reading single level (e.g. surface) UM files
   (https://github.com/NCAS-CMS/cf-python/issues/641)
 * Removed benign UserWarning from `cf.Field.percentile`
   (https://github.com/NCAS-CMS/cf-python/issues/619)

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -18,8 +18,6 @@ version 3.15.0
 * Fixed bug in `cf.Field.compute_vertical_coordinates` that retained
   incorrect bounds properties
   (https://github.com/NCAS-CMS/cf-python/issues/626)
-* Fixed bug when reading single level (e.g. surface) UM files
-  (https://github.com/NCAS-CMS/cf-python/issues/641)
 * Removed benign UserWarning from `cf.Field.percentile`
   (https://github.com/NCAS-CMS/cf-python/issues/619)
 * Handled the renaming of the ESMF Python interface from `ESMF` to

--- a/cf/read_write/um/umread.py
+++ b/cf/read_write/um/umread.py
@@ -1970,7 +1970,7 @@ class UMField:
                 # ----------------------------------------------------
                 # 1-d partition matrix
                 # ----------------------------------------------------
-                z_axis = _axis[self.z_axis]
+                z_axis = _axis.get(self.z_axis)
                 if nz > 1:
                     pmaxes = [z_axis]
                     data_shape = (nz, LBROW, LBNPT)

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -255,7 +255,7 @@ environments for which these features are not required.
 
 .. rubric:: Convolution filters, derivatives and relative vorticity
 
-* `scipy <https://pypi.org/project/scipy>`_, version 1.1.0 or newer.
+* `scipy <https://pypi.org/project/scipy>`_, version 1.10.0 or newer.
 
 .. rubric:: Subspacing based on N-dimensional construct cells (N > 1)
             containing a given value

--- a/docs/source/tutorial.py
+++ b/docs/source/tutorial.py
@@ -758,9 +758,8 @@ print(q.creation_commands())
 import netCDF4
 nc = netCDF4.Dataset('file.nc', 'r')
 v = nc.variables['ta']
-netcdf_array = cf.NetCDFArray(filename='file.nc', ncvar='ta',
-                               dtype=v.dtype, ndim=v.ndim,
-     		  	       shape=v.shape, size=v.size)
+netcdf_array = cf.NetCDFArray(filename='file.nc', address='ta',
+                               dtype=v.dtype, shape=v.shape)
 data_disk = cf.Data(netcdf_array)
 numpy_array = v[...]
 data_memory = cf.Data(numpy_array)

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -4539,9 +4539,8 @@ used to initialise a `cf.Data` instance.
    >>> import netCDF4
    >>> nc = netCDF4.Dataset('file.nc', 'r')
    >>> v = nc.variables['ta']
-   >>> netcdf_array = cf.NetCDFArray(filename='file.nc', ncvar='ta',
-   ...	                               dtype=v.dtype, ndim=v.ndim,
-   ...	     		  	       shape=v.shape, size=v.size)
+   >>> netcdf_array = cf.NetCDFArray(filename='file.nc', address='ta',
+   ...	                               dtype=v.dtype, shape=v.shape)
    >>> data_disk = cf.Data(netcdf_array)
 
   


### PR DESCRIPTION
Fixes #641 

Also some minor fixes for new syntax in the `tutorial.rst`; and increase the `scipy` minimum version (so that `from scipy.signal import window` is sure to work).