### PR TITLE
Fix bug in `cf.read` for some PP data with a single vertical level

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -1,3 +1,13 @@
+version ?.?.?
+--------------
+
+**2023-??-??**
+
+* Fix bug that caused `cf.read` to fail for some PP data with a single
+  vertical level (https://github.com/NCAS-CMS/cf-python/issues/667)
+  
+----
+
 version 3.15.1
 --------------
 

--- a/cf/read_write/um/umread.py
+++ b/cf/read_write/um/umread.py
@@ -2000,7 +2000,7 @@ class UMField:
 
                 indices = [(i, rec) for i, rec in enumerate(recs)]
 
-                if z_axis in self.down_axes:
+                if nz > 1 and z_axis in self.down_axes:
                     indices = self._reorder_z_axis(indices, z_axis, pmaxes)
 
                 for i, rec in indices:


### PR DESCRIPTION
Fixes #667

Prevents `_reorder_z_axis` from being called when there is only one Z level (and so there is nothing to reorder!).