### PR TITLE
Update release_docs and conf.py to avoid regeneration of documents

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -390,8 +390,6 @@ sphinx_gallery_conf = {
     "doc_module": ("cf"),
     "inspect_global_variables": True,
     "within_subsection_order": FileNameSortKey,
-    'expected_failing_examples': ['recipes/plot_07_recipe.py'],
-
 }
 
 # -- Options for LaTeX output -------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -105,9 +105,9 @@ extensions = [
     
 ]
 
-DOCS_VERSION = os.environ.get('DOCS_VERSION', 'none')
+CF_DOCS_MODE = os.environ.get('CF_DOCS_MODE', 'none')
 
-if DOCS_VERSION in ['dev-recipes', 'latest', 'archive']:
+if CF_DOCS_MODE in ['dev-recipes', 'latest', 'archive']:
     extensions.append('sphinx_gallery.gen_gallery')
 
 # Spelling extension configuration: set British English and false positives

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -102,9 +102,13 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_toggleprompt",
     "sphinxcontrib.spelling",
-    "sphinx_gallery.gen_gallery",
+    
 ]
 
+DOCS_VERSION = os.environ.get('DOCS_VERSION', 'none')
+
+if DOCS_VERSION in ['dev-recipes', 'latest', 'archive']:
+    extensions.append('sphinx_gallery.gen_gallery')
 
 # Spelling extension configuration: set British English and false positives
 spelling_lang = "en_GB"
@@ -386,6 +390,8 @@ sphinx_gallery_conf = {
     "doc_module": ("cf"),
     "inspect_global_variables": True,
     "within_subsection_order": FileNameSortKey,
+    'expected_failing_examples': ['recipes/plot_07_recipe.py'],
+
 }
 
 # -- Options for LaTeX output -------------------------------------------------

--- a/release_docs
+++ b/release_docs
@@ -41,7 +41,7 @@ elif [[ $1 = "dev-recipes" ]] ; then
 else
   set +x
   echo "\$1 must be one of 'dev', 'dev-clean', 'dev-scrub', 'latest', 'archive',
-  dev-recipes'"
+  or dev-recipes'"
   exit 2
 fi
 

--- a/release_docs
+++ b/release_docs
@@ -35,9 +35,13 @@ elif [[ $1 = "dev-scrub" ]] ; then
   # also completely deletes the new target directory.
   dir=$PWD/docs/dev
   rm -fr $dir
+elif [[ $1 = "dev-recipes" ]] ; then
+  # For testing: similar to dev, but specifically for generating recipes.
+  dir=$PWD/docs/dev
 else
   set +x
-  echo "\$1 must be one of 'dev', 'dev-clean', 'dev-scrub', 'latest', or 'archive'"
+  echo "\$1 must be one of 'dev', 'dev-clean', 'dev-scrub', 'latest', 'archive',
+  dev-recipes'"
   exit 2
 fi
 
@@ -72,6 +76,8 @@ mkdir -p $dir/_downloads
 #  # Force recreation of recipes
 #  rm source/recipes/*.md5
 #fi
+
+export DOCS_VERSION=$1
 
 make html $dir
 rc=$?

--- a/release_docs
+++ b/release_docs
@@ -41,7 +41,7 @@ elif [[ $1 = "dev-recipes" ]] ; then
 else
   set +x
   echo "\$1 must be one of 'dev', 'dev-clean', 'dev-scrub', 'latest', 'archive',
-  or dev-recipes'"
+  or 'dev-recipes'"
   exit 2
 fi
 
@@ -77,7 +77,7 @@ mkdir -p $dir/_downloads
 #  rm source/recipes/*.md5
 #fi
 
-export DOCS_VERSION=$1
+export CF_DOCS_MODE=$1
 
 make html $dir
 rc=$?


### PR DESCRIPTION
Added a new `dev-recipes` criterion to avoid regeneration of recipes when one simply has to test new documentation.