### PR TITLE
Update create_regular methods to remove cellsize divisibility check

### DIFF
--- a/cf/dimensioncoordinate.py
+++ b/cf/dimensioncoordinate.py
@@ -252,7 +252,7 @@ class DimensionCoordinate(
         :Parameters:
 
             args: sequence of numbers
-                {{args: sequence of numbers}}
+                {{regular args}}
 
             bounds: `bool`, optional
                 If True (the default) then the given range represents

--- a/cf/dimensioncoordinate.py
+++ b/cf/dimensioncoordinate.py
@@ -252,10 +252,7 @@ class DimensionCoordinate(
         :Parameters:
 
             args: sequence of numbers
-                A sequence of three numeric values. The first two values in the
-                sequence represent the coordinate range (see the bounds
-                parameter for details), and the third value represents the
-                cellsize.
+                {{args: sequence of numbers}}
 
             bounds: `bool`, optional
                 If True (the default) then the given range represents
@@ -309,12 +306,6 @@ class DimensionCoordinate(
             raise ValueError(
                 f"Range ({range[0], range[1]}) must be decreasing for a "
                 f"negative cellsize ({cellsize})"
-            )
-
-        if range_diff % cellsize != 0:
-            raise ValueError(
-                f"The range of the dimension ({range_diff}) must be "
-                f"divisible by the cellsize ({cellsize})"
             )
 
         if standard_name is not None and not isinstance(standard_name, str):

--- a/cf/docstring/docstring.py
+++ b/cf/docstring/docstring.py
@@ -513,6 +513,18 @@ _docstring_substitution_definitions = {
                 specified with or without the ``${...}`` syntax. For
                 instance, the following are equivalent: ``'base'`` and
                 ``'${base}'``.""",
+    # args: sequence of numbers
+    "{{args: sequence of numbers}}": 
+                """A sequence of three numeric values. The first two values in 
+                the sequence represent the coordinate range (see the bounds
+                parameter for details), and the third value represents the
+                cellsize.
+
+                .. note:: The cellsize does not have to explicitly divide into 
+                            the range of the given dimension. But as it follows 
+                            `numpy.arange` while creating the points, one should
+                            verify that that the number of grid points are 
+                            returned as expected.""",  
     # ----------------------------------------------------------------
     # Method description substitutions (4 levels of indentation)
     # ----------------------------------------------------------------

--- a/cf/docstring/docstring.py
+++ b/cf/docstring/docstring.py
@@ -513,18 +513,18 @@ _docstring_substitution_definitions = {
                 specified with or without the ``${...}`` syntax. For
                 instance, the following are equivalent: ``'base'`` and
                 ``'${base}'``.""",
-    # args: sequence of numbers
-    "{{args: sequence of numbers}}": 
+    # regular args
+    "{{regular args}}": 
                 """A sequence of three numeric values. The first two values in 
                 the sequence represent the coordinate range (see the bounds
                 parameter for details), and the third value represents the
                 cellsize.
 
                 .. note:: The cellsize does not have to explicitly divide into 
-                            the range of the given dimension. But as it follows 
-                            `numpy.arange` while creating the points, one should
-                            verify that that the number of grid points are 
-                            returned as expected.""",  
+                          the range of the given dimension. But as it follows 
+                          `numpy.arange` while creating the points, one should
+                          verify that that the number of grid points are 
+                          returned as expected.""",  
     # ----------------------------------------------------------------
     # Method description substitutions (4 levels of indentation)
     # ----------------------------------------------------------------

--- a/cf/domain.py
+++ b/cf/domain.py
@@ -343,16 +343,10 @@ class Domain(mixin.FieldDomain, mixin.Properties, cfdm.Domain):
         :Parameters:
 
             x_args: sequence of numbers
-                A sequence of three numeric values. The first two values in the
-                sequence represent the coordinate range (see the bounds
-                parameter for details), and the third value represents the
-                cellsize.
+                {{args: sequence of numbers}}
 
             y_args: sequence of numbers
-                A sequence of three numeric values. The first two values in the
-                sequence represent the coordinate range (see the bounds
-                parameter for details), and the third value represents the
-                cellsize.
+                {{args: sequence of numbers}}
 
             bounds: `bool`, optional
                 If True (default), bounds will be created

--- a/cf/domain.py
+++ b/cf/domain.py
@@ -343,10 +343,10 @@ class Domain(mixin.FieldDomain, mixin.Properties, cfdm.Domain):
         :Parameters:
 
             x_args: sequence of numbers
-                {{args: sequence of numbers}}
+                {{regular args}}
 
             y_args: sequence of numbers
-                {{args: sequence of numbers}}
+                {{regular args}}
 
             bounds: `bool`, optional
                 If True (default), bounds will be created

--- a/cf/test/test_DimensionCoordinate.py
+++ b/cf/test/test_DimensionCoordinate.py
@@ -658,14 +658,6 @@ class DimensionCoordinateTest(unittest.TestCase):
                 standard_name="longitude",
             )
 
-        # Cellsize not divisible by range
-        with self.assertRaises(ValueError):
-            cf.DimensionCoordinate.create_regular(
-                (-180, 180, 50),
-                units="degrees_east",
-                standard_name="longitude",
-            )
-
         # Test decreasing case
         longitude_decreasing = cf.DimensionCoordinate.create_regular(
             (180, -180, -1), units="degrees_east", standard_name="longitude"

--- a/cf/test/test_Domain.py
+++ b/cf/test/test_Domain.py
@@ -322,10 +322,6 @@ class DomainTest(unittest.TestCase):
         self.assertTrue(np.allclose(longitude.array, x_points))
         self.assertTrue(np.allclose(latitude.array, y_points))
 
-        # Test dx and dy not divisors of the range
-        with self.assertRaises(ValueError):
-            cf.Domain.create_regular((-180, 180, 61), (-90, 90, 46))
-
         # Test if range difference in x_range is greater than 360
         with self.assertRaises(ValueError):
             cf.Domain.create_regular((-180, 190, 1), (-90, 90, 1))
@@ -366,6 +362,26 @@ class DomainTest(unittest.TestCase):
             np.allclose(latitude_no_bounds.array, y_points_no_bounds)
         )
 
+        # Test for the given specific domain
+        ymin, ymax, dy = 45., 90., 0.0083333
+        xmin, xmax, dx = 250., 360., 0.0083333
+
+        domain_specific = cf.Domain.create_regular(
+            (xmin, xmax, dx), (ymin, ymax, dy)
+        )
+        self.assertIsInstance(domain_specific, cf.Domain)
+
+        x_bounds_specific = np.arange(xmin, xmax + dx, dx)
+        y_bounds_specific = np.arange(ymin, ymax + dy, dy)
+
+        x_points_specific = (x_bounds_specific[:-1] + x_bounds_specific[1:]) / 2
+        y_points_specific = (y_bounds_specific[:-1] + y_bounds_specific[1:]) / 2
+
+        longitude_specific = domain_specific.construct("longitude")
+        latitude_specific = domain_specific.construct("latitude")
+
+        self.assertTrue(np.allclose(longitude_specific.array, x_points_specific))
+        self.assertTrue(np.allclose(latitude_specific.array, y_points_specific))
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())

--- a/cf/test/test_Domain.py
+++ b/cf/test/test_Domain.py
@@ -363,8 +363,8 @@ class DomainTest(unittest.TestCase):
         )
 
         # Test for the given specific domain
-        ymin, ymax, dy = 45., 90., 0.0083333
-        xmin, xmax, dx = 250., 360., 0.0083333
+        ymin, ymax, dy = 45.0, 90.0, 0.0083333
+        xmin, xmax, dx = 250.0, 360.0, 0.0083333
 
         domain_specific = cf.Domain.create_regular(
             (xmin, xmax, dx), (ymin, ymax, dy)
@@ -374,14 +374,23 @@ class DomainTest(unittest.TestCase):
         x_bounds_specific = np.arange(xmin, xmax + dx, dx)
         y_bounds_specific = np.arange(ymin, ymax + dy, dy)
 
-        x_points_specific = (x_bounds_specific[:-1] + x_bounds_specific[1:]) / 2
-        y_points_specific = (y_bounds_specific[:-1] + y_bounds_specific[1:]) / 2
+        x_points_specific = (
+            x_bounds_specific[:-1] + x_bounds_specific[1:]
+        ) / 2
+        y_points_specific = (
+            y_bounds_specific[:-1] + y_bounds_specific[1:]
+        ) / 2
 
         longitude_specific = domain_specific.construct("longitude")
         latitude_specific = domain_specific.construct("latitude")
 
-        self.assertTrue(np.allclose(longitude_specific.array, x_points_specific))
-        self.assertTrue(np.allclose(latitude_specific.array, y_points_specific))
+        self.assertTrue(
+            np.allclose(longitude_specific.array - x_points_specific, 0)
+        )
+        self.assertTrue(
+            np.allclose(latitude_specific.array - y_points_specific, 0)
+        )
+
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())


### PR DESCRIPTION
The previous iteration of `cf.Domain.create_regular` and `cf.DimensionCoordinate.create_regular` checked explicitly for the range of the dimension to be divisible by the cellsize which is removed here and a note about the same is added in the docstring.