### PR TITLE
Correct `units` test in `propertiesdata.set_data`

### DIFF
--- a/cf/mixin/propertiesdata.py
+++ b/cf/mixin/propertiesdata.py
@@ -5577,7 +5577,7 @@ class PropertiesData(Properties):
 
         if not data.Units:
             units = self.Units
-            if units is not None:
+            if units:
                 if copy:
                     copy = False
                     data = data.override_units(units, inplace=False)

--- a/cf/test/test_DimensionCoordinate.py
+++ b/cf/test/test_DimensionCoordinate.py
@@ -626,6 +626,13 @@ class DimensionCoordinateTest(unittest.TestCase):
         self.assertEqual(d.data.chunks, ((1,) * d.size,))
         self.assertEqual(d.bounds.data.chunks, ((1,) * d.size, (2,)))
 
+    def test_DimensiconCoordinate_set_data(self):
+        """Test the `set_data` DimensionCoordinate method."""
+        # Test set_data when the units are invalid
+        units = "bad units"
+        d = cf.DimensionCoordinate(data=cf.Data([1, 2], units=units))
+        self.assertEqual(d.units, units)
+
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())


### PR DESCRIPTION
The original tested `if units is not None:` with `units` being a `cf.Units` object. This is nonsense, so the test should be `if units:`.

The new test is for the use case that brought this to light.