### PR TITLE
Docs: remove or replace cases of some subjective filler terms

### DIFF
--- a/docs/source/field_analysis.rst
+++ b/docs/source/field_analysis.rst
@@ -331,7 +331,7 @@ In all collapses, missing data array elements are accounted for in the
 calculation.
 
 Any collapse method that involves a calculation (such as calculating a
-mean), as opposed to just selecting a value (such as finding a
+mean), as opposed to only selecting a value (such as finding a
 maximum), will return a field containing double precision floating
 point numbers. If this is not desired then the data type can be reset
 after the collapse with the `~Field.dtype` attribute of the field

--- a/docs/source/field_analysis.rst
+++ b/docs/source/field_analysis.rst
@@ -1584,7 +1584,7 @@ pressure coordinates after the regridding operation.
    Coord references: grid_mapping_name:rotated_latitude_longitude
 
 Note that the `~Field.replace_construct` method of the field construct
-is used to easily replace the vertical dimension coordinate construct,
+is used to directly replace the vertical dimension coordinate construct,
 without having to manually match up the corresponding domain axis
 construct and construct key.
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -77,7 +77,7 @@ Udunits
 
 Udunits (a C library that provides support for units of physical
 quantities) is a required dependency that is not installed by ``pip``,
-but it is easily installed in a ``conda`` environment:
+but it can be installed in a ``conda`` environment:
 
 .. code-block:: console
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -44,9 +44,9 @@ The cf package is only for Python 3.8 or newer.
 cf is in the Python package index: https://pypi.org/project/cf-python
 
 To install cf and its :ref:`required dependencies <Required>` (apart
-from :ref:`Udunits <Udunits>`, and there are also has some
+from :ref:`Udunits <Udunits>`, and there are also some
 :ref:`optional dependencies <Optional>` which are **not**
-automatically installed via ``pip``) run, for example :
+automatically installed via ``pip``) run, for example:
 
 .. code-block:: console
    :caption: *Install as root, with any missing dependencies.*
@@ -83,7 +83,7 @@ but it can be installed in a ``conda`` environment:
 
    $ conda install -c conda-forge udunits2
 
-Alternatively, Udunits is often available in from operating system
+Alternatively, Udunits is often available from operating system
 software download managers, or may be installed from source.
     
 Note that :ref:`some environment variables might also need setting
@@ -102,7 +102,7 @@ details.
 
 To install cf with all of its :ref:`required <Required>` and
 :ref:`optional <Optional>` dependencies, and the `cf-plot
-visualisation package <http://ajheaps.github.io/cf-plot>`_, run
+visualisation package <http://ajheaps.github.io/cf-plot>`_, run:
 
 .. code-block:: console
    :caption: *Install with conda.*
@@ -170,7 +170,7 @@ properly, although the defaults are usually sufficient.
 ---------------
 
 During installation the ``cfa`` command line utility is also
-installed, which
+installed, which:
 
 * :ref:`generates text descriptions of field constructs contained in
   files <File-inspection-with-cfa>`, and

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -113,8 +113,7 @@ manipulation and can:
 **Visualisation**
 -----------------
 
-
-Powerful and flexible visualisations of field
+Powerful, flexible, and user-friendly visualisations of field
 constructs are available with the `cf-plot` package that is installed
 separately to `cf` (see http://ajheaps.github.io/cf-plot for details).
 

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -38,7 +38,7 @@ to new datasets.This is so that datasets that are partially conformant
 may nonetheless be modified in memory.
 
 .. code-block:: python
-   :caption: *A simple example of reading a field construct from a
+   :caption: *A basic example of reading a field construct from a
              file and inspecting it.*
 
    >>> import cf
@@ -114,8 +114,8 @@ manipulation and can:
 -----------------
 
 
-Powerful, flexible, and very simple to produce visualisations of field
-constructs are available with the `cfplot` package, that is installed
+Powerful and flexible visualisations of field
+constructs are available with the `cfplot` package that is installed
 separately to `cf` (see http://ajheaps.github.io/cf-plot for details).
 
 See the `cfplot gallery

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -115,16 +115,16 @@ manipulation and can:
 
 
 Powerful and flexible visualisations of field
-constructs are available with the `cfplot` package that is installed
+constructs are available with the `cf-plot` package that is installed
 separately to `cf` (see http://ajheaps.github.io/cf-plot for details).
 
-See the `cfplot gallery
+See the `cf-plot gallery
 <http://ajheaps.github.io/cf-plot/gallery.html>`_ for the wide range
 of plotting possibilities with example code.
 
 .. figure:: images/cfplot_example.png
 
-   *Example output of cfplot displaying a cf field construct.*
+   *Example output of cf-plot displaying a cf field construct.*
 
 ----
 

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -120,7 +120,7 @@ separately to `cf` (see http://ajheaps.github.io/cf-plot for details).
 
 See the `cfplot gallery
 <http://ajheaps.github.io/cf-plot/gallery.html>`_ for the wide range
-range plotting possibilities with example code.
+of plotting possibilities with example code.
 
 .. figure:: images/cfplot_example.png
 

--- a/docs/source/performance.rst
+++ b/docs/source/performance.rst
@@ -156,8 +156,8 @@ For more information, see `Choosing good chunk sizes in Dask
 All operations on Dask arrays are executed in parallel using `Dask's
 dynamic task scheduling
 <https://docs.dask.org/en/stable/scheduling.html>`_. By default, the
-scheduler uses threads on the local machine, but it is easy to use
-instead local processes, a cluster of many machines, or a single
+scheduler uses threads on the local machine, but can instead use
+local processes, a cluster of many machines, or a single
 thread with no parallelism at all.
 
 Implementing a different scheduler is done via any of the methods

--- a/docs/source/performance.rst
+++ b/docs/source/performance.rst
@@ -190,7 +190,7 @@ available pool of processing elements, which execute the tasks in
 parallel until the final result has been computed.
 
 The following example creates a visualisation of the task graph for a
-simple data computation over four chunks:
+basic data computation over four chunks:
 
 .. code-block:: python
    :caption: *Visualising the task graph for a lazy computation.*

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -529,14 +529,14 @@ files <External-variables-with-cfa>`.
 **Visualisation**
 -----------------
 
-Powerful and flexible visualisations of field
-constructs are available with the `cfplot` package (that needs to be
+Powerful, flexible, and user-friendly visualisations of field
+constructs are available with the `cf-plot` package (that needs to be
 installed separately to cf, see http://ajheaps.github.io/cf-plot for
 details).
 
 .. figure:: images/cfplot_example.png
 
-   *Example output of cfplot displaying a cf field construct.*
+   *Example output of cf-plot displaying a cf field construct.*
 
 See the `cfplot gallery
 <http://ajheaps.github.io/cf-plot/gallery.html>`_ for the wide range

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -1851,9 +1851,9 @@ contains the selected metadata constructs.
    Constructs:
    {'cellmethod1': <CF CellMethod: domainaxis3: maximum>}
 
-As each of these methods returns a `cf.Constructs` instance, it is
-easy to perform further filters on their results:
-   
+As each of these methods returns a `cf.Constructs` instance, further
+filters can be performed directly on their results:
+
 .. code-block:: python
    :caption: *Make selections from previous selections.*
 	     
@@ -4220,8 +4220,8 @@ additional conventions.
 If this field were to be written to a netCDF dataset then, in the
 absence of predefined names, default netCDF variable and dimension
 names would be automatically generated (based on standard names where
-they exist). The setting of bespoke netCDF names is, however, easily
-done with the :ref:`netCDF interface <NetCDF-interface>`.
+they exist). The setting of bespoke netCDF names is, however, possible
+with the :ref:`netCDF interface <NetCDF-interface>`.
 
 .. code-block:: python
    :caption: *Set netCDF variable and dimension names for the field
@@ -6206,7 +6206,7 @@ file:
    >>> print(count_variable.array)
    [3 7 5 9]
 
-The timeseries for the second station is easily selected by indexing
+The timeseries for the second station is selected by indexing
 the "station" axis of the field construct:
 
 .. code-block:: python
@@ -6236,8 +6236,8 @@ data array elements are modified:
    >>> h.data.get_compression_type()
    ''
 
-Perhaps the easiest way to create a compressed field construct is to
-create the equivalent uncompressed field construct and then compress
+Perhaps the most direct way to create a compressed field construct is
+to create the equivalent uncompressed field construct and then compress
 it with its `~Field.compress` method, which also compresses the
 metadata constructs as required.
    
@@ -6466,7 +6466,7 @@ file:
 
 
 Subspaces based on the uncompressed axes of the field construct are
-easily created:
+created:
 
 .. code-block:: python
    :caption: *Get subspaces based on indices of the uncompressed
@@ -6666,7 +6666,7 @@ written to disk as netCDF files with `cf.write`.
 
 Alternatively, the ``cfa`` command line tool may be used with PP and UM
 fields files in exactly the same way as netCDF files. This provides a
-view of PP and UM fields files as CF field constructs, and also easily
+view of PP and UM fields files as CF field constructs, and also
 converts PP and UM fields files to netCDF datasets on disk.
 
 .. code-block:: console

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -529,7 +529,7 @@ files <External-variables-with-cfa>`.
 **Visualisation**
 -----------------
 
-Powerful, flexible, and very simple to produce visualisations of field
+Powerful and flexible visualisations of field
 constructs are available with the `cfplot` package (that needs to be
 installed separately to cf, see http://ajheaps.github.io/cf-plot for
 details).
@@ -5668,7 +5668,7 @@ groups struct (if any) intact. It is always possible, however, to
 create a "flat" dataset, i.e. one without any sub-groups. This does
 not require the removal of the group structure from the field
 construct and all of its components (although that is possible), as it
-can be done by simply by overriding the existing group structure by
+can be done via overriding the existing group structure by
 setting the *group* keyword to `cf.write` to `False`.
    
 .. code-block:: python
@@ -5746,7 +5746,7 @@ read from the flat version of the file:
 but which are not present in it. Instead, such variables are stored in
 other netCDF files known as "external files". External variables may,
 however, be incorporated into the field constructs of the dataset, as
-if they had actually been stored in the same file, simply by providing
+if they had actually been stored in the same file, by providing
 the external file names to the `cf.read` function.
 
 This is illustrated with the files ``parent.nc`` (found in the
@@ -6493,7 +6493,7 @@ data array elements are modified:
 A construct with an underlying gathered array is created by
 initialising a `cf.Data` instance with a gathered array that is stored
 in the special `cf.GatheredArray` array object. The following code
-creates a simple field construct with an underlying gathered array:
+creates a basic field construct with an underlying gathered array:
 
 .. Code Block Start 6
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -1311,7 +1311,7 @@ the dataset, may subsequently be applied manually with the
 The `~Field.apply_masking` method of the field construct utilises as
 many of the ``missing_value``, ``_FillValue``, ``valid_min``,
 ``valid_max``, and ``valid_range`` properties as are present and may
-be used on any construct, not just those that have been read from
+be used on any construct, not only those that have been read from
 datasets.
     
 ----
@@ -1337,7 +1337,7 @@ indexing rules
 the only differences being:
 
 * An integer index *i* specified for a dimension reduces the size of
-  this dimension to unity, taking just the *i*\ -th element, but keeps
+  this dimension to unity, taking only the *i*\ -th element, but keeps
   the dimension itself, so that the rank of the array is not reduced.
 
 ..


### PR DESCRIPTION
Remove or replace the use of the words across the documentation that are considered bad practice (see, for example, [the Google dev docs style guide list of words to not use or to avoid](https://developers.google.com/style/word-list)) given the implication that something is easy when a user might not find it so, and that they are also effectively filler words so unnecessary, namely (see the case-by-case commits which tackle all cases of use of each related term):

* "simple" and "simply";
* "easy" and "easily";
* "just" (converting to "only" in the case that this is what is meant, being unambiguous).

This PR also fixes some sentences with minor typos that I have noticed in the process (see final commit).