### PR TITLE
Projection lat-lon coordinates part 1: `GridMapping` objects

### DIFF
--- a/cf/__init__.py
+++ b/cf/__init__.py
@@ -323,6 +323,31 @@ from .read_write import read, write
 
 from .regrid import RegridOperator
 
+from .gridmappings import (
+    GridMapping,
+    AzimuthalGridMapping,
+    ConicGridMapping,
+    CylindricalGridMapping,
+    LatLonGridMapping,
+    PerspectiveGridMapping,
+    AlbersEqualArea,
+    AzimuthalEquidistant,
+    Geostationary,
+    LambertAzimuthalEqualArea,
+    LambertConformalConic,
+    LambertCylindricalEqualArea,
+    Mercator,
+    ObliqueMercator,
+    Orthographic,
+    PolarStereographic,
+    RotatedLatitudeLongitude,
+    LatitudeLongitude,
+    Sinusoidal,
+    Stereographic,
+    TransverseMercator,
+    VerticalPerspective,
+)
+
 
 # Set up basic logging for the full project with a root logger
 import logging

--- a/cf/__init__.py
+++ b/cf/__init__.py
@@ -346,6 +346,8 @@ from .gridmappings import (
     Stereographic,
     TransverseMercator,
     VerticalPerspective,
+    _all_abstract_grid_mappings,
+    _all_concrete_grid_mappings,
 )
 
 

--- a/cf/__init__.py
+++ b/cf/__init__.py
@@ -348,6 +348,7 @@ from .gridmappings import (
     VerticalPerspective,
     _all_abstract_grid_mappings,
     _all_concrete_grid_mappings,
+    _get_cf_grid_mapping_from_name,
 )
 
 

--- a/cf/__init__.py
+++ b/cf/__init__.py
@@ -346,10 +346,10 @@ from .gridmappings import (
     Stereographic,
     TransverseMercator,
     VerticalPerspective,
+    convert_proj_angular_data_to_cf,
     _all_abstract_grid_mappings,
     _all_concrete_grid_mappings,
     _get_cf_grid_mapping_from_name,
-    _convert_units_proj_to_cf,
 )
 
 

--- a/cf/__init__.py
+++ b/cf/__init__.py
@@ -349,6 +349,7 @@ from .gridmappings import (
     _all_abstract_grid_mappings,
     _all_concrete_grid_mappings,
     _get_cf_grid_mapping_from_name,
+    _convert_units_proj_to_cf,
 )
 
 

--- a/cf/__init__.py
+++ b/cf/__init__.py
@@ -347,6 +347,7 @@ from .gridmappings import (
     TransverseMercator,
     VerticalPerspective,
     convert_proj_angular_data_to_cf,
+    convert_cf_angular_data_to_proj,
     _all_abstract_grid_mappings,
     _all_concrete_grid_mappings,
     _get_cf_grid_mapping_from_name,

--- a/cf/constants.py
+++ b/cf/constants.py
@@ -73,8 +73,6 @@ repr_suffix = ""
 _stash2standard_name = {}
 
 
-
-
 # ---------------------------------------------------------------------
 # Coordinate reference and grid mapping related constants
 # ---------------------------------------------------------------------
@@ -155,7 +153,9 @@ cr_canonical_units = {
     "standard_parallel": Units("degrees_north"),
     "perspective_point_height": Units("m"),
     "azimuth_of_central_line": Units("degrees"),
-    "straight_vertical_longitude_from_pole": Units("degrees_north"),
+    # TODOGM check the below is correct, was 'degrees_north' before but it
+    # is a longitude so surely that was wrong?:
+    "straight_vertical_longitude_from_pole": Units("degrees_east"),
     # *Other, not needed for a specific grid mapping but also listed
     # in 'Table F.1. Grid Mapping Attributes':*
     # TODOGM towgs84 is very complicated, with multiple components

--- a/cf/constants.py
+++ b/cf/constants.py
@@ -142,8 +142,8 @@ cr_canonical_units = {
     "latitude_of_projection_origin": Units("degrees_north"),
     "scale_factor_at_projection_origin": Units("1"),
     # ...false-Xings:
-    # MISSING: false_easting
-    # MISSING false_northing
+    "false_easting": Units("m"),
+    "false_northing": Units("m"),
     # ...central meridian related:
     "longitude_of_central_meridian": Units("degrees_east"),
     "scale_factor_at_central_meridian": Units("1"),
@@ -154,11 +154,18 @@ cr_canonical_units = {
     # ...other:
     "standard_parallel": Units("degrees_north"),
     "perspective_point_height": Units("m"),
-    # MISSING: "azimuth_of_central_line"
+    "azimuth_of_central_line": Units("degrees"),
     "straight_vertical_longitude_from_pole": Units("degrees_north"),
     # *Other, not needed for a specific grid mapping but also listed
     # in 'Table F.1. Grid Mapping Attributes':*
-    # MISSING: "towgs84"
+    # TODOGM towgs84 is very complicated, with multiple components
+    # of translations, roations and scaling each with different units
+    # requirements, so we should probably sort this out later, see:
+    # https://proj.org/en/9.3/operations/transformations/
+    # helmert.html#helmert-transform
+    # where translations are in meters, rotations in arc-seconds, and
+    # scaling is in parts per million.
+    "towgs84": None,
 }
 
 # Indicates what PROJ string ID component(s) refer(s) to the grid mapping

--- a/cf/constants.py
+++ b/cf/constants.py
@@ -72,26 +72,116 @@ repr_suffix = ""
 
 _stash2standard_name = {}
 
+
+
+
 # ---------------------------------------------------------------------
-# Coordinate reference constants TODO: turn these into functions
+# Coordinate reference and grid mapping related constants
 # ---------------------------------------------------------------------
+# Grid Mapping valid attribute names. Taken from the list given in
+# 'Table F.1. Grid Mapping Attributes' in Appendix F: Grid Mappings'
+# of the Conventions document.
+#
+# Values indicate if attribute values are expected to be numeric (instead
+# of string) for the given attribute key (the table defines this via N, S).
+# For any value where this is True, canonical units must be provided
+# in the 'cr_canonical_units' dict below.
+cr_gm_valid_attr_names_are_numeric = {
+    "grid_mapping_name": False,
+    # *Those which describe the ellipsoid and prime meridian:*
+    "earth_radius": True,
+    "inverse_flattening": True,
+    "longitude_of_prime_meridian": True,
+    "prime_meridian_name": False,
+    "reference_ellipsoid_name": False,
+    "semi_major_axis": True,
+    "semi_minor_axis": True,
+    # *Specific/applicable to only given grid mapping(s):*
+    # ...projection origin related:
+    "longitude_of_projection_origin": True,
+    "latitude_of_projection_origin": True,
+    "scale_factor_at_projection_origin": True,
+    # ...false-Xings:
+    "false_easting": True,
+    "false_northing": True,
+    # ...angle axis related:
+    "sweep_angle_axis": False,
+    "fixed_angle_axis": False,
+    # ...central meridian related:
+    "longitude_of_central_meridian": True,
+    "scale_factor_at_central_meridian": True,
+    # ...pole coordinates related:
+    "grid_north_pole_latitude": True,
+    "grid_north_pole_longitude": True,
+    "north_pole_grid_longitude": True,
+    # ...other:
+    "standard_parallel": True,
+    "perspective_point_height": True,
+    "azimuth_of_central_line": True,
+    "straight_vertical_longitude_from_pole": True,
+    # *Other, not needed for a specific grid mapping but also listed
+    # in 'Table F.1. Grid Mapping Attributes':*
+    "crs_wkt": False,
+    "geographic_crs_name": False,
+    "geoid_name": False,
+    "geopotential_datum_name": False,
+    "horizontal_datum_name": False,
+    "projected_crs_name": False,
+    "towgs84": True,
+}
 cr_canonical_units = {
+    # *Those which describe the ellipsoid and prime meridian:*
     "earth_radius": Units("m"),
-    "grid_north_pole_latitude": Units("degrees_north"),
-    "grid_north_pole_longitude": Units("degrees_east"),
     "inverse_flattening": Units("1"),
-    "latitude_of_projection_origin": Units("degrees_north"),
-    "longitude_of_central_meridian": Units("degrees_east"),
     "longitude_of_prime_meridian": Units("degrees_east"),
-    "longitude_of_projection_origin": Units("degrees_east"),
-    "north_pole_grid_longitude": Units("degrees"),
-    "perspective_point_height": Units("m"),
-    "scale_factor_at_central_meridian": Units("1"),
-    "scale_factor_at_projection_origin": Units("1"),
     "semi_major_axis": Units("m"),
     "semi_minor_axis": Units("m"),
+    # *Specific/applicable to only given grid mapping(s):*
+    # ...projection origin related:
+    "longitude_of_projection_origin": Units("degrees_east"),
+    "latitude_of_projection_origin": Units("degrees_north"),
+    "scale_factor_at_projection_origin": Units("1"),
+    # ...false-Xings:
+    # MISSING: false_easting
+    # MISSING false_northing
+    # ...central meridian related:
+    "longitude_of_central_meridian": Units("degrees_east"),
+    "scale_factor_at_central_meridian": Units("1"),
+    # ...pole coordinates related:
+    "grid_north_pole_latitude": Units("degrees_north"),
+    "grid_north_pole_longitude": Units("degrees_east"),
+    "north_pole_grid_longitude": Units("degrees"),
+    # ...other:
     "standard_parallel": Units("degrees_north"),
+    "perspective_point_height": Units("m"),
+    # MISSING: "azimuth_of_central_line"
     "straight_vertical_longitude_from_pole": Units("degrees_north"),
+    # *Other, not needed for a specific grid mapping but also listed
+    # in 'Table F.1. Grid Mapping Attributes':*
+    # MISSING: "towgs84"
+}
+
+# Indicates what PROJ string ID component(s) refer(s) to the grid mapping
+# attribute in question when '+' is added as a suffix, for example
+# 'earth_radius' is '+R' and 'inverse_flattening' is '+rf'
+cr_gm_attr_to_proj_string_comps = {
+    "earth_radius": "R",
+    "inverse_flattening": "rf",
+    "prime_meridian_name": "pm",
+    "reference_ellipsoid_name": "ellps",
+    "semi_major_axis": "a",
+    "semi_minor_axis": "b",
+    "longitude_of_projection_origin": "lon_0",
+    "latitude_of_projection_origin": "lat_0",
+    "scale_factor_at_projection_origin": "k_0",
+    "false_easting": "x_0",
+    "false_northing": "y_0",
+    "sweep_angle_axis": "sweep",
+    "standard_parallel": ("lat_1", "lat_2"),
+    "perspective_point_height": "h",
+    "azimuth_of_central_line": ("alpha", "gamma"),
+    "crs_wkt": "crs_wkt",
+    "towgs84": "towgs84",
 }
 
 cr_coordinates = {

--- a/cf/coordinateconversion.py
+++ b/cf/coordinateconversion.py
@@ -1,5 +1,7 @@
 import cfdm
 
+from .gridmappings import *  # noqa: F403
+
 
 class CoordinateConversion(cfdm.CoordinateConversion):
     """A coordinate conversion component of a coordinate reference
@@ -27,3 +29,6 @@ class CoordinateConversion(cfdm.CoordinateConversion):
 
         """
         return super().__repr__().replace("<", "<CF ", 1)
+
+    def get_grid_mapping():
+        pass

--- a/cf/coordinateconversion.py
+++ b/cf/coordinateconversion.py
@@ -30,5 +30,5 @@ class CoordinateConversion(cfdm.CoordinateConversion):
         """
         return super().__repr__().replace("<", "<CF ", 1)
 
-    def get_grid_mapping():
+    def get_grid_mapping(field):
         pass

--- a/cf/coordinateconversion.py
+++ b/cf/coordinateconversion.py
@@ -29,6 +29,3 @@ class CoordinateConversion(cfdm.CoordinateConversion):
 
         """
         return super().__repr__().replace("<", "<CF ", 1)
-
-    def get_grid_mapping(field):
-        pass

--- a/cf/coordinatereference.py
+++ b/cf/coordinatereference.py
@@ -47,7 +47,7 @@ def _totuple(a):
         return a
 
 
-def create_2d_lats_and_lons():
+def create_2d_lats_and_lons(projection, 1d_proj_coors, crs_params):
     """TODO."""
     # For keys all Grid Mappings supported by the CF Conventions, as
     # listed in Appendix F of the document, given as the specific
@@ -96,7 +96,26 @@ def create_2d_lats_and_lons():
         # -> TODO: not sure what this is in PROJ. Find out!
         "vertical_perspective": "???",
     }
-    return
+
+    # TODO functional code here to go from inputs to lat_data and lon_data
+
+    # Create latitude construct from data
+    lat_data = cf.Data(numpy.array(0))  # TODO: minimal dummy data for now
+    lat_dim = cf.DimensionCoordinate(data=lat_data))
+    lat_dim.set_properties(
+        {"standard_name": "latitude",
+         "units": "degrees_north"}
+    )
+
+    # Create longitude construct from data
+    lon_data = cf.Data(numpy.array(0))  # TODO: minimal dummy data for now
+    lon_dim = cf.DimensionCoordinate(data=lon_data)
+    lon_dim.set_properties(
+        {"standard_name": "longitude",
+         "units": "degrees_east"}
+    )
+
+    return lat_dim, lon_dim
 
 
 class CoordinateReference(cfdm.CoordinateReference):

--- a/cf/coordinatereference.py
+++ b/cf/coordinatereference.py
@@ -49,59 +49,11 @@ def _totuple(a):
 
 def create_2d_lats_and_lons(projection, 1d_proj_coors, crs_params):
     """TODO."""
-    # For keys all Grid Mappings supported by the CF Conventions, as
-    # listed in Appendix F of the document, given as the specific
-    # 'grid_mapping_name' attribute string, mapped to values of their PROJ
-    # 'proj-string' which defines the equivalent coordnate transformtion
-    # and its parameters under PROJ.
-    #
-    # TODO double check this mapping to PROJ is correct!
-    grid_mapping_name_attr_to_proj_string_map = {
-        # Albers Equal Area
-        "albers_conical_equal_area": "aea +lat_1=29.5 +lat_2=42.5",
-        # Azimuthal equidistant
-        "azimuthal_equidistant": "aeqd",
-        # Geostationary projection
-        "geostationary": "geos +h=35785831.0 +lon_0=-60 +sweep=y",
-        # Lambert azimuthal equal area
-        "lambert_azimuthal_equal_area": "laea",
-        # Lambert conformal
-        "lambert_conformal_conic": "lcc +lon_0=-90 +lat_1=33 +lat_2=45",
-        # Lambert Cylindrical Equal Area
-        # -> note this is called 'Equal Area Cylindrical' in PROJ
-        "lambert_cylindrical_equal_area": "cea",
-        # Latitude-Longitude
-        # -> Note this has other names such as 'Equidistant Cylindrical' and
-        # 'Plate Carrée', see e.g.
-        #  https://en.wikipedia.org/wiki/Equirectangular_projection
-        "latitude_longitude": "eqc",
-        # Mercator
-        "mercator": "merc",
-        # Oblique Mercator
-        "oblique_mercator": "omerc +lat_1=45 +lat_2=55",
-        # Orthographic
-        "orthographic": "ortho",
-        # Polar stereographic
-        "polar_stereographic": "ups",
-        # Rotated pole
-        # -> need to use latitude_longitude but rotate with extra coors
-        "rotated_latitude_longitude": "eqc +lat_ts=0 +lon_0=0",
-        # Sinusoidal
-        "sinusoidal": "sinu",
-        # Stereographic
-        "stereographic": "stere +lat_0=90 +lat_ts=75",
-        # Transverse Mercator
-        "transverse_mercator": "tmerc",
-        # Vertical perspective
-        # -> Note in PROJ this comes under 'Near-sided perspective'
-        "vertical_perspective": "+proj=nsper +h=3000000 +lat_0=-20 +lon_0=145",
-    }
-
     # TODO functional code here to go from inputs to lat_data and lon_data
 
     # Create latitude construct from data
     lat_data = cf.Data(numpy.array(0))  # TODO: minimal dummy data for now
-    lat_dim = cf.DimensionCoordinate(data=lat_data))
+    lat_dim = cf.DimensionCoordinate(data=lat_data)
     lat_dim.set_properties(
         {"standard_name": "latitude",
          "units": "degrees_north"}

--- a/cf/coordinatereference.py
+++ b/cf/coordinatereference.py
@@ -54,6 +54,8 @@ def create_2d_lats_and_lons(projection, 1d_proj_coors, crs_params):
     # 'grid_mapping_name' attribute string, mapped to values of their PROJ
     # 'proj-string' which defines the equivalent coordnate transformtion
     # and its parameters under PROJ.
+    #
+    # TODO double check this mapping to PROJ is correct!
     grid_mapping_name_attr_to_proj_string_map = {
         # Albers Equal Area
         "albers_conical_equal_area": "aea +lat_1=29.5 +lat_2=42.5",
@@ -69,10 +71,9 @@ def create_2d_lats_and_lons(projection, 1d_proj_coors, crs_params):
         # -> note this is called 'Equal Area Cylindrical' in PROJ
         "lambert_cylindrical_equal_area": "cea",
         # Latitude-Longitude
-        # -> note this is called 'Equidistant Cylindrical (Plate Carrée)'
-        #    in PROJ (TODO: double check this, I think based on
-        #    https://en.wikipedia.org/wiki/Equirectangular_projection it
-        #    is True...)
+        # -> Note this has other names such as 'Equidistant Cylindrical' and
+        # 'Plate Carrée', see e.g.
+        #  https://en.wikipedia.org/wiki/Equirectangular_projection
         "latitude_longitude": "eqc",
         # Mercator
         "mercator": "merc",
@@ -81,11 +82,10 @@ def create_2d_lats_and_lons(projection, 1d_proj_coors, crs_params):
         # Orthographic
         "orthographic": "ortho",
         # Polar stereographic
-        "polar_stereographic": "stere +lat_0=90 +lat_ts=75",
+        "polar_stereographic": "ups",
         # Rotated pole
-        # -> TODO: not sure what this is in PROJ, could need to use
-        #    latitude_longitude ("eqc") and set extra parameters?
-        "rotated_latitude_longitude": "???",
+        # -> need to use latitude_longitude but rotate with extra coors
+        "rotated_latitude_longitude": "eqc +lat_ts=0 +lon_0=0",
         # Sinusoidal
         "sinusoidal": "sinu",
         # Stereographic
@@ -93,8 +93,8 @@ def create_2d_lats_and_lons(projection, 1d_proj_coors, crs_params):
         # Transverse Mercator
         "transverse_mercator": "tmerc",
         # Vertical perspective
-        # -> TODO: not sure what this is in PROJ. Find out!
-        "vertical_perspective": "???",
+        # -> Note in PROJ this comes under 'Near-sided perspective'
+        "vertical_perspective": "+proj=nsper +h=3000000 +lat_0=-20 +lon_0=145",
     }
 
     # TODO functional code here to go from inputs to lat_data and lon_data

--- a/cf/coordinatereference.py
+++ b/cf/coordinatereference.py
@@ -47,7 +47,7 @@ def _totuple(a):
         return a
 
 
-def create_2d_lats_and_lons(projection, 1d_proj_coors, crs_params):
+def create_2d_lats_and_lons(projection, proj_1d_coors, crs_params):
     """TODO."""
     # TODO functional code here to go from inputs to lat_data and lon_data
 

--- a/cf/domain.py
+++ b/cf/domain.py
@@ -17,6 +17,7 @@ from .functions import (
     indices_shape,
     parse_indices,
 )
+from .gridmappings import _get_cf_grid_mapping_from_name
 
 _empty_set = set()
 
@@ -476,21 +477,19 @@ class Domain(mixin.FieldDomain, mixin.Properties, cfdm.Domain):
             default, message=f"{self.__class__.__name__} has no data"
         )
 
-
-def _get_cf_grid_mapping_from_name(gm_name):
-    """TODOSADIE."""
-    cf_supported_gm_names = {
-        gm.grid_mapping_name: gm for gm in _all_concrete_grid_mappings
-    }
-    if gm_name in cf_supported_gm_names:
-        return cf_supported_gm_names[gm_name]
-    else:
-        return
-
-    def get_grid_mappings(self):
+    def get_grid_mappings(self, as_class=False):
         """Returns coordinate conversions with grid mapping parameters.
 
         .. versionadded:: GMVER
+
+        :Parameters:
+
+            as_class: `bool`, optional
+                If `True`, return the grid mapping as the equivalent
+                CF Class, for example cf.RotatedLatitudeLongitude,
+                rather than as a string corresponding to the value
+                of the 'grid_mapping_name' attribute, which is
+                the default.
 
         :Returns:
 
@@ -514,7 +513,10 @@ def _get_cf_grid_mapping_from_name(gm_name):
                 "grid_mapping_name", default=None
             )
             if gm:
-                gms[cref_name] = gm
+                if as_class:
+                    gms[cref_name] = _get_cf_grid_mapping_from_name(gm)
+                else:
+                    gms[cref_name] = gm
         return gms
 
     def identity(self, default="", strict=False, relaxed=False, nc_only=False):

--- a/cf/domain.py
+++ b/cf/domain.py
@@ -476,6 +476,17 @@ class Domain(mixin.FieldDomain, mixin.Properties, cfdm.Domain):
             default, message=f"{self.__class__.__name__} has no data"
         )
 
+
+def _get_cf_grid_mapping_from_name(gm_name):
+    """TODOSADIE."""
+    cf_supported_gm_names = {
+        gm.grid_mapping_name: gm for gm in _all_concrete_grid_mappings
+    }
+    if gm_name in cf_supported_gm_names:
+        return cf_supported_gm_names[gm_name]
+    else:
+        return
+
     def get_grid_mappings(self):
         """Returns coordinate conversions with grid mapping parameters.
 
@@ -499,11 +510,11 @@ class Domain(mixin.FieldDomain, mixin.Properties, cfdm.Domain):
         """
         gms = {}
         for cref_name, cref in self.coordinate_references().items():
-             gm = cref.coordinate_conversion.get_parameter(
-                    "grid_mapping_name", default=None
-                )
-             if gm:
-                 gms[cref_name] = gm
+            gm = cref.coordinate_conversion.get_parameter(
+                "grid_mapping_name", default=None
+            )
+            if gm:
+                gms[cref_name] = gm
         return gms
 
     def identity(self, default="", strict=False, relaxed=False, nc_only=False):

--- a/cf/domain.py
+++ b/cf/domain.py
@@ -478,7 +478,7 @@ class Domain(mixin.FieldDomain, mixin.Properties, cfdm.Domain):
         )
 
     def get_grid_mappings(self, as_class=False):
-        """Returns coordinate conversions with grid mapping parameters.
+        """Returns coordinate conversions with their grid mappings.
 
         .. versionadded:: GMVER
 
@@ -486,23 +486,28 @@ class Domain(mixin.FieldDomain, mixin.Properties, cfdm.Domain):
 
             as_class: `bool`, optional
                 If `True`, return the grid mapping as the equivalent
-                CF Class, for example cf.RotatedLatitudeLongitude,
-                rather than as a string corresponding to the value
-                of the 'grid_mapping_name' attribute, which is
-                the default.
+                CF Grid Mapping class, for example
+                cf.RotatedLatitudeLongitude, rather than as a string
+                corresponding to the value of the 'grid_mapping_name'
+                attribute, for example 'rotated_latitude_longitude'.
+                By default the 'grid_mapping_name' value is returned.
 
         :Returns:
 
                 `dict`
                      CoordinateConversion construct identifiers with
-                     vaules of their 'grid_mapping_name' attributes,
-                     for all CoordinateConversions of the domain that
-                     have a 'grid_mapping_name' parameter defined.
+                     values of their 'grid_mapping_name' attribute,
+                     or corresponding CF Grid Mapping class if
+                     as_class is `True`, for all CoordinateConversions
+                     of the domain that have a 'grid_mapping_name'
+                     parameter defined.
 
         **Examples**
 
         >>> f.get_grid_mappings()
-        {"coordinatereference1": "rotated_latitude_longitude"}
+        {'coordinatereference1': "rotated_latitude_longitude"}
+        >>> f.get_grid_mappings(as_class=True)
+        {'coordinatereference1': cf.gridmappings.RotatedLatitudeLongitude}
         >>> g.get_grid_mappings()
         {}
 

--- a/cf/domain.py
+++ b/cf/domain.py
@@ -476,6 +476,36 @@ class Domain(mixin.FieldDomain, mixin.Properties, cfdm.Domain):
             default, message=f"{self.__class__.__name__} has no data"
         )
 
+    def get_grid_mappings(self):
+        """Returns coordinate conversions with grid mapping parameters.
+
+        .. versionadded:: GMVER
+
+        :Returns:
+
+                `dict`
+                     CoordinateConversion construct identifiers with
+                     vaules of their 'grid_mapping_name' attributes,
+                     for all CoordinateConversions of the domain that
+                     have a 'grid_mapping_name' parameter defined.
+
+        **Examples**
+
+        >>> f.get_grid_mappings()
+        {"coordinatereference1": "rotated_latitude_longitude"}
+        >>> g.get_grid_mappings()
+        {}
+
+        """
+        gms = {}
+        for cref_name, cref in self.coordinate_references().items():
+             gm = cref.coordinate_conversion.get_parameter(
+                    "grid_mapping_name", default=None
+                )
+             if gm:
+                 gms[cref_name] = gm
+        return gms
+
     def identity(self, default="", strict=False, relaxed=False, nc_only=False):
         """Return the canonical identity.
 

--- a/cf/field.py
+++ b/cf/field.py
@@ -15643,10 +15643,19 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
             removed_at="4.0.0",
         )  # pragma: no cover
 
-    def get_grid_mappings(self):
+    def get_grid_mappings(self, as_class=False):
         """Returns coordinate conversions with grid mapping parameters.
 
         .. versionadded:: GMVER
+
+        :Parameters:
+
+            as_class: `bool`, optional
+                If `True`, return the grid mapping as the equivalent
+                CF Class, for example cf.RotatedLatitudeLongitude,
+                rather than as a string corresponding to the value
+                of the 'grid_mapping_name' attribute, which is
+                the default.
 
         :Returns:
 
@@ -15659,9 +15668,11 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
         **Examples**
 
         >>> f.get_grid_mappings()
-        {"coordinatereference1": "rotated_latitude_longitude"}
+        {'coordinatereference1': "rotated_latitude_longitude"}
+        >>> f.get_grid_mappings(as_class=True)
+        {'coordinatereference1': cf.gridmappings.RotatedLatitudeLongitude}
         >>> g.get_grid_mappings()
         {}
 
         """
-        return self.domain.get_grid_mappings()
+        return self.domain.get_grid_mappings(as_class=as_class)

--- a/cf/field.py
+++ b/cf/field.py
@@ -15644,7 +15644,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
         )  # pragma: no cover
 
     def get_grid_mappings(self, as_class=False):
-        """Returns coordinate conversions with grid mapping parameters.
+        """Returns coordinate conversions with their grid mappings.
 
         .. versionadded:: GMVER
 
@@ -15652,18 +15652,21 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
 
             as_class: `bool`, optional
                 If `True`, return the grid mapping as the equivalent
-                CF Class, for example cf.RotatedLatitudeLongitude,
-                rather than as a string corresponding to the value
-                of the 'grid_mapping_name' attribute, which is
-                the default.
+                CF Grid Mapping class, for example
+                cf.RotatedLatitudeLongitude, rather than as a string
+                corresponding to the value of the 'grid_mapping_name'
+                attribute, for example 'rotated_latitude_longitude'.
+                By default the 'grid_mapping_name' value is returned.
 
         :Returns:
 
                 `dict`
                      CoordinateConversion construct identifiers with
-                     vaules of their 'grid_mapping_name' attributes,
-                     for all CoordinateConversions of the domain that
-                     have a 'grid_mapping_name' parameter defined.
+                     values of their 'grid_mapping_name' attribute,
+                     or corresponding CF Grid Mapping class if
+                     as_class is `True`, for all CoordinateConversions
+                     of the domain that have a 'grid_mapping_name'
+                     parameter defined.
 
         **Examples**
 

--- a/cf/field.py
+++ b/cf/field.py
@@ -15642,3 +15642,26 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
             version="3.0.0",
             removed_at="4.0.0",
         )  # pragma: no cover
+
+    def get_grid_mappings(self):
+        """Returns coordinate conversions with grid mapping parameters.
+
+        .. versionadded:: GMVER
+
+        :Returns:
+
+                `dict`
+                     CoordinateConversion construct identifiers with
+                     vaules of their 'grid_mapping_name' attributes,
+                     for all CoordinateConversions of the domain that
+                     have a 'grid_mapping_name' parameter defined.
+
+        **Examples**
+
+        >>> f.get_grid_mappings()
+        {"coordinatereference1": "rotated_latitude_longitude"}
+        >>> g.get_grid_mappings()
+        {}
+
+        """
+        return self.domain.get_grid_mappings()

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -99,6 +99,33 @@ the values documented as defaults in the docstrings are taken from this:
 WGS1984_CF_ATTR_DEFAULTS = CRS.from_proj4("+proj=merc").to_cf()
 
 
+def _convert_units_cf_to_proj(cf_units):
+    """Take CF units and convert them to equivalent units under PROJ."""
+    pass
+
+
+def _convert_units_proj_to_cf(cf_units):
+    """Take units used in PROJ and convert them to CF units."""
+    pass
+
+
+def _make_proj_string_comp(spec):
+    """Form a PROJ proj-string end from the given PROJ parameters.
+
+    :Parameters:
+
+        spec: `dict`
+            A dictionary providing the proj-string specifiers for
+            parameters, as keys, with their values as values. Values
+            must be convertible to strings.
+
+    """
+    proj_string = ""
+    for comp, value in spec.items():
+        proj_string += f" +{comp}={value}"
+    return proj_string
+
+
 """Abstract classes for general Grid Mappings.
 
 Note that default arguments are based upon the PROJ defaults, which can
@@ -148,8 +175,8 @@ class GridMapping(ABC):
             inverse_flattening: number, optional
                 The reverse flattening of the ellipsoid (PROJ 'rf'
                 value), :math:`\frac{1}{f}`, where f corresponds to
-                the flattening value (PROJ 'f' value) for the ellipsoid.
-                Unitless. The default is 298.257223563.
+                the flattening value (PROJ 'f' value) for the
+                ellipsoid. Unitless. The default is 298.257223563.
 
             prime_meridian_name: `str`, optional
                 A predeclared name to define the prime meridian (PROJ

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -3,23 +3,23 @@ from pyproj import CRS
 ALL_GRID_MAPPING_ATTR_NAMES = {
     "grid_mapping_name",
     # *Those which describe the ellipsoid and prime meridian:*
-    "earth_radius",                       # PROJ '+R' value
-    "inverse_flattening",                 # PROJ '+rf' value
+    "earth_radius",  # -------------------- PROJ '+R' value
+    "inverse_flattening",  # -------------- PROJ '+rf' value
     "longitude_of_prime_meridian",
-    "prime_meridian_name",                # PROJ '+pm' value
-    "reference_ellipsoid_name",           # PROJ '+ellps' value
-    "semi_major_axis",                    # PROJ '+a' value
-    "semi_minor_axis",                    # PROJ '+b' value
+    "prime_meridian_name",  # ------------- PROJ '+pm' value
+    "reference_ellipsoid_name",  # -------- PROJ '+ellps' value
+    "semi_major_axis",  # ----------------- PROJ '+a' value
+    "semi_minor_axis",  # ----------------- PROJ '+b' value
     # *Specific/applicable to only given grid mapping(s):*
     # ...projection origin related:
-    "longitude_of_projection_origin",     # PROJ '+lon_0' value
-    "latitude_of_projection_origin",      # PROJ '+lat_0' value
+    "longitude_of_projection_origin",  # -- PROJ '+lon_0' value
+    "latitude_of_projection_origin",  # --- PROJ '+lat_0' value
     "scale_factor_at_projection_origin",  # PROJ '+k_0' value
     # ...false-Xings:
-    "false_easting",                      # PROJ '+x_0' value
-    "false_northing",                     # PROJ '+y_0' value
+    "false_easting",  # ------------------- PROJ '+x_0' value
+    "false_northing",  # ------------------ PROJ '+y_0' value
     # ...angle axis related:
-    "sweep_angle_axis",                   # PROJ '+sweep' value
+    "sweep_angle_axis",  # ---------------- PROJ '+sweep' value
     "fixed_angle_axis",
     # ...central meridian related:
     "longitude_of_central_meridian",
@@ -29,19 +29,19 @@ ALL_GRID_MAPPING_ATTR_NAMES = {
     "grid_north_pole_longitude",
     "north_pole_grid_longitude",
     # ...other:
-    "standard_parallel",                  # PROJ ['+lat_1', '+lat_2'] values
-    "perspective_point_height",           # PROJ '+h' value
-    "azimuth_of_central_line",            # PROJ '+alpha' (ignore '+gamma')
+    "standard_parallel",  # --------------- PROJ ['+lat_1', '+lat_2'] values
+    "perspective_point_height",  # -------- PROJ '+h' value
+    "azimuth_of_central_line",  # --------- PROJ '+alpha' (ignore '+gamma')
     "straight_vertical_longitude_from_pole",
     # *Other, not needed for a specific grid mapping but also listed
     # in 'Table F.1. Grid Mapping Attributes':*
-    "crs_wkt",                            # PROJ 'crs_wkt' value
+    "crs_wkt",  # ------------------------- PROJ 'crs_wkt' value
     "geographic_crs_name",
     "geoid_name",
     "geopotential_datum_name",
     "horizontal_datum_name",
     "projected_crs_name",
-    "towgs84",                            # PROJ '+towgs84' value
+    "towgs84",  # ------------------------- PROJ '+towgs84' value
 }
 
 """
@@ -1169,10 +1169,6 @@ class RotatedLatitudeLongitude(LatLonGridMapping):
     http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/
     cf-conventions.html#_rotated_pole
 
-    or the corresponding PROJ projection page:
-
-    https://proj.org/en/9.2/operations/projections/eqc.html
-
     for more information.
 
     .. versionadded:: GMVER
@@ -1215,7 +1211,9 @@ class RotatedLatitudeLongitude(LatLonGridMapping):
         *args,
         **kwargs,
     ):
-        super().__init__("rotated_latitude_longitude", "eqc", *args, **kwargs)
+        super().__init__(
+            "rotated_latitude_longitude", "latlon", *args, **kwargs
+        )
 
         self.grid_north_pole_latitude = grid_north_pole_latitude
         self.grid_north_pole_longitude = grid_north_pole_longitude
@@ -1223,21 +1221,13 @@ class RotatedLatitudeLongitude(LatLonGridMapping):
 
 
 class LatitudeLongitude(LatLonGridMapping):
-    """The Latitude-Longitude i.e. Plate Carrée grid mapping.
-
-    For alternative names, see e.g:
-
-    https://en.wikipedia.org/wiki/Equirectangular_projection
+    """The Latitude-Longitude grid mapping.
 
     See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
     this grid mapping:
 
     http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/
     cf-conventions.html#_latitude_longitude
-
-    or the corresponding PROJ projection page:
-
-    https://proj.org/en/9.2/operations/projections/eqc.html
 
     for more information.
 
@@ -1246,7 +1236,7 @@ class LatitudeLongitude(LatLonGridMapping):
     """
 
     def __init__(self, *args, **kwargs):
-        super().__init__("latitude_longitude", "eqc", *args, **kwargs)
+        super().__init__("latitude_longitude", "latlon", *args, **kwargs)
 
 
 class Sinusoidal(GridMapping):

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -44,8 +44,6 @@ the values documented as defaults in the docstrings are taken from this:
 """
 WGS1984_CF_ATTR_DEFAULTS = CRS.from_proj4("+proj=merc").to_cf()
 
-DUMMY_PARAMS = {"a": "b", "c": 0.0}  # TODOPARAMETERS, drop this
-
 
 def convert_proj_angular_data_to_cf(proj_data, context=None):
     """Convert a PROJ angular data component into CF Data with CF Units.
@@ -411,16 +409,22 @@ class GridMapping(ABC):
 
     def __eq__(self, other):
         """The rich comparison operator ``==``."""
-        return self.get_proj_string() == other.get_proj_string()
+        return self.get_proj_crs() == other.get_proj_crs()
 
     def __hash__(self, other):
-        """The rich comparison operator ``==``."""
-        return hash(self.get_proj_string())
+        """The built-in function `hash`, x.__hash__() <==> hash(x)."""
+        return hash(self.get_proj_crs())
 
-    @abstractmethod
-    def get_proj_string(self):
+    def get_proj_string(self, params=None):
         """The value of the PROJ proj-string defining the projection."""
-        pass
+        # TODO enable parameter input and sync'ing
+        if not params:
+            params = ""
+        return f"{PROJ_PREFIX}={self.proj_id}{params}"
+
+    def get_proj_crs(self):
+        """TODO."""
+        return CRS.from_proj4(self.get_proj_string())
 
 
 class AzimuthalGridMapping(GridMapping):
@@ -688,11 +692,6 @@ class AlbersEqualArea(ConicGridMapping):
     grid_mapping_name = "albers_conical_equal_area"
     proj_id = "aea"
 
-    def get_proj_string(self):
-        """The value of the PROJ proj-string defining the projection."""
-        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
-        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
-
 
 class AzimuthalEquidistant(AzimuthalGridMapping):
     """The Azimuthal Equidistant grid mapping.
@@ -745,11 +744,6 @@ class AzimuthalEquidistant(AzimuthalGridMapping):
 
     grid_mapping_name = "azimuthal_equidistant"
     proj_id = "aeqd"
-
-    def get_proj_string(self):
-        """The value of the PROJ proj-string defining the projection."""
-        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
-        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
 
 
 class Geostationary(PerspectiveGridMapping):
@@ -866,11 +860,6 @@ class Geostationary(PerspectiveGridMapping):
         self.sweep_angle_axis = sweep_angle_axis.lower()
         self.fixed_angle_axis = fixed_angle_axis.lower()
 
-    def get_proj_string(self):
-        """The value of the PROJ proj-string defining the projection."""
-        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
-        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
-
 
 class LambertAzimuthalEqualArea(AzimuthalGridMapping):
     """The Lambert Azimuthal Equal Area grid mapping.
@@ -923,11 +912,6 @@ class LambertAzimuthalEqualArea(AzimuthalGridMapping):
 
     grid_mapping_name = "lambert_azimuthal_equal_area"
     proj_id = "laea"
-
-    def get_proj_string(self):
-        """The value of the PROJ proj-string defining the projection."""
-        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
-        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
 
 
 class LambertConformalConic(ConicGridMapping):
@@ -996,11 +980,6 @@ class LambertConformalConic(ConicGridMapping):
 
     grid_mapping_name = "lambert_conformal_conic"
     proj_id = "lcc"
-
-    def get_proj_string(self):
-        """The value of the PROJ proj-string defining the projection."""
-        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
-        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
 
 
 class LambertCylindricalEqualArea(CylindricalGridMapping):
@@ -1085,11 +1064,6 @@ class LambertCylindricalEqualArea(CylindricalGridMapping):
             scale_factor_at_projection_origin
         )
 
-    def get_proj_string(self):
-        """The value of the PROJ proj-string defining the projection."""
-        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
-        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
-
 
 class Mercator(CylindricalGridMapping):
     """The Mercator grid mapping.
@@ -1172,11 +1146,6 @@ class Mercator(CylindricalGridMapping):
         self.scale_factor_at_projection_origin = (
             scale_factor_at_projection_origin
         )
-
-    def get_proj_string(self):
-        """The value of the PROJ proj-string defining the projection."""
-        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
-        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
 
 
 class ObliqueMercator(CylindricalGridMapping):
@@ -1262,11 +1231,6 @@ class ObliqueMercator(CylindricalGridMapping):
             scale_factor_at_projection_origin
         )
 
-    def get_proj_string(self):
-        """The value of the PROJ proj-string defining the projection."""
-        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
-        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
-
 
 class Orthographic(AzimuthalGridMapping):
     """The Orthographic grid mapping.
@@ -1319,11 +1283,6 @@ class Orthographic(AzimuthalGridMapping):
 
     grid_mapping_name = "orthographic"
     proj_id = "ortho"
-
-    def get_proj_string(self):
-        """The value of the PROJ proj-string defining the projection."""
-        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
-        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
 
 
 class PolarStereographic(AzimuthalGridMapping):
@@ -1445,11 +1404,6 @@ class PolarStereographic(AzimuthalGridMapping):
             scale_factor_at_projection_origin
         )
 
-    def get_proj_string(self):
-        """The value of the PROJ proj-string defining the projection."""
-        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
-        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
-
 
 class RotatedLatitudeLongitude(LatLonGridMapping):
     """The Rotated Latitude-Longitude grid mapping.
@@ -1504,11 +1458,6 @@ class RotatedLatitudeLongitude(LatLonGridMapping):
         self.grid_north_pole_longitude = grid_north_pole_longitude
         self.north_pole_grid_longitude = north_pole_grid_longitude
 
-    def get_proj_string(self):
-        """The value of the PROJ proj-string defining the projection."""
-        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
-        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
-
 
 class LatitudeLongitude(LatLonGridMapping):
     """The Latitude-Longitude grid mapping.
@@ -1527,11 +1476,6 @@ class LatitudeLongitude(LatLonGridMapping):
 
     grid_mapping_name = "latitude_longitude"
     proj_id = "latlong"
-
-    def get_proj_string(self):
-        """The value of the PROJ proj-string defining the projection."""
-        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
-        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
 
 
 class Sinusoidal(GridMapping):
@@ -1591,11 +1535,6 @@ class Sinusoidal(GridMapping):
         self.longitude_of_projection_origin = longitude_of_projection_origin
         self.false_easting = false_easting
         self.false_northing = false_northing
-
-    def get_proj_string(self):
-        """The value of the PROJ proj-string defining the projection."""
-        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
-        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
 
 
 class Stereographic(AzimuthalGridMapping):
@@ -1675,11 +1614,6 @@ class Stereographic(AzimuthalGridMapping):
             scale_factor_at_projection_origin
         )
 
-    def get_proj_string(self):
-        """The value of the PROJ proj-string defining the projection."""
-        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
-        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
-
 
 class TransverseMercator(CylindricalGridMapping):
     """The Transverse Mercator grid mapping.
@@ -1754,11 +1688,6 @@ class TransverseMercator(CylindricalGridMapping):
         self.longitude_of_central_meridian = longitude_of_central_meridian
         self.latitude_of_projection_origin = latitude_of_projection_origin
 
-    def get_proj_string(self):
-        """The value of the PROJ proj-string defining the projection."""
-        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
-        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
-
 
 class VerticalPerspective(PerspectiveGridMapping):
     """The Vertical (or Near-sided) Perspective grid mapping.
@@ -1819,11 +1748,6 @@ class VerticalPerspective(PerspectiveGridMapping):
 
     grid_mapping_name = "vertical_perspective"
     proj_id = "nsper"
-
-    def get_proj_string(self):
-        """The value of the PROJ proj-string defining the projection."""
-        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
-        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
 
 
 # TODO move this definition elsewhere, having at end feels like an

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -101,15 +101,15 @@ class GridMapping(ABC):
 
     def __init__(
         self,
-        # i.e. WGS1984_CF_ATTR_DEFAULTS.reference_ellipsoid_name:
+        # i.e. WGS1984_CF_ATTR_DEFAULTS["reference_ellipsoid_name"], etc.
         reference_ellipsoid_name="WGS 84",
+        # The next three parameters are non-zero floats so don't hard-code
+        # WGS84 defaults in case of future precision changes:
         semi_major_axis=WGS1984_CF_ATTR_DEFAULTS["semi_major_axis"],
         semi_minor_axis=WGS1984_CF_ATTR_DEFAULTS["semi_minor_axis"],
         inverse_flattening=WGS1984_CF_ATTR_DEFAULTS["inverse_flattening"],
-        prime_meridian_name=WGS1984_CF_ATTR_DEFAULTS["prime_meridian_name"],
-        longitude_of_prime_meridian=WGS1984_CF_ATTR_DEFAULTS[
-            "longitude_of_prime_meridian"
-        ],
+        prime_meridian_name="Greenwich",
+        longitude_of_prime_meridian=0.0,
         earth_radius=None,
     ):
         """**Initialisation**
@@ -194,10 +194,11 @@ class GridMapping(ABC):
         """The PROJ projection identifier shorthand name."""
         pass
 
+    @property
+    @abstractmethod
     def get_proj_string(self):
-        """TODO"""
-        # TODO finish to return parameters for full proj string
-        return f"+proj={self.proj_id}"
+        """The value of the PROJ proj-string defining the projection."""
+        pass
 
     def __repr__(self):
         """x.__repr__() <==> repr(x)"""
@@ -254,10 +255,9 @@ class AzimuthalGridMapping(GridMapping):
         latitude_of_projection_origin=0.0,
         false_easting=0.0,
         false_northing=0.0,
-        *args,
         **kwargs,
     ):
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
 
         self.longitude_of_projection_origin = longitude_of_projection_origin
         self.latitude_of_projection_origin = latitude_of_projection_origin
@@ -319,10 +319,9 @@ class ConicGridMapping(GridMapping):
         latitude_of_projection_origin=0.0,
         false_easting=0.0,
         false_northing=0.0,
-        *args,
         **kwargs,
     ):
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
 
         self.standard_parallel = standard_parallel
         self.longitude_of_central_meridian = longitude_of_central_meridian
@@ -348,8 +347,8 @@ class CylindricalGridMapping(GridMapping):
 
     """
 
-    def __init__(self, false_easting=0.0, false_northing=0.0, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, false_easting=0.0, false_northing=0.0, **kwargs):
+        super().__init__(**kwargs)
 
         self.false_easting = false_easting
         self.false_northing = false_northing
@@ -365,9 +364,7 @@ class LatLonGridMapping(GridMapping):
     .. versionadded:: GMVER
 
     """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    pass
 
 
 class PerspectiveGridMapping(AzimuthalGridMapping):
@@ -384,13 +381,8 @@ class PerspectiveGridMapping(AzimuthalGridMapping):
 
     """
 
-    def __init__(
-        self,
-        perspective_point_height,
-        *args,
-        **kwargs,
-    ):
-        super().__init__(*args, **kwargs)
+    def __init__(self, perspective_point_height, **kwargs):
+        super().__init__(**kwargs)
 
         self.perspective_point_height = perspective_point_height
 
@@ -604,7 +596,6 @@ class Geostationary(PerspectiveGridMapping):
     def __init__(
         self,
         perspective_point_height,
-        *args,
         longitude_of_projection_origin=0.0,
         latitude_of_projection_origin=0.0,
         false_easting=0.0,
@@ -615,7 +606,6 @@ class Geostationary(PerspectiveGridMapping):
     ):
         super().__init__(
             perspective_point_height,
-            *args,
             longitude_of_projection_origin=0.0,
             latitude_of_projection_origin=0.0,
             false_easting=0.0,
@@ -833,7 +823,6 @@ class LambertCylindricalEqualArea(CylindricalGridMapping):
 
     def __init__(
         self,
-        *args,
         false_easting=0.0,
         false_northing=0.0,
         standard_parallel=(0.0, None),
@@ -842,7 +831,7 @@ class LambertCylindricalEqualArea(CylindricalGridMapping):
         **kwargs,
     ):
         super().__init__(
-            *args, false_easting=0.0, false_northing=0.0, **kwargs
+            false_easting=0.0, false_northing=0.0, **kwargs
         )
 
         self.standard_parallel = standard_parallel
@@ -920,7 +909,6 @@ class Mercator(CylindricalGridMapping):
 
     def __init__(
         self,
-        *args,
         false_easting=0.0,
         false_northing=0.0,
         standard_parallel=(0.0, None),
@@ -929,7 +917,7 @@ class Mercator(CylindricalGridMapping):
         **kwargs,
     ):
         super().__init__(
-            *args, false_easting=0.0, false_northing=0.0, **kwargs
+            false_easting=0.0, false_northing=0.0, **kwargs
         )
 
         self.standard_parallel = standard_parallel
@@ -1010,7 +998,6 @@ class ObliqueMercator(CylindricalGridMapping):
 
     def __init__(
         self,
-        *args,
         azimuth_of_central_line=0.0,
         latitude_of_projection_origin=0.0,
         longitude_of_projection_origin=0.0,
@@ -1020,7 +1007,7 @@ class ObliqueMercator(CylindricalGridMapping):
         **kwargs,
     ):
         super().__init__(
-            *args, false_easting=0.0, false_northing=0.0, **kwargs
+            false_easting=0.0, false_northing=0.0, **kwargs
         )
 
         self.azimuth_of_central_line = azimuth_of_central_line
@@ -1171,7 +1158,6 @@ class PolarStereographic(AzimuthalGridMapping):
 
     def __init__(
         self,
-        *args,
         latitude_of_projection_origin=0.0,
         longitude_of_projection_origin=0.0,
         false_easting=0.0,
@@ -1184,7 +1170,6 @@ class PolarStereographic(AzimuthalGridMapping):
         # TODO check defaults here, they do not appear for
         # CRS.from_proj4("+proj=ups").to_cf() to cross reference!
         super().__init__(
-            *args,
             latitude_of_projection_origin=0.0,
             longitude_of_projection_origin=0.0,
             false_easting=0.0,
@@ -1268,11 +1253,10 @@ class RotatedLatitudeLongitude(LatLonGridMapping):
         self,
         grid_north_pole_latitude,
         grid_north_pole_longitude,
-        *args,
         north_pole_grid_longitude=0.0,
         **kwargs,
     ):
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
 
         self.grid_north_pole_latitude = grid_north_pole_latitude
         self.grid_north_pole_longitude = grid_north_pole_longitude
@@ -1354,13 +1338,12 @@ class Sinusoidal(GridMapping):
 
     def __init__(
         self,
-        *args,
         longitude_of_projection_origin=0.0,
         false_easting=0.0,
         false_northing=0.0,
         **kwargs,
     ):
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
 
         self.longitude_of_projection_origin = longitude_of_projection_origin
         self.false_easting = false_easting
@@ -1428,7 +1411,6 @@ class Stereographic(AzimuthalGridMapping):
 
     def __init__(
         self,
-        *args,
         false_easting=0.0,
         false_northing=0.0,
         longitude_of_projection_origin=0.0,
@@ -1437,7 +1419,6 @@ class Stereographic(AzimuthalGridMapping):
         **kwargs,
     ):
         super().__init__(
-            *args,
             false_easting=0.0,
             false_northing=0.0,
             longitude_of_projection_origin=0.0,
@@ -1511,7 +1492,6 @@ class TransverseMercator(CylindricalGridMapping):
 
     def __init__(
         self,
-        *args,
         scale_factor_at_central_meridian=1.0,
         longitude_of_central_meridian=0.0,
         latitude_of_projection_origin=0.0,
@@ -1520,7 +1500,7 @@ class TransverseMercator(CylindricalGridMapping):
         **kwargs,
     ):
         super().__init__(
-            *args, false_easting=0.0, false_northing=0.0, **kwargs
+            false_easting=0.0, false_northing=0.0, **kwargs
         )
 
         self.scale_factor_at_central_meridian = (

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -57,7 +57,7 @@ class GridMapping:
         earth_radius=None,
         inverse_flattening=None,
         longitude_of_prime_meridian=None,
-        prime_meridian_name=None,
+        prime_meridian_name="Greenwich",
         reference_ellipsoid_name=None,
         semi_major_axis=None,
         semi_minor_axis=None,
@@ -66,32 +66,67 @@ class GridMapping:
 
         :Parameters:
 
-            grid_mapping_name: string
-                TODO
+        Parameters to define the grid mapping:
 
-            proj_id: string
-                TODO "_proj" projection name
+            grid_mapping_name: `str`
+                The value of the 'grid_mapping_name' attribute
+                attached to a data variable, for example
+                "mercator" to indicate the Mercator projection.
+
+            proj_id: `str`
+                The PROJ projection identifier shorthand name that
+                corresponds to the specified 'grid_mapping_name'
+                attribute, for example "merc" for the Mercator
+                projection. This is the initial component in the
+                PROJ 'proj-string' to describe the coordinate
+                transformation.
+
+                .. note:: Do not specify the full 'proj-string'
+                          including parameters, and do not specify
+                          the projection specifier '+proj' as a
+                          prefix. Only give the projection ID.
+
+        Parameters to define the ellipsoid size and shape:
 
             earth_radius: number, optional
-                TODO
+                The radius of the sphere e.g. Earth (PROJ 'R' value),
+                in units of meters. The default is TODO.
 
-            inverse_flattening: TODO, optional
-                TODO
+                If used in conjunction with 'reference_ellipsoid_name',
+                this parameter takes precedence.
+
+            reference_ellipsoid_name: `str` or `None`, optional
+                The name of a built-in ellipsoid definition.
+                The default is `None`.
+
+                If used in conjunction with 'earth_radius', the
+                'earth_radius' parameter takes precedence.
+
+            inverse_flattening: number, optional
+                The reverse flattening of the ellipsoid (PROJ 'rf'
+                value), :math:`\frac{1}{f}`, where f corresponds to
+                the flattening value (PROJ 'f' value) for the ellipsoid,
+                in units of TODO. The default is TODO.
 
             longitude_of_prime_meridian: TODO, optional
                 TODO
 
-            prime_meridian_name: TODO, optional
-                TODO
+            prime_meridian_name: `str`, optional
+                The name, or the longitude relative to greenwich, of
+                the prime meridian (PROJ 'pm' value). The default is
+                "Greenwich". Supported names and corresponding
+                longitudes are listed at:
 
-            reference_ellipsoid_name: TODO, optional
-                TODO
+                https://proj.org/en/9.2/usage/
+                projections.html#prime-meridian
 
-            semi_major_axis: TODO, optional
-                TODO
+            semi_major_axis: number, optional
+                The semi-major axis of the ellipsoid (PROJ 'a' value)
+                in units of TODO. The default is TODO.
 
-            semi_minor_axis: TODO, optional
-                TODO
+            semi_minor_axis: number, optional
+                The semi-minor axis of the ellipsoid (PROJ 'b' value)
+                in units of TODO. The default is TODO.
 
         """
         if not grid_mapping_name and not proj_id:

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -104,39 +104,36 @@ WGS1984_CF_ATTR_DEFAULTS = CRS.from_proj4("+proj=merc").to_cf()
 DUMMY_PARAMS = {"a": "b", "c": 0.0}  # TODOPARAMETERS, drop this
 
 
-def _convert_units_cf_to_proj(cf_units):
-    """Take CF units and convert them to equivalent units under PROJ.
+def convert_proj_angular_data_to_cf(proj_data, context=None):
+    """Take a PROJ angular data component and convert it to CF Data with CF Units.
 
     Note that PROJ units for latitude and longitude are in
     units of decimal degrees, where forming a string by adding
     a suffix character indicates alternative units of
     radians if the suffix is 'R' or 'r'. If a string, a suffix
-    of 'd', 'D' or '°' confirm units of decimal degrees. The default
-    is usually 0.0 decimal degrees. For more information, see:
+    of 'd', 'D' or '°' confirm units of decimal degrees.
 
-    https://proj.org/en/9.2/usage/projections.html#projection-units
+    .. versionadded:: GMVER
 
-    TODO finish docs
+    :Parameters:
 
-    """
-    value = None
-    proj_units = None
-    return value, proj_units
+        proj_data: `str`
+            The PROJ angular data component, for example "90", "90.0",
+             "90.0D", "1.0R", or "1r".
 
+            For details on valid PROJ data components in PROJ strings,
+            notably indicating units, see:
 
-def _convert_units_proj_to_cf(proj_val_with_units, context=None):
-    """Take units used in PROJ and convert them to CF units.
+            https://proj.org/en/9.2/usage/projections.html#projection-units
 
-    Note that PROJ units for latitude and longitude are in
-    units of decimal degrees, where forming a string by adding
-    a suffix character indicates alternative units of
-    radians if the suffix is 'R' or 'r'. If a string, a suffix
-    of 'd', 'D' or '°' confirm units of decimal degrees. The default
-    is usually 0.0 decimal degrees. For more information, see:
-
-    https://proj.org/en/9.2/usage/projections.html#projection-units
-
-    TODO finish docs
+        context: `str` or `None`, optional
+            The physical context of the conversion, where 'lat' indicates
+            a latitude value and 'lon' indicates a longitude, such that
+            indication of either context will return cf.Data with values
+            having units appropriate to that context, namely 'degrees_north'
+            or 'degrees_east' respectively. If None, 'degrees' or 'radians'
+            (depending on the input PROJ units) will be the units.
+            The default is None.
 
     """
     cf_compatible = True  # unless find otherwise (True unless proven False)
@@ -163,7 +160,7 @@ def _convert_units_proj_to_cf(proj_val_with_units, context=None):
     # exact regex match, because anything not following the pattern (e.g.
     # something with extra letters) will be ambiguous for PROJ units.
     valid_form = re.compile("(-?\d+(\.\d+)?)([rRdD°]?)")
-    form = re.fullmatch(valid_form, proj_val_with_units)
+    form = re.fullmatch(valid_form, proj_data)
     if form:
         comps = form.groups()
         suffix = None

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -948,10 +948,10 @@ class Geostationary(PerspectiveGridMapping):
     ):
         super().__init__(
             perspective_point_height,
-            longitude_of_projection_origin=0.0,
-            latitude_of_projection_origin=0.0,
-            false_easting=0.0,
-            false_northing=0.0,
+            longitude_of_projection_origin=longitude_of_projection_origin,
+            latitude_of_projection_origin=latitude_of_projection_origin,
+            false_easting=false_easting,
+            false_northing=false_northing,
             **kwargs,
         )
 
@@ -1170,7 +1170,11 @@ class LambertCylindricalEqualArea(CylindricalGridMapping):
         longitude_of_central_meridian=0.0,
         **kwargs,
     ):
-        super().__init__(false_easting=0.0, false_northing=0.0, **kwargs)
+        super().__init__(
+            false_easting=false_easting,
+            false_northing=false_northing,
+            **kwargs,
+        )
 
         self.standard_parallel = (
             _validate_map_parameter("standard_parallel", standard_parallel[0]),
@@ -1259,7 +1263,11 @@ class Mercator(CylindricalGridMapping):
         scale_factor_at_projection_origin=1.0,
         **kwargs,
     ):
-        super().__init__(false_easting=0.0, false_northing=0.0, **kwargs)
+        super().__init__(
+            false_easting=false_easting,
+            false_northing=false_northing,
+            **kwargs,
+        )
 
         self.standard_parallel = (
             _validate_map_parameter("standard_parallel", standard_parallel[0]),
@@ -1348,7 +1356,11 @@ class ObliqueMercator(CylindricalGridMapping):
         false_northing=0.0,
         **kwargs,
     ):
-        super().__init__(false_easting=0.0, false_northing=0.0, **kwargs)
+        super().__init__(
+            false_easting=false_easting,
+            false_northing=false_northing,
+            **kwargs,
+        )
 
         self.azimuth_of_central_line = _validate_map_parameter(
             "azimuth_of_central_line", azimuth_of_central_line
@@ -1512,10 +1524,10 @@ class PolarStereographic(AzimuthalGridMapping):
         # TODO check defaults here, they do not appear for
         # CRS.from_proj4("+proj=ups").to_cf() to cross reference!
         super().__init__(
-            latitude_of_projection_origin=0.0,
-            longitude_of_projection_origin=0.0,
-            false_easting=0.0,
-            false_northing=0.0,
+            latitude_of_projection_origin=latitude_of_projection_origin,
+            longitude_of_projection_origin=longitude_of_projection_origin,
+            false_easting=false_easting,
+            false_northing=false_northing,
             **kwargs,
         )
 
@@ -1753,10 +1765,10 @@ class Stereographic(AzimuthalGridMapping):
         **kwargs,
     ):
         super().__init__(
-            false_easting=0.0,
-            false_northing=0.0,
-            longitude_of_projection_origin=0.0,
-            latitude_of_projection_origin=0.0,
+            false_easting=false_easting,
+            false_northing=false_northing,
+            longitude_of_projection_origin=longitude_of_projection_origin,
+            latitude_of_projection_origin=latitude_of_projection_origin,
             **kwargs,
         )
 
@@ -1831,7 +1843,11 @@ class TransverseMercator(CylindricalGridMapping):
         false_northing=0.0,
         **kwargs,
     ):
-        super().__init__(false_easting=0.0, false_northing=0.0, **kwargs)
+        super().__init__(
+            false_easting=false_easting,
+            false_northing=false_northing,
+            **kwargs,
+        )
 
         self.scale_factor_at_central_meridian = _validate_map_parameter(
             "scale_factor_at_central_meridian",

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -3,23 +3,23 @@ from pyproj import CRS
 ALL_GRID_MAPPING_ATTR_NAMES = {
     "grid_mapping_name",
     # *Those which describe the ellipsoid and prime meridian:*
-    "earth_radius",
-    "inverse_flattening",
+    "earth_radius",  # PROJ +R
+    "inverse_flattening",  # PROJ "+rf"
     "longitude_of_prime_meridian",
-    "prime_meridian_name",
-    "reference_ellipsoid_name",
-    "semi_major_axis",
-    "semi_minor_axis",
+    "prime_meridian_name",  # PROJ +pm
+    "reference_ellipsoid_name",  # PROJ +ellps
+    "semi_major_axis",  # PROJ "+a"
+    "semi_minor_axis",  # PROJ "+b"
     # *Specific/applicable to only given grid mapping(s):*
     # ...projection origin related:
-    "longitude_of_projection_origin",
-    "latitude_of_projection_origin",
-    "scale_factor_at_projection_origin",
+    "longitude_of_projection_origin",  # PROJ +lon_0
+    "latitude_of_projection_origin",  # PROJ +lat_0
+    "scale_factor_at_projection_origin",  # PROJ k_0
     # ...false-Xings:
-    "false_easting",
-    "false_northing",
+    "false_easting",  # PROJ +x_0
+    "false_northing",  # PROJ +y_0
     # ...angle axis related:
-    "sweep_angle_axis",
+    "sweep_angle_axis",  # PROJ +sweep
     "fixed_angle_axis",
     # ...central meridian related:
     "longitude_of_central_meridian",
@@ -29,21 +29,22 @@ ALL_GRID_MAPPING_ATTR_NAMES = {
     "grid_north_pole_longitude",
     "north_pole_grid_longitude",
     # ...other:
-    "standard_parallel",
-    "perspective_point_height",
-    "azimuth_of_central_line",
-    "straight_vertical_longitude_from_pole",
+    "standard_parallel",  # PROJ ["+lat_1", "+lat_2"] (up to 2)
+    "perspective_point_height",  # PROJ "+h"
+    "azimuth_of_central_line",  # PROJ +gamma OR +alpha
+    "straight_vertical_longitude_from_pole",  # PROJ +south
     # *Other, not needed for a specific grid mapping but also listed
     # in 'Table F.1. Grid Mapping Attributes':*
-    "crs_wkt",
-    "geographic_crs_name",
-    "geoid_name",
+    "crs_wkt" "geographic_crs_name",  # PROJ "crs_wkt",  # PROJ geoid_crs
+    "geoid_name",  # PROJ geoidgrids
     "geopotential_datum_name",
     "horizontal_datum_name",
-    "inverse_flattening",
     "projected_crs_name",
-    "towgs84",
+    "towgs84",  # PROJ +towgs84
 }
+
+
+"""Abstract classes for general Grid Mappings."""
 
 
 class GridMapping:
@@ -69,7 +70,7 @@ class GridMapping:
                 TODO
 
             proj_id: string
-                TODO
+                TODO "_proj" projection name
 
             earth_radius: number, optional
                 TODO
@@ -101,62 +102,109 @@ class GridMapping:
                 "base PROJ '+proj' identifier with the proj_id parameter."
             )
 
+        # Defining the Grid Mapping
+        self.grid_mapping_name = grid_mapping_name
+        self.proj_id = proj_id
+
+        # The attributes which describe the ellipsoid and prime meridian,
+        # which may be included, when applicable, with any grid mapping
+        self.earth_radius = earth_radius
+        self.inverse_flattening = inverse_flattening
+        self.longitude_of_prime_meridian = longitude_of_prime_meridian
+        self.prime_meridian_name = prime_meridian_name
+        self.reference_ellipsoid_name = reference_ellipsoid_name
+        self.semi_major_axis = semi_major_axis
+        self.semi_minor_axis = semi_minor_axis
+
 
 class AzimuthalGridMapping(GridMapping):
-    """TODO."""
+    """A Grid Mapping with Azimuthal classification."""
 
     def __init__(
         self,
         longitude_of_projection_origin,
         latitude_of_projection_origin,
+        false_easting,
+        false_northing,
         *args,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
 
+        self.longitude_of_projection_origin = longitude_of_projection_origin
+        self.latitude_of_projection_origin = latitude_of_projection_origin
+        self.false_easting = false_easting
+        self.false_northing = false_northing
+
 
 class ConicGridMapping(GridMapping):
-    """TODO."""
+    """A Grid Mapping with Conic classification."""
 
     def __init__(
-        self, standard_parallel, longitude_of_central_meridian, *args, **kwargs
+        self,
+        standard_parallel,
+        longitude_of_central_meridian,
+        latitude_of_projection_origin,
+        false_easting,
+        false_northing,
+        *args,
+        **kwargs,
     ):
         super().__init__(*args, **kwargs)
 
+        self.standard_parallel = standard_parallel
+        self.longitude_of_central_meridian = longitude_of_central_meridian
+        self.latitude_of_projection_origin = latitude_of_projection_origin
+        self.false_easting = false_easting
+        self.false_northing = false_northing
+
 
 class CylindricalGridMapping(GridMapping):
-    """TODO."""
+    """A Grid Mapping with Cylindrical classification."""
 
     def __init__(self, false_easting, false_northing, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        self.false_easting = false_easting
+        self.false_northing = false_northing
+
 
 class LatLonGridMapping(GridMapping):
-    """TODO."""
+    """A Grid Mapping with Latitude-Longitude nature.
+
+    Such a Grid Mapping is based upon latitude and longitude coordinates
+    on a spherical Earth, defining the canonical 2D geographical coordinate
+    system so that the figure of the Earth can be described.
+
+    """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
 
 class PerspectiveGridMapping(AzimuthalGridMapping):
-    """TODO."""
+    """A Grid Mapping with Azimuthal classification and perspective view."""
 
     def __init__(
         self,
-        false_easting,
-        false_northing,
         perspective_point_height,
         *args,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
 
+        self.perspective_point_height = perspective_point_height
 
-class StereographicGridMapping(AzimuthalGridMapping):
-    """TODO."""
 
-    def __init__(self, false_easting, false_northing, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+"""Concrete classes for all Grid Mappings supported by the CF Conventions.
+
+For the full listing, see:
+
+https://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/
+cf-conventions.html#appendix-grid-mappings
+
+from which these classes should be kept consistent and up-to-date.
+"""
 
 
 class AlbersEqualArea(ConicGridMapping):
@@ -180,7 +228,7 @@ class AlbersEqualArea(ConicGridMapping):
         self,
         standard_parallel,
         longitude_of_central_meridian,
-        atitude_of_projection_origin,
+        latitude_of_projection_origin,
         false_easting,
         false_northing,
         *args,
@@ -237,17 +285,20 @@ class Geostationary(PerspectiveGridMapping):
 
     def __init__(
         self,
-        latitude_of_projection_origin,
         longitude_of_projection_origin,
-        perspective_point_height,
+        latitude_of_projection_origin,
         false_easting,
         false_northing,
+        perspective_point_height,
         sweep_angle_axis,
         fixed_angle_axis,
         *args,
         **kwargs,
     ):
         super().__init__("geostationary", "geos", *args, **kwargs)
+
+        self.sweep_angle_axis = sweep_angle_axis
+        self.fixed_angle_axis = fixed_angle_axis
 
 
 class LambertAzimuthalEqualArea(AzimuthalGridMapping):
@@ -330,16 +381,22 @@ class LambertCylindricalEqualArea(CylindricalGridMapping):
 
     def __init__(
         self,
-        longitude_of_central_meridian,
-        standard_parallel,
-        scale_factor_at_projection_origin,
         false_easting,
         false_northing,
+        standard_parallel,
+        longitude_of_central_meridian,
+        scale_factor_at_projection_origin,
         *args,
         **kwargs,
     ):
         super().__init__(
             "lambert_cylindrical_equal_area", "cea", *args, **kwargs
+        )
+
+        self.standard_parallel = standard_parallel
+        self.longitude_of_central_meridian = longitude_of_central_meridian
+        self.scale_factor_at_projection_origin = (
+            scale_factor_at_projection_origin
         )
 
 
@@ -362,15 +419,21 @@ class Mercator(CylindricalGridMapping):
 
     def __init__(
         self,
-        longitude_of_projection_origin,
-        standard_parallel,
-        scale_factor_at_projection_origin,
         false_easting,
         false_northing,
+        standard_parallel,
+        longitude_of_projection_origin,
+        scale_factor_at_projection_origin,
         *args,
         **kwargs,
     ):
         super().__init__("mercator", "merc", *args, **kwargs)
+
+        self.standard_parallel = standard_parallel
+        self.longitude_of_projection_origin = longitude_of_projection_origin
+        self.scale_factor_at_projection_origin = (
+            scale_factor_at_projection_origin
+        )
 
 
 class ObliqueMercator(CylindricalGridMapping):
@@ -392,16 +455,23 @@ class ObliqueMercator(CylindricalGridMapping):
 
     def __init__(
         self,
+        false_easting,
+        false_northing,
         azimuth_of_central_line,
         latitude_of_projection_origin,
         longitude_of_projection_origin,
         scale_factor_at_projection_origin,
-        false_easting,
-        false_northing,
         *args,
         **kwargs,
     ):
         super().__init__("oblique_mercator", "omerc", *args, **kwargs)
+
+        self.azimuth_of_central_line = azimuth_of_central_line
+        self.latitude_of_projection_origin = latitude_of_projection_origin
+        self.longitude_of_projection_origin = longitude_of_projection_origin
+        self.scale_factor_at_projection_origin = (
+            scale_factor_at_projection_origin
+        )
 
 
 class Orthographic(AzimuthalGridMapping):
@@ -433,7 +503,7 @@ class Orthographic(AzimuthalGridMapping):
         super().__init__("orthographic", "ortho", *args, **kwargs)
 
 
-class PolarStereographic(StereographicGridMapping):
+class PolarStereographic(AzimuthalGridMapping):
     """The Universal Polar Stereographic grid mapping.
 
     See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
@@ -452,16 +522,35 @@ class PolarStereographic(StereographicGridMapping):
 
     def __init__(
         self,
-        straight_vertical_longitude_from_pole,
         latitude_of_projection_origin,
-        standard_parallel,
-        scale_factor_at_projection_origin,
         false_easting,
         false_northing,
+        standard_parallel,
+        scale_factor_at_projection_origin,
+        longitude_of_projection_origin=None,
+        straight_vertical_longitude_from_pole=None,
         *args,
         **kwargs,
     ):
         super().__init__("polar_stereographic", "ups", *args, **kwargs)
+
+        # See: https://github.com/cf-convention/cf-conventions/issues/445
+        if (
+            longitude_of_projection_origin
+            and straight_vertical_longitude_from_pole
+        ):
+            raise ValueError(
+                "Only one of 'longitude_of_projection_origin' and "
+                "'straight_vertical_longitude_from_pole' can be set."
+            )
+
+        self.straight_vertical_longitude_from_pole = (
+            straight_vertical_longitude_from_pole
+        )
+        self.standard_parallel = standard_parallel
+        self.scale_factor_at_projection_origin = (
+            scale_factor_at_projection_origin
+        )
 
 
 class RotatedLatitudeLongitude(LatLonGridMapping):
@@ -491,8 +580,12 @@ class RotatedLatitudeLongitude(LatLonGridMapping):
     ):
         super().__init__("rotated_latitude_longitude", "eqc", *args, **kwargs)
 
+        self.grid_north_pole_latitude = grid_north_pole_latitude
+        self.grid_north_pole_longitude = grid_north_pole_longitude
+        self.north_pole_grid_longitude = north_pole_grid_longitude
 
-class LatitudeLongitude(RotatedLatitudeLongitude):
+
+class LatitudeLongitude(LatLonGridMapping):
     """The Latitude-Longitude i.e. Plate Carrée grid mapping.
 
     For alternative names, see e.g:
@@ -544,8 +637,12 @@ class Sinusoidal(GridMapping):
     ):
         super().__init__("sinusoidal", "sinu", *args, **kwargs)
 
+        self.longitude_of_projection_origin = longitude_of_projection_origin
+        self.false_easting = false_easting
+        self.false_northing = false_northing
 
-class Stereographic(StereographicGridMapping):
+
+class Stereographic(AzimuthalGridMapping):
     """The Stereographic grid mapping.
 
     See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
@@ -566,13 +663,17 @@ class Stereographic(StereographicGridMapping):
         self,
         longitude_of_projection_origin,
         latitude_of_projection_origin,
-        scale_factor_at_projection_origin,
         false_easting,
         false_northing,
+        scale_factor_at_projection_origin,
         *args,
         **kwargs,
     ):
         super().__init__("stereographic", "stere", *args, **kwargs)
+
+        self.scale_factor_at_projection_origin = (
+            scale_factor_at_projection_origin
+        )
 
 
 class TransverseMercator(CylindricalGridMapping):
@@ -594,15 +695,21 @@ class TransverseMercator(CylindricalGridMapping):
 
     def __init__(
         self,
+        false_easting,
+        false_northing,
         scale_factor_at_central_meridian,
         longitude_of_central_meridian,
         latitude_of_projection_origin,
-        false_easting,
-        false_northing,
         *args,
         **kwargs,
     ):
         super().__init__("transverse_mercator", "tmerc", *args, **kwargs)
+
+        self.scale_factor_at_central_meridian = (
+            scale_factor_at_central_meridian
+        )
+        self.longitude_of_central_meridian = longitude_of_central_meridian
+        self.latitude_of_projection_origin = latitude_of_projection_origin
 
 
 class VerticalPerspective(PerspectiveGridMapping):
@@ -624,11 +731,11 @@ class VerticalPerspective(PerspectiveGridMapping):
 
     def __init__(
         self,
-        latitude_of_projection_origin,
         longitude_of_projection_origin,
-        perspective_point_height,
+        latitude_of_projection_origin,
         false_easting,
         false_northing,
+        perspective_point_height,
         *args,
         **kwargs,
     ):

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -165,20 +165,19 @@ def _convert_units_proj_to_cf(proj_val_with_units, context=None):
     valid_form = re.compile("(\d+(\.\d+)?)([rRdD°]?)")
     form = re.fullmatch(valid_form, proj_val_with_units)
     if form:
-        suffix, float_comp = None, None
-        if len(form.groups()) == 3:
-            value, float_comp, suffix = form.groups()
-            #if float_comp:
-            #    is_flaot= True
-            #print("FOR", form, "GET", value, is_float, suffix)
-        elif len(form.groups()) == 2:
-            value, float_comp = form.groups()
+        comps = form.groups()
+        suffix = None
+        if len(comps) == 3:
+            value, float_comp, suffix = comps
         else:
-            value = form.groups()
+            value, *float_comp = comps
+
+        print("%%%%%%%", value, float_comp, suffix)
 
         if suffix in ("r", "R"):  # radians units
             cf_units = "radians"
             # Convert to decimal so we can store the degree_X form from context:
+            # TODO
         elif suffix and suffix not in ("d", "D", "°"):  # 'decimal degrees' units
             cf_compatible = False
     else:

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -729,18 +729,19 @@ class LambertCylindricalEqualArea(CylindricalGridMapping):
         longitude_of_central_meridian: TODO
             TODO
 
-        scale_factor_at_projection_origin: TODO
-            TODO
+        scale_factor_at_projection_origin: number, optional
+            The scale factor at natural origin (PROJ 'k_0' value). It
+            is unitless. The default is 1.0.
 
     """
 
     def __init__(
         self,
         longitude_of_central_meridian,
-        scale_factor_at_projection_origin,
         standard_parallel=(0.0, 0.0),
         false_easting=0.0,
         false_northing=0.0,
+        scale_factor_at_projection_origin=1.0,
         *args,
         **kwargs,
     ):
@@ -802,18 +803,19 @@ class Mercator(CylindricalGridMapping):
             of 'd', 'D' or '°' confirm units of decimal degrees. The default
             is 0.0 decimal degrees.
 
-        scale_factor_at_projection_origin: TODO
-            TODO
+        scale_factor_at_projection_origin: number, optional
+            The scale factor at natural origin (PROJ 'k_0' value). It
+            is unitless. The default is 1.0.
 
     """
 
     def __init__(
         self,
-        scale_factor_at_projection_origin,
         standard_parallel=(0.0, 0.0),
         longitude_of_projection_origin=0.0,
         false_easting=0.0,
         false_northing=0.0,
+        scale_factor_at_projection_origin=1.0,
         *args,
         **kwargs,
     ):
@@ -872,19 +874,20 @@ class ObliqueMercator(CylindricalGridMapping):
             of 'd', 'D' or '°' confirm units of decimal degrees. The default
             is 0.0 decimal degrees.
 
-        scale_factor_at_projection_origin: TODO
-            TODO
+        scale_factor_at_projection_origin: number, optional
+            The scale factor at natural origin (PROJ 'k_0' value). It
+            is unitless. The default is 1.0.
 
     """
 
     def __init__(
         self,
-        scale_factor_at_projection_origin,
         azimuth_of_central_line,
         latitude_of_projection_origin=0.0,
         longitude_of_projection_origin=0.0,
         false_easting=0.0,
         false_northing=0.0,
+        scale_factor_at_projection_origin=1.0,
         *args,
         **kwargs,
     ):
@@ -993,8 +996,9 @@ class PolarStereographic(AzimuthalGridMapping):
             of 'd', 'D' or '°' confirm units of decimal degrees. The default
             is 0.0 decimal degrees.
 
-        scale_factor_at_projection_origin: TODO
-            TODO
+        scale_factor_at_projection_origin: number, optional
+            The scale factor at natural origin (PROJ 'k_0' value). It
+            is unitless. The default is 1.0.
 
         false_easting: number, optional
             The false easting (PROJ 'x_0') value, in units of metres.
@@ -1020,13 +1024,13 @@ class PolarStereographic(AzimuthalGridMapping):
 
     def __init__(
         self,
-        scale_factor_at_projection_origin,
         standard_parallel=(0.0, 0.0),
         latitude_of_projection_origin=0.0,
         longitude_of_projection_origin=0.0,
         straight_vertical_longitude_from_pole=None,
         false_easting=0.0,
         false_northing=0.0,
+        scale_factor_at_projection_origin=1.0,
         *args,
         **kwargs,
     ):
@@ -1218,18 +1222,19 @@ class Stereographic(AzimuthalGridMapping):
             The false northing (PROJ 'y_0') value, in units of metres.
             The default is 0.0.
 
-        scale_factor_at_projection_origin: TODO
-            TODO
+        scale_factor_at_projection_origin: number, optional
+            The scale factor at natural origin (PROJ 'k_0' value). It
+            is unitless. The default is 1.0.
 
     """
 
     def __init__(
         self,
-        scale_factor_at_projection_origin,
         false_easting=0.0,
         false_northing=0.0,
         longitude_of_projection_origin=0.0,
         latitude_of_projection_origin=0.0,
+        scale_factor_at_projection_origin=1.0,
         *args,
         **kwargs,
     ):

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -4,85 +4,16 @@ from abc import ABC, abstractmethod
 
 from pyproj import CRS
 
+from .constants import (
+    cr_gm_valid_attr_names_are_numeric,
+    cr_gm_attr_to_proj_string_comps,
+)
 from .data import Data
 from .data.utils import is_numeric_dtype
 from .units import Units
 
 
 PROJ_PREFIX = "+proj"
-
-# Grid Mapping valid attribute names. Taken from the list given in
-# 'Table F.1. Grid Mapping Attributes' in Appendix F: Grid Mappings'
-# of the Conventions document.
-#
-# Values indicate if attribute values are expected to be numeric (instead
-# of string) for the given attribute key (the table defines this via N, S).
-ALL_GRID_MAPPING_ATTR_NAMES = {
-    "grid_mapping_name": False,
-    # *Those which describe the ellipsoid and prime meridian:*
-    "earth_radius": True,
-    "inverse_flattening": True,
-    "longitude_of_prime_meridian": True,
-    "prime_meridian_name": False,
-    "reference_ellipsoid_name": False,
-    "semi_major_axis": True,
-    "semi_minor_axis": True,
-    # *Specific/applicable to only given grid mapping(s):*
-    # ...projection origin related:
-    "longitude_of_projection_origin": True,
-    "latitude_of_projection_origin": True,
-    "scale_factor_at_projection_origin": True,
-    # ...false-Xings:
-    "false_easting": True,
-    "false_northing": True,
-    # ...angle axis related:
-    "sweep_angle_axis": False,
-    "fixed_angle_axis": False,
-    # ...central meridian related:
-    "longitude_of_central_meridian": True,
-    "scale_factor_at_central_meridian": True,
-    # ...pole coordinates related:
-    "grid_north_pole_latitude": True,
-    "grid_north_pole_longitude": True,
-    "north_pole_grid_longitude": True,
-    # ...other:
-    "standard_parallel": True,
-    "perspective_point_height": True,
-    "azimuth_of_central_line": True,
-    "straight_vertical_longitude_from_pole": True,
-    # *Other, not needed for a specific grid mapping but also listed
-    # in 'Table F.1. Grid Mapping Attributes':*
-    "crs_wkt": False,
-    "geographic_crs_name": False,
-    "geoid_name": False,
-    "geopotential_datum_name": False,
-    "horizontal_datum_name": False,
-    "projected_crs_name": False,
-    "towgs84": True,
-}
-
-# Indicates what PROJ string ID component(s) refer(s) to the grid mapping
-# attribute in question when '+' is added as a suffix, for example
-# 'earth_radius' is '+R' and 'inverse_flattening' is '+rf'
-GRID_MAPPING_ATTR_TO_PROJ_STRING_COMP_VALUES = {
-    "earth_radius": "R",
-    "inverse_flattening": "rf",
-    "prime_meridian_name": "pm",
-    "reference_ellipsoid_name": "ellps",
-    "semi_major_axis": "a",
-    "semi_minor_axis": "b",
-    "longitude_of_projection_origin": "lon_0",
-    "latitude_of_projection_origin": "lat_0",
-    "scale_factor_at_projection_origin": "k_0",
-    "false_easting": "x_0",
-    "false_northing": "y_0",
-    "sweep_angle_axis": "sweep",
-    "standard_parallel": ("lat_1", "lat_2"),
-    "perspective_point_height": "h",
-    "azimuth_of_central_line": ("alpha", "gamma"),
-    "crs_wkt": "crs_wkt",
-    "towgs84": "towgs84",
-}
 
 
 """
@@ -403,7 +334,7 @@ class GridMapping(ABC):
 
         """
         for kwarg in kwargs:
-            if kwarg not in ALL_GRID_MAPPING_ATTR_NAMES:
+            if kwarg not in cr_gm_valid_attr_names_are_numeric:
                 raise ValueError(
                     "Unrecognised map parameter provided for the "
                     f"Grid Mapping: {kwarg}"

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -1,47 +1,49 @@
+from pyproj import CRS
+
 ALL_GRID_MAPPING_ATTR_NAMES = {
-        "grid_mapping_name",
-        # *Those which describe the ellipsoid and prime meridian:*
-        "earth_radius",
-        "inverse_flattening",
-        "longitude_of_prime_meridian",
-        "prime_meridian_name",
-        "reference_ellipsoid_name",
-        "semi_major_axis",
-        "semi_minor_axis",
-        # *Specific/applicable to only given grid mapping(s):*
-        # ...projection origin related:
-        "longitude_of_projection_origin",
-        "latitude_of_projection_origin",
-        "scale_factor_at_projection_origin",
-        # ...false-Xings:
-        "false_easting",
-        "false_northing",
-        # ...angle axis related:
-        "sweep_angle_axis",
-        "fixed_angle_axis",
-        # ...central meridian related:
-        "longitude_of_central_meridian",
-        "scale_factor_at_central_meridian",
-        # ...pole coordinates related:
-        "grid_north_pole_latitude",
-        "grid_north_pole_longitude",
-        "north_pole_grid_longitude",
-        # ...other:
-        "standard_parallel",
-        "perspective_point_height",
-        "azimuth_of_central_line",
-        "straight_vertical_longitude_from_pole",
-        # *Other, not needed for a specific grid mapping but also listed
-        # in 'Table F.1. Grid Mapping Attributes':*
-        "crs_wkt",
-        "geographic_crs_name",
-        "geoid_name",
-        "geopotential_datum_name",
-        "horizontal_datum_name",
-        "inverse_flattening",
-        "projected_crs_name",
-        "towgs84",
-    }
+    "grid_mapping_name",
+    # *Those which describe the ellipsoid and prime meridian:*
+    "earth_radius",
+    "inverse_flattening",
+    "longitude_of_prime_meridian",
+    "prime_meridian_name",
+    "reference_ellipsoid_name",
+    "semi_major_axis",
+    "semi_minor_axis",
+    # *Specific/applicable to only given grid mapping(s):*
+    # ...projection origin related:
+    "longitude_of_projection_origin",
+    "latitude_of_projection_origin",
+    "scale_factor_at_projection_origin",
+    # ...false-Xings:
+    "false_easting",
+    "false_northing",
+    # ...angle axis related:
+    "sweep_angle_axis",
+    "fixed_angle_axis",
+    # ...central meridian related:
+    "longitude_of_central_meridian",
+    "scale_factor_at_central_meridian",
+    # ...pole coordinates related:
+    "grid_north_pole_latitude",
+    "grid_north_pole_longitude",
+    "north_pole_grid_longitude",
+    # ...other:
+    "standard_parallel",
+    "perspective_point_height",
+    "azimuth_of_central_line",
+    "straight_vertical_longitude_from_pole",
+    # *Other, not needed for a specific grid mapping but also listed
+    # in 'Table F.1. Grid Mapping Attributes':*
+    "crs_wkt",
+    "geographic_crs_name",
+    "geoid_name",
+    "geopotential_datum_name",
+    "horizontal_datum_name",
+    "inverse_flattening",
+    "projected_crs_name",
+    "towgs84",
+}
 
 
 class GridMapping:
@@ -49,8 +51,8 @@ class GridMapping:
 
     def __init__(
         self,
-        grid_mapping_name,
-        proj_id,
+        grid_mapping_name=None,
+        proj_id=None,
         earth_radius=None,
         inverse_flattening=None,
         longitude_of_prime_meridian=None,
@@ -91,15 +93,62 @@ class GridMapping:
                 TODO
 
         """
-        raise NotImplementedError(
-            "Must define a specific Grid Mapping via setting its CF "
-            "Conventions 'grid_mapping_name' attribute value with the "
-            "grid_mapping_name parameter, as well as the corresponding "
-            "base PROJ '+proj' identifier with the proj_id parameter."
-        )
+        if not grid_mapping_name and not proj_id:
+            raise NotImplementedError(
+                "Must define a specific Grid Mapping via setting its CF "
+                "Conventions 'grid_mapping_name' attribute value with the "
+                "grid_mapping_name parameter, as well as the corresponding "
+                "base PROJ '+proj' identifier with the proj_id parameter."
+            )
 
 
-class AlbersEqualArea(GridMapping):
+class AzimuthalGridMapping(GridMapping):
+    """TODO."""
+
+    def __init__(
+        self, longitude_of_projection_origin, latitude_of_projection_origin
+    ):
+        super().__init__()
+
+
+class ConicGridMapping(GridMapping):
+    """TODO."""
+
+    def __init__(self, standard_parallel, longitude_of_central_meridian):
+        super().__init__()
+
+
+class CylindricalGridMapping(GridMapping):
+    """TODO."""
+
+    def __init__(self, false_easting, false_northing):
+        super().__init__()
+
+
+class LatLonGridMapping(GridMapping):
+    """TODO."""
+
+    def __init__(self):
+        super().__init__()
+
+
+class PerspectiveGridMapping(AzimuthalGridMapping):
+    """TODO."""
+
+    def __init__(
+        self, false_easting, false_northing, perspective_point_height
+    ):
+        super().__init__()
+
+
+class StereographicGridMapping(AzimuthalGridMapping):
+    """TODO."""
+
+    def __init__(self, false_easting, false_northing):
+        super().__init__()
+
+
+class AlbersEqualArea(ConicGridMapping):
     """The Albers Equal Area grid mapping.
 
     See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
@@ -120,7 +169,7 @@ class AlbersEqualArea(GridMapping):
         super().__init__("albers_conical_equal_area", "aea")
 
 
-class AzimuthalEquidistant(GridMapping):
+class AzimuthalEquidistant(AzimuthalGridMapping):
     """The Azimuthal Equidistant grid mapping.
 
     See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
@@ -141,7 +190,7 @@ class AzimuthalEquidistant(GridMapping):
         super().__init__("azimuthal_equidistant", "aeqd")
 
 
-class Geostationary(GridMapping):
+class Geostationary(PerspectiveGridMapping):
     """The Geostationary Satellite View grid mapping.
 
     See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
@@ -162,7 +211,7 @@ class Geostationary(GridMapping):
         super().__init__("geostationary", "geos")
 
 
-class LambertAzimuthalEqualArea(GridMapping):
+class LambertAzimuthalEqualArea(AzimuthalGridMapping):
     """The Lambert Azimuthal Equal Area grid mapping.
 
     See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
@@ -183,7 +232,7 @@ class LambertAzimuthalEqualArea(GridMapping):
         super().__init__("lambert_azimuthal_equal_area", "laea")
 
 
-class LambertConformalConic(GridMapping):
+class LambertConformalConic(ConicGridMapping):
     """The Lambert Conformal Conic grid mapping.
 
     See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
@@ -204,7 +253,7 @@ class LambertConformalConic(GridMapping):
         super().__init__("lambert_conformal_conic", "lcc")
 
 
-class LambertCylindricalEqualArea(GridMapping):
+class LambertCylindricalEqualArea(CylindricalGridMapping):
     """The Equal Area Cylindrical grid mapping.
 
     See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
@@ -225,7 +274,112 @@ class LambertCylindricalEqualArea(GridMapping):
         super().__init__("lambert_cylindrical_equal_area", "cea")
 
 
-class LatitudeLongitude(GridMapping):
+class Mercator(CylindricalGridMapping):
+    """The Mercator grid mapping.
+
+    See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
+    this grid mapping:
+
+    http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/
+    cf-conventions.html#_mercator
+
+    or the corresponding PROJ projection page:
+
+    https://proj.org/en/9.2/operations/projections/merc.html
+
+    for more information.
+
+    """
+
+    def __init__(self):
+        super().__init__("mercator", "merc")
+
+
+class ObliqueMercator(CylindricalGridMapping):
+    """The Oblique Mercator grid mapping.
+
+    See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
+    this grid mapping:
+
+    http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/
+    cf-conventions.html#_oblique_mercator
+
+    or the corresponding PROJ projection page:
+
+    https://proj.org/en/9.2/operations/projections/omerc.html
+
+    for more information.
+
+    """
+
+    def __init__(self):
+        super().__init__("oblique_mercator", "omerc")
+
+
+class Orthographic(AzimuthalGridMapping):
+    """The Orthographic grid mapping.
+
+    See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
+    this grid mapping:
+
+    http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/
+    cf-conventions.html#_orthographic
+
+    or the corresponding PROJ projection page:
+
+    https://proj.org/en/9.2/operations/projections/ortho.html
+
+    for more information.
+
+    """
+
+    def __init__(self):
+        super().__init__("orthographic", "ortho")
+
+
+class PolarStereographic(StereographicGridMapping):
+    """The Universal Polar Stereographic grid mapping.
+
+    See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
+    this grid mapping:
+
+    http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/
+    cf-conventions.html#polar-stereographic
+
+    or the corresponding PROJ projection page:
+
+    https://proj.org/en/9.2/operations/projections/ups.html
+
+    for more information.
+
+    """
+
+    def __init__(self):
+        super().__init__("polar_stereographic", "ups")
+
+
+class RotatedLatitudeLongitude(LatLonGridMapping):
+    """The Rotated Latitude-Longitude grid mapping.
+
+    See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
+    this grid mapping:
+
+    http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/
+    cf-conventions.html#_rotated_pole
+
+    or the corresponding PROJ projection page:
+
+    https://proj.org/en/9.2/operations/projections/eqc.html
+
+    for more information.
+
+    """
+
+    def __init__(self):
+        super().__init__("rotated_latitude_longitude", "eqc")
+
+
+class LatitudeLongitude(RotatedLatitudeLongitude):
     """The Latitude-Longitude i.e. Plate Carrée grid mapping.
 
     For alternative names, see e.g:
@@ -250,114 +404,6 @@ class LatitudeLongitude(GridMapping):
         super().__init__("latitude_longitude", "eqc")
 
 
-class Mercator(GridMapping):
-    """The Mercator grid mapping.
-
-    See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
-    this grid mapping:
-
-    http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/
-    cf-conventions.html#_mercator
-
-    or the corresponding PROJ projection page:
-
-    https://proj.org/en/9.2/operations/projections/merc.html
-
-    for more information.
-
-    """
-
-    def __init__(self):
-        super().__init__("mercator", "merc")
-
-
-class ObliqueMercator(GridMapping):
-    """The Oblique Mercator grid mapping.
-
-    See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
-    this grid mapping:
-
-    http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/
-    cf-conventions.html#_oblique_mercator
-
-    or the corresponding PROJ projection page:
-
-    https://proj.org/en/9.2/operations/projections/omerc.html
-
-    for more information.
-
-    """
-
-    def __init__(self):
-        super().__init__("oblique_mercator", "omerc")
-
-
-class Orthographic(GridMapping):
-    """The Orthographic grid mapping.
-
-    See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
-    this grid mapping:
-
-    http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/
-    cf-conventions.html#_orthographic
-
-    or the corresponding PROJ projection page:
-
-    https://proj.org/en/9.2/operations/projections/ortho.html
-
-    for more information.
-
-    """
-
-    def __init__(self):
-        super().__init__("orthographic", "ortho")
-
-
-class PolarStereographic(GridMapping):
-    """The Universal Polar Stereographic grid mapping.
-
-    See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
-    this grid mapping:
-
-    http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/
-    cf-conventions.html#polar-stereographic
-
-    or the corresponding PROJ projection page:
-
-    https://proj.org/en/9.2/operations/projections/ups.html
-
-    for more information.
-
-    """
-
-    def __init__(self):
-        super().__init__("polar_stereographic", "ups")
-
-
-class RotatedLatitudeLongitude(GridMapping):
-    """The Rotated Latitude-Longitude grid mapping.
-
-    See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
-    this grid mapping:
-
-    http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/
-    cf-conventions.html#_rotated_pole
-
-    or the corresponding PROJ projection page:
-
-    https://proj.org/en/9.2/operations/projections/eqc.html
-
-    for more information.
-
-    Note: this grid mapping relates to the Latitude-Longitude i.e. Plate
-    Carrée grid mapping in that it... TODO.
-
-    """
-
-    def __init__(self):
-        super().__init__("rotated_latitude_longitude", "eqc")
-
-
 class Sinusoidal(GridMapping):
     """The Sinusoidal (Sanson-Flamsteed) grid mapping.
 
@@ -379,7 +425,7 @@ class Sinusoidal(GridMapping):
         super().__init__("sinusoidal", "sinu")
 
 
-class Stereographic(GridMapping):
+class Stereographic(StereographicGridMapping):
     """The Stereographic grid mapping.
 
     See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
@@ -400,7 +446,7 @@ class Stereographic(GridMapping):
         super().__init__("stereographic", "stere")
 
 
-class TransverseMercator(GridMapping):
+class TransverseMercator(CylindricalGridMapping):
     """The Transverse Mercator grid mapping.
 
     See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
@@ -421,7 +467,7 @@ class TransverseMercator(GridMapping):
         super().__init__("transverse_mercator", "tmerc")
 
 
-class VerticalPerspective(GridMapping):
+class VerticalPerspective(PerspectiveGridMapping):
     """The Vertical (or Near-sided) Perspective grid mapping.
 
     See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -130,11 +130,13 @@ class AzimuthalGridMapping(GridMapping):
         latitude_of_projection_origin: TODO
             TODO
 
-        false_easting: TODO
-            TODO
+        false_easting: number, optional
+            The false easting (PROJ 'x_0') value, in units of metres.
+            The default is 0.0.
 
-        false_northing: TODO
-            TODO
+        false_northing: number, optional
+            The false northing (PROJ 'y_0') value, in units of metres.
+            The default is 0.0.
 
     """
 
@@ -142,8 +144,8 @@ class AzimuthalGridMapping(GridMapping):
         self,
         longitude_of_projection_origin,
         latitude_of_projection_origin,
-        false_easting,
-        false_northing,
+        false_easting=0.0,
+        false_northing=0.0,
         *args,
         **kwargs,
     ):
@@ -171,11 +173,13 @@ class ConicGridMapping(GridMapping):
         latitude_of_projection_origin: TODO
             TODO
 
-        false_easting: TODO
-            TODO
+        false_easting: number, optional
+            The false easting (PROJ 'x_0') value, in units of metres.
+            The default is 0.0.
 
-        false_northing: TODO
-            TODO
+        false_northing: number, optional
+            The false northing (PROJ 'y_0') value, in units of metres.
+            The default is 0.0.
 
     """
 
@@ -184,8 +188,8 @@ class ConicGridMapping(GridMapping):
         standard_parallel,
         longitude_of_central_meridian,
         latitude_of_projection_origin,
-        false_easting,
-        false_northing,
+        false_easting=0.0,
+        false_northing=0.0,
         *args,
         **kwargs,
     ):
@@ -205,15 +209,17 @@ class CylindricalGridMapping(GridMapping):
 
     :Parameters:
 
-        false_easting: TODO
-            TODO
+        false_easting: number, optional
+            The false easting (PROJ 'x_0') value, in units of metres.
+            The default is 0.0.
 
-        false_northing: TODO
-            TODO
+        false_northing: number, optional
+            The false northing (PROJ 'y_0') value, in units of metres.
+            The default is 0.0.
 
     """
 
-    def __init__(self, false_easting, false_northing, *args, **kwargs):
+    def __init__(self, false_easting=0.0, false_northing=0.0, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         self.false_easting = false_easting
@@ -297,11 +303,13 @@ class AlbersEqualArea(ConicGridMapping):
         latitude_of_projection_origin: TODO
             TODO
 
-        false_easting: TODO
-            TODO
+        false_easting: number, optional
+            The false easting (PROJ 'x_0') value, in units of metres.
+            The default is 0.0.
 
-        false_northing: TODO
-            TODO
+        false_northing: number, optional
+            The false northing (PROJ 'y_0') value, in units of metres.
+            The default is 0.0.
 
     """
 
@@ -310,8 +318,8 @@ class AlbersEqualArea(ConicGridMapping):
         standard_parallel,
         longitude_of_central_meridian,
         latitude_of_projection_origin,
-        false_easting,
-        false_northing,
+        false_easting=0.0,
+        false_northing=0.0,
         *args,
         **kwargs,
     ):
@@ -343,11 +351,13 @@ class AzimuthalEquidistant(AzimuthalGridMapping):
         latitude_of_projection_origin: TODO
             TODO
 
-        false_easting: TODO
-            TODO
+        false_easting: number, optional
+            The false easting (PROJ 'x_0') value, in units of metres.
+            The default is 0.0.
 
-        false_northing: TODO
-            TODO
+        false_northing: number, optional
+            The false northing (PROJ 'y_0') value, in units of metres.
+            The default is 0.0.
 
     """
 
@@ -355,8 +365,8 @@ class AzimuthalEquidistant(AzimuthalGridMapping):
         self,
         longitude_of_projection_origin,
         latitude_of_projection_origin,
-        false_easting,
-        false_northing,
+        false_easting=0.0,
+        false_northing=0.0,
         *args,
         **kwargs,
     ):
@@ -388,11 +398,13 @@ class Geostationary(PerspectiveGridMapping):
         latitude_of_projection_origin: TODO
             TODO
 
-        false_easting: TODO
-            TODO
+        false_easting: number, optional
+            The false easting (PROJ 'x_0') value, in units of metres.
+            The default is 0.0.
 
-        false_northing: TODO
-            TODO
+        false_northing: number, optional
+            The false northing (PROJ 'y_0') value, in units of metres.
+            The default is 0.0.
 
         perspective_point_height: TODO
             TODO
@@ -409,11 +421,11 @@ class Geostationary(PerspectiveGridMapping):
         self,
         longitude_of_projection_origin,
         latitude_of_projection_origin,
-        false_easting,
-        false_northing,
         perspective_point_height,
         sweep_angle_axis,
         fixed_angle_axis,
+        false_easting=0.0,
+        false_northing=0.0,
         *args,
         **kwargs,
     ):
@@ -448,11 +460,13 @@ class LambertAzimuthalEqualArea(AzimuthalGridMapping):
         latitude_of_projection_origin: TODO
             TODO
 
-        false_easting: TODO
-            TODO
+        false_easting: number, optional
+            The false easting (PROJ 'x_0') value, in units of metres.
+            The default is 0.0.
 
-        false_northing: TODO
-            TODO
+        false_northing: number, optional
+            The false northing (PROJ 'y_0') value, in units of metres.
+            The default is 0.0.
 
     """
 
@@ -460,8 +474,8 @@ class LambertAzimuthalEqualArea(AzimuthalGridMapping):
         self,
         longitude_of_projection_origin,
         latitude_of_projection_origin,
-        false_easting,
-        false_northing,
+        false_easting=0.0,
+        false_northing=0.0,
         *args,
         **kwargs,
     ):
@@ -498,11 +512,13 @@ class LambertConformalConic(ConicGridMapping):
         latitude_of_projection_origin: TODO
             TODO
 
-        false_easting: TODO
-            TODO
+        false_easting: number, optional
+            The false easting (PROJ 'x_0') value, in units of metres.
+            The default is 0.0.
 
-        false_northing: TODO
-            TODO
+        false_northing: number, optional
+            The false northing (PROJ 'y_0') value, in units of metres.
+            The default is 0.0.
 
     """
 
@@ -511,8 +527,8 @@ class LambertConformalConic(ConicGridMapping):
         standard_parallel,
         longitude_of_central_meridian,
         latitude_of_projection_origin,
-        false_easting,
-        false_northing,
+        false_easting=0.0,
+        false_northing=0.0,
         *args,
         **kwargs,
     ):
@@ -538,11 +554,13 @@ class LambertCylindricalEqualArea(CylindricalGridMapping):
 
     :Parameters:
 
-        false_easting: TODO
-            TODO
+        false_easting: number, optional
+            The false easting (PROJ 'x_0') value, in units of metres.
+            The default is 0.0.
 
-        false_northing: TODO
-            TODO
+        false_northing: number, optional
+            The false northing (PROJ 'y_0') value, in units of metres.
+            The default is 0.0.
 
         standard_parallel: TODO
             TODO
@@ -557,11 +575,11 @@ class LambertCylindricalEqualArea(CylindricalGridMapping):
 
     def __init__(
         self,
-        false_easting,
-        false_northing,
         standard_parallel,
         longitude_of_central_meridian,
         scale_factor_at_projection_origin,
+        false_easting=0.0,
+        false_northing=0.0,
         *args,
         **kwargs,
     ):
@@ -595,11 +613,13 @@ class Mercator(CylindricalGridMapping):
 
     :Parameters:
 
-        false_easting: TODO
-            TODO
+        false_easting: number, optional
+            The false easting (PROJ 'x_0') value, in units of metres.
+            The default is 0.0.
 
-        false_northing: TODO
-            TODO
+        false_northing: number, optional
+            The false northing (PROJ 'y_0') value, in units of metres.
+            The default is 0.0.
 
         standard_parallel: TODO
             TODO
@@ -614,11 +634,11 @@ class Mercator(CylindricalGridMapping):
 
     def __init__(
         self,
-        false_easting,
-        false_northing,
         standard_parallel,
         longitude_of_projection_origin,
         scale_factor_at_projection_origin,
+        false_easting=0.0,
+        false_northing=0.0,
         *args,
         **kwargs,
     ):
@@ -650,11 +670,13 @@ class ObliqueMercator(CylindricalGridMapping):
 
     :Parameters:
 
-        false_easting: TODO
-            TODO
+        false_easting: number, optional
+            The false easting (PROJ 'x_0') value, in units of metres.
+            The default is 0.0.
 
-        false_northing: TODO
-            TODO
+        false_northing: number, optional
+            The false northing (PROJ 'y_0') value, in units of metres.
+            The default is 0.0.
 
         azimuth_of_central_line: TODO
             TODO
@@ -672,12 +694,12 @@ class ObliqueMercator(CylindricalGridMapping):
 
     def __init__(
         self,
-        false_easting,
-        false_northing,
         azimuth_of_central_line,
         latitude_of_projection_origin,
         longitude_of_projection_origin,
         scale_factor_at_projection_origin,
+        false_easting=0.0,
+        false_northing=0.0,
         *args,
         **kwargs,
     ):
@@ -716,11 +738,13 @@ class Orthographic(AzimuthalGridMapping):
         latitude_of_projection_origin: TODO
             TODO
 
-        false_easting: TODO
-            TODO
+        false_easting: number, optional
+            The false easting (PROJ 'x_0') value, in units of metres.
+            The default is 0.0.
 
-        false_northing: TODO
-            TODO
+        false_northing: number, optional
+            The false northing (PROJ 'y_0') value, in units of metres.
+            The default is 0.0.
 
     """
 
@@ -728,8 +752,8 @@ class Orthographic(AzimuthalGridMapping):
         self,
         longitude_of_projection_origin,
         latitude_of_projection_origin,
-        false_easting,
-        false_northing,
+        false_easting=0.0,
+        false_northing=0.0,
         *args,
         **kwargs,
     ):
@@ -767,11 +791,13 @@ class PolarStereographic(AzimuthalGridMapping):
         scale_factor_at_projection_origin: TODO
             TODO
 
-        false_easting: TODO
-            TODO
+        false_easting: number, optional
+            The false easting (PROJ 'x_0') value, in units of metres.
+            The default is 0.0.
 
-        false_northing: TODO
-            TODO
+        false_northing: number, optional
+            The false northing (PROJ 'y_0') value, in units of metres.
+            The default is 0.0.
 
         standard_parallel: TODO
             TODO
@@ -781,12 +807,12 @@ class PolarStereographic(AzimuthalGridMapping):
     def __init__(
         self,
         latitude_of_projection_origin,
-        false_easting,
-        false_northing,
         standard_parallel,
         scale_factor_at_projection_origin,
         longitude_of_projection_origin=None,
         straight_vertical_longitude_from_pole=None,
+        false_easting=0.0,
+        false_northing=0.0,
         *args,
         **kwargs,
     ):
@@ -905,19 +931,21 @@ class Sinusoidal(GridMapping):
         longitude_of_projection_origin: TODO
             TODO
 
-        false_easting: TODO
-            TODO
+        false_easting: number, optional
+            The false easting (PROJ 'x_0') value, in units of metres.
+            The default is 0.0.
 
-        false_northing: TODO
-            TODO
+        false_northing: number, optional
+            The false northing (PROJ 'y_0') value, in units of metres.
+            The default is 0.0.
 
     """
 
     def __init__(
         self,
         longitude_of_projection_origin,
-        false_easting,
-        false_northing,
+        false_easting=0.0,
+        false_northing=0.0,
         *args,
         **kwargs,
     ):
@@ -953,11 +981,13 @@ class Stereographic(AzimuthalGridMapping):
         latitude_of_projection_origin: TODO
             TODO
 
-        false_easting: TODO
-            TODO
+        false_easting: number, optional
+            The false easting (PROJ 'x_0') value, in units of metres.
+            The default is 0.0.
 
-        false_northing: TODO
-            TODO
+        false_northing: number, optional
+            The false northing (PROJ 'y_0') value, in units of metres.
+            The default is 0.0.
 
         scale_factor_at_projection_origin: TODO
             TODO
@@ -968,9 +998,9 @@ class Stereographic(AzimuthalGridMapping):
         self,
         longitude_of_projection_origin,
         latitude_of_projection_origin,
-        false_easting,
-        false_northing,
         scale_factor_at_projection_origin,
+        false_easting=0.0,
+        false_northing=0.0,
         *args,
         **kwargs,
     ):
@@ -1000,11 +1030,13 @@ class TransverseMercator(CylindricalGridMapping):
 
     :Parameters:
 
-        false_easting: TODO
-            TODO
+        false_easting: number, optional
+            The false easting (PROJ 'x_0') value, in units of metres.
+            The default is 0.0.
 
-        false_northing: TODO
-            TODO
+        false_northing: number, optional
+            The false northing (PROJ 'y_0') value, in units of metres.
+            The default is 0.0.
 
         scale_factor_at_central_meridian: TODO
             TODO
@@ -1019,11 +1051,11 @@ class TransverseMercator(CylindricalGridMapping):
 
     def __init__(
         self,
-        false_easting,
-        false_northing,
         scale_factor_at_central_meridian,
         longitude_of_central_meridian,
         latitude_of_projection_origin,
+        false_easting=0.0,
+        false_northing=0.0,
         *args,
         **kwargs,
     ):
@@ -1061,11 +1093,13 @@ class VerticalPerspective(PerspectiveGridMapping):
         latitude_of_projection_origin: TODO
             TODO
 
-        false_easting: TODO
-            TODO
+        false_easting: number, optional
+            The false easting (PROJ 'x_0') value, in units of metres.
+            The default is 0.0.
 
-        false_northing: TODO
-            TODO
+        false_northing: number, optional
+            The false northing (PROJ 'y_0') value, in units of metres.
+            The default is 0.0.
 
         perspective_point_height: TODO
             TODO
@@ -1076,9 +1110,9 @@ class VerticalPerspective(PerspectiveGridMapping):
         self,
         longitude_of_projection_origin,
         latitude_of_projection_origin,
-        false_easting,
-        false_northing,
         perspective_point_height,
+        false_easting=0.0,
+        false_northing=0.0,
         *args,
         **kwargs,
     ):

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -655,9 +655,6 @@ class AlbersEqualArea(ConicGridMapping):
             the `Data` units are taken and must be angular and
             compatible with latitude.
 
-            The default is (0.0, 0.0), that is 0.0 degrees_north
-            for the first and second standard parallel values.
-
         longitude_of_central_meridian: number or scalar `Data`, optional
             The longitude of (natural) origin i.e. central meridian.
             If provided as a number or `Data` without units, the units
@@ -1039,7 +1036,8 @@ class LambertCylindricalEqualArea(CylindricalGridMapping):
             taken and must be compatible with distance.
             The default is 0.0 metres.
 
-        standard_parallel: 2-`tuple` of number or scalar `Data` or `None`
+        standard_parallel: 2-`tuple` of number or scalar `Data`
+                           or `None`, optional
             The standard parallel value(s): the first (PROJ 'lat_1'
             value) and/or the second (PROJ 'lat_2' value), given
             as a 2-tuple of numbers or strings corresponding to
@@ -1074,7 +1072,7 @@ class LambertCylindricalEqualArea(CylindricalGridMapping):
         self,
         false_easting=0.0,
         false_northing=0.0,
-        standard_parallel=(0.0, None),
+        standard_parallel=(0.0, 0.0),
         scale_factor_at_projection_origin=1.0,
         longitude_of_central_meridian=0.0,
         **kwargs,
@@ -1126,7 +1124,8 @@ class Mercator(CylindricalGridMapping):
             taken and must be compatible with distance.
             The default is 0.0 metres.
 
-        standard_parallel: 2-`tuple` of number or scalar `Data` or `None`
+        standard_parallel: 2-`tuple` of number or scalar `Data`
+                           or `None`, optional
             The standard parallel value(s): the first (PROJ 'lat_1'
             value) and/or the second (PROJ 'lat_2' value), given
             as a 2-tuple of numbers or strings corresponding to
@@ -1161,7 +1160,7 @@ class Mercator(CylindricalGridMapping):
         self,
         false_easting=0.0,
         false_northing=0.0,
-        standard_parallel=(0.0, None),
+        standard_parallel=(0.0, 0.0),
         longitude_of_projection_origin=0.0,
         scale_factor_at_projection_origin=1.0,
         **kwargs,
@@ -1386,7 +1385,8 @@ class PolarStereographic(AzimuthalGridMapping):
             taken and must be compatible with distance.
             The default is 0.0 metres.
 
-        standard_parallel: 2-`tuple` of number or scalar `Data` or `None`
+        standard_parallel: 2-`tuple` of number or scalar `Data`
+                           or `None`, optional
             The standard parallel value(s): the first (PROJ 'lat_1'
             value) and/or the second (PROJ 'lat_2' value), given
             as a 2-tuple of numbers or strings corresponding to

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -251,7 +251,7 @@ def _make_proj_string_comp(spec):
 
 
 def _validate_map_parameter(mp_name, mp_value):
-    """TODO
+    """Validate map parameters for correct type and canonical units.
 
     :Parameters:
 
@@ -263,8 +263,8 @@ def _validate_map_parameter(mp_name, mp_value):
 
     :Returns:
 
-        `dict`
-            TODO
+        `Data`, `str`, or `None`
+            A value conformed to the TODO
 
     """
     # 0. Check input parameters are valid CF GM map parameters, not
@@ -283,7 +283,7 @@ def _validate_map_parameter(mp_name, mp_value):
     expect_numeric = cr_gm_valid_attr_names_are_numeric[mp_name]
     if expect_numeric:
         if (isinstance(mp_value, Data) and not is_numeric_dtype(mp_value)) or (
-            not isinstance(mp_value, (int, float))
+            not isinstance(mp_value, (Data, int, float))
         ):
             raise TypeError(
                 f"Map parameter {mp_name} has an incompatible "
@@ -316,6 +316,8 @@ def _validate_map_parameter(mp_name, mp_value):
                 conforming_value = Units.conform(
                     mp_value.array.item(), units, canon_units
                 )
+            else:
+                conforming_value = mp_value
         else:
             conforming_value = mp_value
 

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -277,7 +277,7 @@ def _validate_map_parameter(mp_name, mp_value):
 
     # 1. If None, can return early:
     if mp_value is None:  # distinguish from 0 or 0.0 etc.
-        return mp_name, None
+        return None
 
     # 2. Now ensure the type of the value is as expected.
     expect_numeric = cr_gm_valid_attr_names_are_numeric[mp_name]
@@ -320,10 +320,10 @@ def _validate_map_parameter(mp_name, mp_value):
             conforming_value = mp_value
 
         # Return numeric value as Data with conformed value and canonical units
-        return mp_name, Data(conforming_value, units=canon_units)
+        return Data(conforming_value, units=canon_units)
     else:
         # Return string value
-        return mp_name, mp_value
+        return mp_value
 
 
 """Abstract classes for general Grid Mappings.
@@ -559,10 +559,18 @@ class AzimuthalGridMapping(GridMapping):
     ):
         super().__init__(**kwargs)
 
-        self.longitude_of_projection_origin = longitude_of_projection_origin
-        self.latitude_of_projection_origin = latitude_of_projection_origin
-        self.false_easting = false_easting
-        self.false_northing = false_northing
+        self.longitude_of_projection_origin = _validate_map_parameter(
+            "longitude_of_projection_origin", longitude_of_projection_origin
+        )
+        self.latitude_of_projection_origin = _validate_map_parameter(
+            "latitude_of_projection_origin", latitude_of_projection_origin
+        )
+        self.false_easting = _validate_map_parameter(
+            "false_easting", false_easting
+        )
+        self.false_northing = _validate_map_parameter(
+            "false_northing", false_northing
+        )
 
 
 class ConicGridMapping(GridMapping):
@@ -628,11 +636,22 @@ class ConicGridMapping(GridMapping):
     ):
         super().__init__(**kwargs)
 
-        self.standard_parallel = standard_parallel
-        self.longitude_of_central_meridian = longitude_of_central_meridian
-        self.latitude_of_projection_origin = latitude_of_projection_origin
-        self.false_easting = false_easting
-        self.false_northing = false_northing
+        self.standard_parallel = (
+            _validate_map_parameter("standard_parallel", standard_parallel[0]),
+            _validate_map_parameter("standard_parallel", standard_parallel[1]),
+        )
+        self.longitude_of_central_meridian = _validate_map_parameter(
+            "longitude_of_central_meridian", longitude_of_central_meridian
+        )
+        self.latitude_of_projection_origin = _validate_map_parameter(
+            "latitude_of_projection_origin", latitude_of_projection_origin
+        )
+        self.false_easting = _validate_map_parameter(
+            "false_easting", false_easting
+        )
+        self.false_northing = _validate_map_parameter(
+            "false_northing", false_northing
+        )
 
 
 class CylindricalGridMapping(GridMapping):
@@ -661,8 +680,12 @@ class CylindricalGridMapping(GridMapping):
     def __init__(self, false_easting=0.0, false_northing=0.0, **kwargs):
         super().__init__(**kwargs)
 
-        self.false_easting = false_easting
-        self.false_northing = false_northing
+        self.false_easting = _validate_map_parameter(
+            "false_easting", false_easting
+        )
+        self.false_northing = _validate_map_parameter(
+            "false_northing", false_northing
+        )
 
 
 class LatLonGridMapping(GridMapping):
@@ -699,7 +722,9 @@ class PerspectiveGridMapping(AzimuthalGridMapping):
     def __init__(self, perspective_point_height, **kwargs):
         super().__init__(**kwargs)
 
-        self.perspective_point_height = perspective_point_height
+        self.perspective_point_height = _validate_map_parameter(
+            "perspective_point_height", perspective_point_height
+        )
 
 
 """Concrete classes for all Grid Mappings supported by the CF Conventions.
@@ -930,9 +955,17 @@ class Geostationary(PerspectiveGridMapping):
             **kwargs,
         )
 
+        # Values "x" and "y" are not case-sensitive, so convert to lower-case
+        self.sweep_angle_axis = _validate_map_parameter(
+            "sweep_angle_axis", sweep_angle_axis
+        ).lower()
+        self.fixed_angle_axis = _validate_map_parameter(
+            "fixed_angle_axis", fixed_angle_axis
+        ).lower()
+
         # sweep_angle_axis must be the opposite (of "x" and "y") to
         # fixed_angle_axis.
-        if (sweep_angle_axis.lower(), fixed_angle_axis.lower()) not in [
+        if (self.sweep_angle_axis, self.fixed_angle_axis) not in [
             ("x", "y"),
             ("y", "x"),
         ]:
@@ -940,10 +973,6 @@ class Geostationary(PerspectiveGridMapping):
                 "The sweep_angle_axis must be the opposite value, from 'x' "
                 "and 'y', to the fixed_angle_axis."
             )
-
-        # Values "x" and "y" are not case-sensitive, so convert to lower-case
-        self.sweep_angle_axis = sweep_angle_axis.lower()
-        self.fixed_angle_axis = fixed_angle_axis.lower()
 
 
 class LambertAzimuthalEqualArea(AzimuthalGridMapping):
@@ -1143,10 +1172,16 @@ class LambertCylindricalEqualArea(CylindricalGridMapping):
     ):
         super().__init__(false_easting=0.0, false_northing=0.0, **kwargs)
 
-        self.standard_parallel = standard_parallel
-        self.longitude_of_central_meridian = longitude_of_central_meridian
-        self.scale_factor_at_projection_origin = (
-            scale_factor_at_projection_origin
+        self.standard_parallel = (
+            _validate_map_parameter("standard_parallel", standard_parallel[0]),
+            _validate_map_parameter("standard_parallel", standard_parallel[1]),
+        )
+        self.longitude_of_central_meridian = _validate_map_parameter(
+            "longitude_of_central_meridian", longitude_of_central_meridian
+        )
+        self.scale_factor_at_projection_origin = _validate_map_parameter(
+            "scale_factor_at_projection_origin",
+            scale_factor_at_projection_origin,
         )
 
 
@@ -1226,10 +1261,16 @@ class Mercator(CylindricalGridMapping):
     ):
         super().__init__(false_easting=0.0, false_northing=0.0, **kwargs)
 
-        self.standard_parallel = standard_parallel
-        self.longitude_of_projection_origin = longitude_of_projection_origin
-        self.scale_factor_at_projection_origin = (
-            scale_factor_at_projection_origin
+        self.standard_parallel = (
+            _validate_map_parameter("standard_parallel", standard_parallel[0]),
+            _validate_map_parameter("standard_parallel", standard_parallel[1]),
+        )
+        self.longitude_of_projection_origin = _validate_map_parameter(
+            "longitude_of_projection_origin", longitude_of_projection_origin
+        )
+        self.scale_factor_at_projection_origin = _validate_map_parameter(
+            "scale_factor_at_projection_origin",
+            scale_factor_at_projection_origin,
         )
 
 
@@ -1309,11 +1350,18 @@ class ObliqueMercator(CylindricalGridMapping):
     ):
         super().__init__(false_easting=0.0, false_northing=0.0, **kwargs)
 
-        self.azimuth_of_central_line = azimuth_of_central_line
-        self.latitude_of_projection_origin = latitude_of_projection_origin
-        self.longitude_of_projection_origin = longitude_of_projection_origin
-        self.scale_factor_at_projection_origin = (
-            scale_factor_at_projection_origin
+        self.azimuth_of_central_line = _validate_map_parameter(
+            "azimuth_of_central_line", azimuth_of_central_line
+        )
+        self.latitude_of_projection_origin = _validate_map_parameter(
+            "latitude_of_projection_origin", latitude_of_projection_origin
+        )
+        self.longitude_of_projection_origin = _validate_map_parameter(
+            "longitude_of_projection_origin", longitude_of_projection_origin
+        )
+        self.scale_factor_at_projection_origin = _validate_map_parameter(
+            "scale_factor_at_projection_origin",
+            scale_factor_at_projection_origin,
         )
 
 
@@ -1481,12 +1529,17 @@ class PolarStereographic(AzimuthalGridMapping):
                 "'straight_vertical_longitude_from_pole' can be set."
             )
 
-        self.straight_vertical_longitude_from_pole = (
-            straight_vertical_longitude_from_pole
+        self.straight_vertical_longitude_from_pole = _validate_map_parameter(
+            "straight_vertical_longitude_from_pole",
+            straight_vertical_longitude_from_pole,
         )
-        self.standard_parallel = standard_parallel
-        self.scale_factor_at_projection_origin = (
-            scale_factor_at_projection_origin
+        self.standard_parallel = (
+            _validate_map_parameter("standard_parallel", standard_parallel[0]),
+            _validate_map_parameter("standard_parallel", standard_parallel[1]),
+        )
+        self.scale_factor_at_projection_origin = _validate_map_parameter(
+            "scale_factor_at_projection_origin",
+            scale_factor_at_projection_origin,
         )
 
 
@@ -1539,9 +1592,15 @@ class RotatedLatitudeLongitude(LatLonGridMapping):
     ):
         super().__init__(**kwargs)
 
-        self.grid_north_pole_latitude = grid_north_pole_latitude
-        self.grid_north_pole_longitude = grid_north_pole_longitude
-        self.north_pole_grid_longitude = north_pole_grid_longitude
+        self.grid_north_pole_latitude = _validate_map_parameter(
+            "grid_north_pole_latitude", grid_north_pole_latitude
+        )
+        self.grid_north_pole_longitude = _validate_map_parameter(
+            "grid_north_pole_longitude", grid_north_pole_longitude
+        )
+        self.north_pole_grid_longitude = _validate_map_parameter(
+            "north_pole_grid_longitude", north_pole_grid_longitude
+        )
 
 
 class LatitudeLongitude(LatLonGridMapping):
@@ -1617,9 +1676,15 @@ class Sinusoidal(GridMapping):
     ):
         super().__init__(**kwargs)
 
-        self.longitude_of_projection_origin = longitude_of_projection_origin
-        self.false_easting = false_easting
-        self.false_northing = false_northing
+        self.longitude_of_projection_origin = _validate_map_parameter(
+            "longitude_of_projection_origin", longitude_of_projection_origin
+        )
+        self.false_easting = _validate_map_parameter(
+            "false_easting", false_easting
+        )
+        self.false_northing = _validate_map_parameter(
+            "false_northing", false_northing
+        )
 
 
 class Stereographic(AzimuthalGridMapping):
@@ -1695,8 +1760,9 @@ class Stereographic(AzimuthalGridMapping):
             **kwargs,
         )
 
-        self.scale_factor_at_projection_origin = (
-            scale_factor_at_projection_origin
+        self.scale_factor_at_projection_origin = _validate_map_parameter(
+            "scale_factor_at_projection_origin",
+            scale_factor_at_projection_origin,
         )
 
 
@@ -1767,11 +1833,16 @@ class TransverseMercator(CylindricalGridMapping):
     ):
         super().__init__(false_easting=0.0, false_northing=0.0, **kwargs)
 
-        self.scale_factor_at_central_meridian = (
-            scale_factor_at_central_meridian
+        self.scale_factor_at_central_meridian = _validate_map_parameter(
+            "scale_factor_at_central_meridian",
+            scale_factor_at_central_meridian,
         )
-        self.longitude_of_central_meridian = longitude_of_central_meridian
-        self.latitude_of_projection_origin = latitude_of_projection_origin
+        self.longitude_of_central_meridian = _validate_map_parameter(
+            "longitude_of_central_meridian", longitude_of_central_meridian
+        )
+        self.latitude_of_projection_origin = _validate_map_parameter(
+            "latitude_of_projection_origin", latitude_of_projection_origin
+        )
 
 
 class VerticalPerspective(PerspectiveGridMapping):

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -102,11 +102,11 @@ class GridMapping:
         proj_id=None,
         # i.e. WGS1984_CF_ATTR_DEFAULTS.reference_ellipsoid_name:
         reference_ellipsoid_name="WGS 84",
-        semi_major_axis=WGS1984_CF_ATTR_DEFAULTS.semi_major_axis,
-        semi_minor_axis=WGS1984_CF_ATTR_DEFAULTS.semi_minor_axis,
-        inverse_flattening=WGS1984_CF_ATTR_DEFAULTS.inverse_flattening,
-        prime_meridian_name=WGS1984_CF_ATTR_DEFAULTS.prime_meridian_name,
-        longitude_of_prime_meridian=WGS1984_CF_ATTR_DEFAULTS.longitude_of_prime_meridian,
+        semi_major_axis=WGS1984_CF_ATTR_DEFAULTS["semi_major_axis"],
+            semi_minor_axis=WGS1984_CF_ATTR_DEFAULTS["semi_minor_axis"],
+        inverse_flattening=WGS1984_CF_ATTR_DEFAULTS["inverse_flattening"],
+            prime_meridian_name=WGS1984_CF_ATTR_DEFAULTS["prime_meridian_name"],
+        longitude_of_prime_meridian=WGS1984_CF_ATTR_DEFAULTS["longitude_of_prime_meridian"],
         earth_radius=None,
     ):
         """**Initialisation**
@@ -213,6 +213,30 @@ class GridMapping:
         self.reference_ellipsoid_name = reference_ellipsoid_name
         self.semi_major_axis = semi_major_axis
         self.semi_minor_axis = semi_minor_axis
+
+    def get_proj_string(self):
+        """TODO"""
+        # TODO finish to return parameters for full proj string
+        return f"+proj={self.proj_id}"
+
+    def __repr__(self):
+        """x.__repr__() <==> repr(x)"""
+        # Report parent GridMapping class to indicate classification,
+        # but only if it has one (> 2 avoids own class and 'object')
+        # base. E.g. we get <CF AzimuthalGridMapping:Orthographic>,
+        # <CF GridMapping:AzimuthalGridMapping>, <CF GridMapping>.
+        parent_gm = ""
+        if len(self.__class__.__mro__) > 2:
+            parent_gm = self.__class__.__mro__[1].__name__ + ": "
+        return (
+            f"<CF {parent_gm}{self.__class__.__name__}>"
+        )
+
+    def __str__(self):
+        """x.__str__() <==> str(x)"""
+        return (
+            f"{self.__repr__()[:-1]} {self.get_proj_string()}>"
+        )
 
 
 class AzimuthalGridMapping(GridMapping):
@@ -621,7 +645,7 @@ class Geostationary(PerspectiveGridMapping):
         # sweep_angle_axis must be the opposite (of "x" and "y") to
         # fixed_angle_axis.
         if (sweep_angle_axis.lower(), fixed_angle_axis.lower()) not in [
-            ("x", "y")("y", "x")
+                ("x", "y"),("y", "x")
         ]:
             raise ValueError(
                 "The sweep_angle_axis must be the opposite value, from 'x' "
@@ -1212,7 +1236,7 @@ class RotatedLatitudeLongitude(LatLonGridMapping):
         **kwargs,
     ):
         super().__init__(
-            "rotated_latitude_longitude", "latlon", *args, **kwargs
+            "rotated_latitude_longitude", "latlong", *args, **kwargs
         )
 
         self.grid_north_pole_latitude = grid_north_pole_latitude
@@ -1236,7 +1260,7 @@ class LatitudeLongitude(LatLonGridMapping):
     """
 
     def __init__(self, *args, **kwargs):
-        super().__init__("latitude_longitude", "latlon", *args, **kwargs)
+        super().__init__("latitude_longitude", "latlong", *args, **kwargs)
 
 
 class Sinusoidal(GridMapping):

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -174,8 +174,17 @@ class ConicGridMapping(GridMapping):
 
     :Parameters:
 
-        standard_parallel: TODO
-            TODO
+        standard_parallel: number, `str` or 2-`tuple`, optional
+            The standard parallel values, either the first (PROJ
+            'lat_1' value), the second (PROJ 'lat_2' value) or
+            both, given as a 2-tuple of numbers or strings corresponding to
+            the first and then the second in order, where `None`
+            indicates that a value is not being specified for either. In
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            for both values is 0.0 decimal degrees.
 
         longitude_of_central_meridian: TODO
             TODO
@@ -263,8 +272,10 @@ class PerspectiveGridMapping(AzimuthalGridMapping):
 
     :Parameters:
 
-        perspective_point_height: TODO
-            TODO
+        perspective_point_height: number
+            The height of the view point above the surface (PROJ
+            'h') value, for example the height of a satellite above
+            the Earth, in units of meters.
 
     """
 
@@ -309,8 +320,19 @@ class AlbersEqualArea(ConicGridMapping):
 
     :Parameters:
 
-        standard_parallel: TODO
-            TODO
+        standard_parallel: number, `str` or 2-`tuple`, optional
+            The standard parallel values, either the first (PROJ
+            'lat_1' value), the second (PROJ 'lat_2' value) or
+            both, given as a 2-tuple of numbers or strings corresponding to
+            the first and then the second in order, where `None`
+            indicates that a value is not being specified for either. In
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees.
+
+            The default is (0.0, 0.0), that is 0.0 decimal degrees
+            for the first and second standard parallel values.
 
         longitude_of_central_meridian: TODO
             TODO
@@ -335,8 +357,8 @@ class AlbersEqualArea(ConicGridMapping):
 
     def __init__(
         self,
-        standard_parallel,
         longitude_of_central_meridian,
+        standard_parallel=(0.0, 0.0),
         latitude_of_projection_origin=0.0,
         false_easting=0.0,
         false_northing=0.0,
@@ -422,6 +444,11 @@ class Geostationary(PerspectiveGridMapping):
 
     :Parameters:
 
+        perspective_point_height: number
+            The height of the view point above the surface (PROJ
+            'h') value, for example the height of a satellite above
+            the Earth, in units of meters.
+
         longitude_of_projection_origin: number or `str`, optional
             The longitude of projection center (PROJ 'lon_0' value), in
             units of decimal degrees, where forming a string by adding
@@ -446,33 +473,54 @@ class Geostationary(PerspectiveGridMapping):
             The false northing (PROJ 'y_0') value, in units of metres.
             The default is 0.0.
 
-        perspective_point_height: TODO
-            TODO
+        sweep_angle_axis: `str`, optional
+            Sweep angle axis of the viewing instrument, which indicates
+            the axis on which the view sweeps. Valid options
+            are "x" and "y". The default is "y".
 
-        sweep_angle_axis: TODO
-            TODO
+            For more information about the nature of this parameter, see:
 
-        fixed_angle_axis: TODO
-            TODO
+            https://proj.org/en/9.2/operations/projections/
+            geos.html#note-on-sweep-angle
+
+        fixed_angle_axis: `str`, optional
+            The axis on which the view is fixed. It corresponds to the
+            inner-gimbal axis of the gimbal view model, whose axis of
+            rotation moves about the outer-gimbal axis. Valid options
+            are "x" and "y". The default is "x".
+
+             .. note:: If the fixed_angle_axis is "x", sweep_angle_axis
+                       is "y", and vice versa.
 
     """
 
     def __init__(
         self,
         perspective_point_height,
-        sweep_angle_axis,
-        fixed_angle_axis,
         longitude_of_projection_origin=0.0,
         latitude_of_projection_origin=0.0,
         false_easting=0.0,
         false_northing=0.0,
+        sweep_angle_axis="y",
+        fixed_angle_axis="x",
         *args,
         **kwargs,
     ):
         super().__init__("geostationary", "geos", *args, **kwargs)
 
-        self.sweep_angle_axis = sweep_angle_axis
-        self.fixed_angle_axis = fixed_angle_axis
+        # sweep_angle_axis must be the opposite (of "x" and "y") to
+        # fixed_angle_axis.
+        if (sweep_angle_axis.lower(), fixed_angle_axis.lower()) not in [
+            ("x", "y")("y", "x")
+        ]:
+            raise ValueError(
+                "The sweep_angle_axis must be the opposite value, from 'x' "
+                "and 'y', to the fixed_angle_axis."
+            )
+
+        # Values "x" and "y" are not case-sensitive, so convert to lower-case
+        self.sweep_angle_axis = sweep_angle_axis.lower()
+        self.fixed_angle_axis = fixed_angle_axis.lower()
 
 
 class LambertAzimuthalEqualArea(AzimuthalGridMapping):
@@ -553,8 +601,17 @@ class LambertConformalConic(ConicGridMapping):
 
     :Parameters:
 
-        standard_parallel: TODO
-            TODO
+        standard_parallel: number, `str` or 2-`tuple`, optional
+            The standard parallel values, either the first (PROJ
+            'lat_1' value), the second (PROJ 'lat_2' value) or
+            both, given as a 2-tuple of numbers or strings corresponding to
+            the first and then the second in order, where `None`
+            indicates that a value is not being specified for either. In
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            for both values is 0.0 decimal degrees.
 
         longitude_of_projection_origin: number or `str`, optional
             The longitude of projection center (PROJ 'lon_0' value), in
@@ -584,7 +641,7 @@ class LambertConformalConic(ConicGridMapping):
 
     def __init__(
         self,
-        standard_parallel,
+        standard_parallel=(0.0, 0.0),
         longitude_of_central_meridian=0.0,
         latitude_of_projection_origin=0.0,
         false_easting=0.0,
@@ -622,8 +679,17 @@ class LambertCylindricalEqualArea(CylindricalGridMapping):
             The false northing (PROJ 'y_0') value, in units of metres.
             The default is 0.0.
 
-        standard_parallel: TODO
-            TODO
+        standard_parallel: number, `str` or 2-`tuple`, optional
+            The standard parallel values, either the first (PROJ
+            'lat_1' value), the second (PROJ 'lat_2' value) or
+            both, given as a 2-tuple of numbers or strings corresponding to
+            the first and then the second in order, where `None`
+            indicates that a value is not being specified for either. In
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            for both values is 0.0 decimal degrees.
 
         longitude_of_central_meridian: TODO
             TODO
@@ -635,9 +701,9 @@ class LambertCylindricalEqualArea(CylindricalGridMapping):
 
     def __init__(
         self,
-        standard_parallel,
         longitude_of_central_meridian,
         scale_factor_at_projection_origin,
+        standard_parallel=(0.0, 0.0),
         false_easting=0.0,
         false_northing=0.0,
         *args,
@@ -681,8 +747,17 @@ class Mercator(CylindricalGridMapping):
             The false northing (PROJ 'y_0') value, in units of metres.
             The default is 0.0.
 
-        standard_parallel: TODO
-            TODO
+        standard_parallel: number, `str` or 2-`tuple`, optional
+            The standard parallel values, either the first (PROJ
+            'lat_1' value), the second (PROJ 'lat_2' value) or
+            both, given as a 2-tuple of numbers or strings corresponding to
+            the first and then the second in order, where `None`
+            indicates that a value is not being specified for either. In
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            for both values is 0.0 decimal degrees.
 
         longitude_of_projection_origin: number or `str`, optional
             The longitude of projection center (PROJ 'lon_0' value), in
@@ -699,8 +774,8 @@ class Mercator(CylindricalGridMapping):
 
     def __init__(
         self,
-        standard_parallel,
         scale_factor_at_projection_origin,
+        standard_parallel=(0.0, 0.0),
         longitude_of_projection_origin=0.0,
         false_easting=0.0,
         false_northing=0.0,
@@ -769,10 +844,10 @@ class ObliqueMercator(CylindricalGridMapping):
 
     def __init__(
         self,
+        scale_factor_at_projection_origin,
         azimuth_of_central_line,
         latitude_of_projection_origin=0.0,
         longitude_of_projection_origin=0.0,
-        scale_factor_at_projection_origin,
         false_easting=0.0,
         false_northing=0.0,
         *args,
@@ -894,15 +969,24 @@ class PolarStereographic(AzimuthalGridMapping):
             The false northing (PROJ 'y_0') value, in units of metres.
             The default is 0.0.
 
-        standard_parallel: TODO
-            TODO
+        standard_parallel: number, `str` or 2-`tuple`, optional
+            The standard parallel values, either the first (PROJ
+            'lat_1' value), the second (PROJ 'lat_2' value) or
+            both, given as a 2-tuple of numbers or strings corresponding to
+            the first and then the second in order, where `None`
+            indicates that a value is not being specified for either. In
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            for both values is 0.0 decimal degrees.
 
     """
 
     def __init__(
         self,
-        standard_parallel,
         scale_factor_at_projection_origin,
+        standard_parallel=(0.0, 0.0),
         latitude_of_projection_origin=0.0,
         longitude_of_projection_origin=0.0,
         straight_vertical_longitude_from_pole=None,
@@ -1202,6 +1286,11 @@ class VerticalPerspective(PerspectiveGridMapping):
 
     :Parameters:
 
+        perspective_point_height: number
+            The height of the view point above the surface (PROJ
+            'h') value, for example the height of a satellite above
+            the Earth, in units of meters.
+
         longitude_of_projection_origin: number or `str`, optional
             The longitude of projection center (PROJ 'lon_0' value), in
             units of decimal degrees, where forming a string by adding
@@ -1225,9 +1314,6 @@ class VerticalPerspective(PerspectiveGridMapping):
         false_northing: number, optional
             The false northing (PROJ 'y_0') value, in units of metres.
             The default is 0.0.
-
-        perspective_point_height: TODO
-            TODO
 
     """
 

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -5,7 +5,9 @@ from abc import ABC, abstractmethod
 from pyproj import CRS
 
 from .data import Data
+from .data.utils import is_numeric_dtype
 from .units import Units
+
 
 PROJ_PREFIX = "+proj"
 ALL_GRID_MAPPING_ATTR_NAMES = {
@@ -229,6 +231,10 @@ def convert_cf_angular_data_to_proj(data):
     if data.size != 1:
         raise ValueError(
             f"Input cf.Data must have size 1, got size: {data.size}"
+        )
+    if not is_numeric_dtype(data):
+        raise TypeError(
+            f"Input cf.Data must have numeric data type, got: {data.dtype}"
         )
 
     units = data.Units

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -165,11 +165,17 @@ def _convert_units_proj_to_cf(proj_val_with_units, context=None):
     valid_form = re.compile("(\d+(\.\d+)?)([rRdD°]?)")
     form = re.fullmatch(valid_form, proj_val_with_units)
     if form:
+        suffix, float_comp = None, None
         if len(form.groups()) == 3:
-            value, _, suffix = form.groups()
+            value, float_comp, suffix = form.groups()
+            #if float_comp:
+            #    is_flaot= True
+            #print("FOR", form, "GET", value, is_float, suffix)
+        elif len(form.groups()) == 2:
+            value, float_comp = form.groups()
         else:
             value = form.groups()
-            suffix = None
+
         if suffix in ("r", "R"):  # radians units
             cf_units = "radians"
             # Convert to decimal so we can store the degree_X form from context:
@@ -184,7 +190,13 @@ def _convert_units_proj_to_cf(proj_val_with_units, context=None):
             "Ensure valid PROJ units are supplied."
         )
 
-    return Data(value, Units(cf_units))
+    # Convert string value to relevant numeric form
+    if float_comp:
+        numeric_value = float(value)
+    else:
+        numeric_value = int(value)
+
+    return Data(numeric_value, Units(cf_units))
 
 
 def _make_proj_string_comp(spec):

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 
 from pyproj import CRS
 
+
 PROJ_PREFIX = "+proj"
 ALL_GRID_MAPPING_ATTR_NAMES = {
     "grid_mapping_name",
@@ -265,6 +266,10 @@ class GridMapping(ABC):
     def __eq__(self, other):
         """The rich comparison operator ``==``."""
         return self.get_proj_string() == other.get_proj_string()
+
+    def __hash__(self, other):
+        """The rich comparison operator ``==``."""
+        return hash(self.get_proj_string())
 
     @property
     @abstractmethod
@@ -1718,3 +1723,34 @@ class VerticalPerspective(PerspectiveGridMapping):
         """The value of the PROJ proj-string defining the projection."""
         parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
         return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
+
+
+# TODO move this definition elsewhere, having at end feels like an
+# anti-pattern...
+_all_abstract_grid_mappings = (
+    GridMapping,
+    AzimuthalGridMapping,
+    ConicGridMapping,
+    CylindricalGridMapping,
+    LatLonGridMapping,
+    PerspectiveGridMapping,
+)
+# Representing all Grid Mappings repsented by the CF Conventions (APpendix F)
+_all_concrete_grid_mappings = (
+    AlbersEqualArea,
+    AzimuthalEquidistant,
+    Geostationary,
+    LambertAzimuthalEqualArea,
+    LambertConformalConic,
+    LambertCylindricalEqualArea,
+    Mercator,
+    ObliqueMercator,
+    Orthographic,
+    PolarStereographic,
+    RotatedLatitudeLongitude,
+    LatitudeLongitude,
+    Sinusoidal,
+    Stereographic,
+    TransverseMercator,
+    VerticalPerspective,
+)

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -118,7 +118,25 @@ class GridMapping:
 
 
 class AzimuthalGridMapping(GridMapping):
-    """A Grid Mapping with Azimuthal classification."""
+    """A Grid Mapping with Azimuthal classification.
+
+    .. versionadded:: GMVER
+
+    :Parameters:
+
+        longitude_of_projection_origin: TODO
+            TODO
+
+        latitude_of_projection_origin: TODO
+            TODO
+
+        false_easting: TODO
+            TODO
+
+        false_northing: TODO
+            TODO
+
+    """
 
     def __init__(
         self,
@@ -138,7 +156,28 @@ class AzimuthalGridMapping(GridMapping):
 
 
 class ConicGridMapping(GridMapping):
-    """A Grid Mapping with Conic classification."""
+    """A Grid Mapping with Conic classification.
+
+    .. versionadded:: GMVER
+
+    :Parameters:
+
+        standard_parallel: TODO
+            TODO
+
+        longitude_of_central_meridian: TODO
+            TODO
+
+        latitude_of_projection_origin: TODO
+            TODO
+
+        false_easting: TODO
+            TODO
+
+        false_northing: TODO
+            TODO
+
+    """
 
     def __init__(
         self,
@@ -160,7 +199,19 @@ class ConicGridMapping(GridMapping):
 
 
 class CylindricalGridMapping(GridMapping):
-    """A Grid Mapping with Cylindrical classification."""
+    """A Grid Mapping with Cylindrical classification.
+
+    .. versionadded:: GMVER
+
+    :Parameters:
+
+        false_easting: TODO
+            TODO
+
+        false_northing: TODO
+            TODO
+
+    """
 
     def __init__(self, false_easting, false_northing, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -176,6 +227,8 @@ class LatLonGridMapping(GridMapping):
     on a spherical Earth, defining the canonical 2D geographical coordinate
     system so that the figure of the Earth can be described.
 
+    .. versionadded:: GMVER
+
     """
 
     def __init__(self, *args, **kwargs):
@@ -183,7 +236,16 @@ class LatLonGridMapping(GridMapping):
 
 
 class PerspectiveGridMapping(AzimuthalGridMapping):
-    """A Grid Mapping with Azimuthal classification and perspective view."""
+    """A Grid Mapping with Azimuthal classification and perspective view.
+
+    .. versionadded:: GMVER
+
+    :Parameters:
+
+        perspective_point_height: TODO
+            TODO
+
+    """
 
     def __init__(
         self,
@@ -222,6 +284,25 @@ class AlbersEqualArea(ConicGridMapping):
 
     for more information.
 
+    .. versionadded:: GMVER
+
+    :Parameters:
+
+        standard_parallel: TODO
+            TODO
+
+        longitude_of_central_meridian: TODO
+            TODO
+
+        latitude_of_projection_origin: TODO
+            TODO
+
+        false_easting: TODO
+            TODO
+
+        false_northing: TODO
+            TODO
+
     """
 
     def __init__(
@@ -252,6 +333,22 @@ class AzimuthalEquidistant(AzimuthalGridMapping):
 
     for more information.
 
+    .. versionadded:: GMVER
+
+    :Parameters:
+
+        longitude_of_projection_origin: TODO
+            TODO
+
+        latitude_of_projection_origin: TODO
+            TODO
+
+        false_easting: TODO
+            TODO
+
+        false_northing: TODO
+            TODO
+
     """
 
     def __init__(
@@ -280,6 +377,31 @@ class Geostationary(PerspectiveGridMapping):
     https://proj.org/en/9.2/operations/projections/geos.html
 
     for more information.
+
+    .. versionadded:: GMVER
+
+    :Parameters:
+
+        longitude_of_projection_origin: TODO
+            TODO
+
+        latitude_of_projection_origin: TODO
+            TODO
+
+        false_easting: TODO
+            TODO
+
+        false_northing: TODO
+            TODO
+
+        perspective_point_height: TODO
+            TODO
+
+        sweep_angle_axis: TODO
+            TODO
+
+        fixed_angle_axis: TODO
+            TODO
 
     """
 
@@ -316,6 +438,22 @@ class LambertAzimuthalEqualArea(AzimuthalGridMapping):
 
     for more information.
 
+    .. versionadded:: GMVER
+
+    :Parameters:
+
+        longitude_of_projection_origin: TODO
+            TODO
+
+        latitude_of_projection_origin: TODO
+            TODO
+
+        false_easting: TODO
+            TODO
+
+        false_northing: TODO
+            TODO
+
     """
 
     def __init__(
@@ -347,6 +485,25 @@ class LambertConformalConic(ConicGridMapping):
 
     for more information.
 
+    .. versionadded:: GMVER
+
+    :Parameters:
+
+        standard_parallel: TODO
+            TODO
+
+        longitude_of_central_meridian: TODO
+            TODO
+
+        latitude_of_projection_origin: TODO
+            TODO
+
+        false_easting: TODO
+            TODO
+
+        false_northing: TODO
+            TODO
+
     """
 
     def __init__(
@@ -376,6 +533,25 @@ class LambertCylindricalEqualArea(CylindricalGridMapping):
     https://proj.org/en/9.2/operations/projections/cea.html
 
     for more information.
+
+    .. versionadded:: GMVER
+
+    :Parameters:
+
+        false_easting: TODO
+            TODO
+
+        false_northing: TODO
+            TODO
+
+        standard_parallel: TODO
+            TODO
+
+        longitude_of_central_meridian: TODO
+            TODO
+
+        scale_factor_at_projection_origin: TODO
+            TODO
 
     """
 
@@ -415,6 +591,25 @@ class Mercator(CylindricalGridMapping):
 
     for more information.
 
+    .. versionadded:: GMVER
+
+    :Parameters:
+
+        false_easting: TODO
+            TODO
+
+        false_northing: TODO
+            TODO
+
+        standard_parallel: TODO
+            TODO
+
+        longitude_of_projection_origin: TODO
+            TODO
+
+        scale_factor_at_projection_origin: TODO
+            TODO
+
     """
 
     def __init__(
@@ -450,6 +645,28 @@ class ObliqueMercator(CylindricalGridMapping):
     https://proj.org/en/9.2/operations/projections/omerc.html
 
     for more information.
+
+    .. versionadded:: GMVER
+
+    :Parameters:
+
+        false_easting: TODO
+            TODO
+
+        false_northing: TODO
+            TODO
+
+        azimuth_of_central_line: TODO
+            TODO
+
+        latitude_of_projection_origin: TODO
+            TODO
+
+        longitude_of_projection_origin: TODO
+            TODO
+
+        scale_factor_at_projection_origin: TODO
+            TODO
 
     """
 
@@ -489,6 +706,22 @@ class Orthographic(AzimuthalGridMapping):
 
     for more information.
 
+    .. versionadded:: GMVER
+
+    :Parameters:
+
+        longitude_of_projection_origin: TODO
+            TODO
+
+        latitude_of_projection_origin: TODO
+            TODO
+
+        false_easting: TODO
+            TODO
+
+        false_northing: TODO
+            TODO
+
     """
 
     def __init__(
@@ -517,6 +750,31 @@ class PolarStereographic(AzimuthalGridMapping):
     https://proj.org/en/9.2/operations/projections/ups.html
 
     for more information.
+
+    .. versionadded:: GMVER
+
+    :Parameters:
+
+        straight_vertical_longitude_from_pole: TODO
+            TODO
+
+        longitude_of_projection_origin: TODO
+            TODO
+
+        latitude_of_projection_origin: TODO
+            TODO
+
+        scale_factor_at_projection_origin: TODO
+            TODO
+
+        false_easting: TODO
+            TODO
+
+        false_northing: TODO
+            TODO
+
+        standard_parallel: TODO
+            TODO
 
     """
 
@@ -568,6 +826,19 @@ class RotatedLatitudeLongitude(LatLonGridMapping):
 
     for more information.
 
+    .. versionadded:: GMVER
+
+    :Parameters:
+
+        grid_north_pole_latitude: TODO
+            TODO
+
+        grid_north_pole_longitude: TODO
+            TODO
+
+        north_pole_grid_longitude: TODO
+            TODO
+
     """
 
     def __init__(
@@ -604,6 +875,8 @@ class LatitudeLongitude(LatLonGridMapping):
 
     for more information.
 
+    .. versionadded:: GMVER
+
     """
 
     def __init__(self, *args, **kwargs):
@@ -624,6 +897,19 @@ class Sinusoidal(GridMapping):
     https://proj.org/en/9.2/operations/projections/sinu.html
 
     for more information.
+
+    .. versionadded:: GMVER
+
+    :Parameters:
+
+        longitude_of_projection_origin: TODO
+            TODO
+
+        false_easting: TODO
+            TODO
+
+        false_northing: TODO
+            TODO
 
     """
 
@@ -656,6 +942,25 @@ class Stereographic(AzimuthalGridMapping):
     https://proj.org/en/9.2/operations/projections/stere.html
 
     for more information.
+
+    .. versionadded:: GMVER
+
+    :Parameters:
+
+        longitude_of_projection_origin: TODO
+            TODO
+
+        latitude_of_projection_origin: TODO
+            TODO
+
+        false_easting: TODO
+            TODO
+
+        false_northing: TODO
+            TODO
+
+        scale_factor_at_projection_origin: TODO
+            TODO
 
     """
 
@@ -690,6 +995,25 @@ class TransverseMercator(CylindricalGridMapping):
     https://proj.org/en/9.2/operations/projections/tmerc.html
 
     for more information.
+
+    .. versionadded:: GMVER
+
+    :Parameters:
+
+        false_easting: TODO
+            TODO
+
+        false_northing: TODO
+            TODO
+
+        scale_factor_at_central_meridian: TODO
+            TODO
+
+        longitude_of_central_meridian: TODO
+            TODO
+
+        latitude_of_projection_origin: TODO
+            TODO
 
     """
 
@@ -726,6 +1050,25 @@ class VerticalPerspective(PerspectiveGridMapping):
     https://proj.org/en/9.2/operations/projections/nsper.html
 
     for more information.
+
+    .. versionadded:: GMVER
+
+    :Parameters:
+
+        longitude_of_projection_origin: TODO
+            TODO
+
+        latitude_of_projection_origin: TODO
+            TODO
+
+        false_easting: TODO
+            TODO
+
+        false_northing: TODO
+            TODO
+
+        perspective_point_height: TODO
+            TODO
 
     """
 

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -239,27 +239,16 @@ def convert_cf_angular_data_to_proj(data):
     units_str = units.units
 
     degrees_unit_prefix = ["degree", "degrees"]
-    # Valid possibilities from 4.1. Latitude Coordinate:
-    # http://cfconventions.org/cf-conventions/
-    # cf-conventions.html#latitude-coordinate
-    valid_cf_lat_units = [
+    # Taken from 4.1. Latitude Coordinate and 4.2. Longitude Coordinate:
+    # http://cfconventions.org/cf-conventions/cf-conventions.html...
+    # ...#latitude-coordinate and ...#longitude-coordinate
+    valid_cf_lat_lon_units = [
         s + e
         for s, e in itertools.product(
-            degrees_unit_prefix, ("_north", "_N", "N")
+            degrees_unit_prefix, ("_north", "_N", "N", "_east", "_E", "E")
         )
     ]
-    # Valid possibilities from 4.2. Longitude Coordinate, see:
-    # http://cfconventions.org/cf-conventions/
-    # cf-conventions.html#longitude-coordinate
-    valid_cf_lon_units = [
-        s + e
-        for s, e in itertools.product(
-            degrees_unit_prefix, ("_east", "_E", "E")
-        )
-    ]
-    valid_degrees_units = (
-        degrees_unit_prefix + valid_cf_lat_units + valid_cf_lon_units
-    )
+    valid_degrees_units = degrees_unit_prefix + valid_cf_lat_lon_units
 
     if units_str in valid_degrees_units:
         # No need for suffix 'D' for decimal degrees, as that is the default

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -247,6 +247,25 @@ class GridMapping(ABC):
         self.semi_major_axis = semi_major_axis
         self.semi_minor_axis = semi_minor_axis
 
+    def __repr__(self):
+        """x.__repr__() <==> repr(x)"""
+        # Report parent GridMapping class to indicate classification,
+        # but only if it has one (> 2 avoids own class and 'object')
+        # base. E.g. we get <CF AzimuthalGridMapping:Orthographic>,
+        # <CF GridMapping:AzimuthalGridMapping>, <CF GridMapping>.
+        parent_gm = ""
+        if len(self.__class__.__mro__) > 2:
+            parent_gm = self.__class__.__mro__[1].__name__ + ": "
+        return f"<CF {parent_gm}{self.__class__.__name__}>"
+
+    def __str__(self):
+        """x.__str__() <==> str(x)"""
+        return f"{self.__repr__()[:-1]} {self.get_proj_string()}>"
+
+    def __eq__(self, other):
+        """The rich comparison operator ``==``."""
+        return self.get_proj_string() == other.get_proj_string()
+
     @property
     @abstractmethod
     def grid_mapping_name(self):
@@ -263,21 +282,6 @@ class GridMapping(ABC):
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
         pass
-
-    def __repr__(self):
-        """x.__repr__() <==> repr(x)"""
-        # Report parent GridMapping class to indicate classification,
-        # but only if it has one (> 2 avoids own class and 'object')
-        # base. E.g. we get <CF AzimuthalGridMapping:Orthographic>,
-        # <CF GridMapping:AzimuthalGridMapping>, <CF GridMapping>.
-        parent_gm = ""
-        if len(self.__class__.__mro__) > 2:
-            parent_gm = self.__class__.__mro__[1].__name__ + ": "
-        return f"<CF {parent_gm}{self.__class__.__name__}>"
-
-    def __str__(self):
-        """x.__str__() <==> str(x)"""
-        return f"{self.__repr__()[:-1]} {self.get_proj_string()}>"
 
 
 class AzimuthalGridMapping(GridMapping):

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -2,7 +2,6 @@ from abc import ABC, abstractmethod
 
 from pyproj import CRS
 
-
 PROJ_PREFIX = "+proj"
 ALL_GRID_MAPPING_ATTR_NAMES = {
     "grid_mapping_name",
@@ -230,7 +229,6 @@ class GridMapping(ABC):
                           takes precedence.
 
         """
-
         for kwarg in kwargs:
             if kwarg not in ALL_GRID_MAPPING_ATTR_NAMES:
                 raise ValueError(
@@ -247,6 +245,13 @@ class GridMapping(ABC):
         self.reference_ellipsoid_name = reference_ellipsoid_name
         self.semi_major_axis = semi_major_axis
         self.semi_minor_axis = semi_minor_axis
+
+    @property
+    @classmethod
+    @abstractmethod
+    def grid_mapping_name(cls):
+        """The value of the 'grid_mapping_name' attribute."""
+        return
 
     def __repr__(self):
         """x.__repr__() <==> repr(x)"""
@@ -270,12 +275,6 @@ class GridMapping(ABC):
     def __hash__(self, other):
         """The rich comparison operator ``==``."""
         return hash(self.get_proj_string())
-
-    @property
-    @abstractmethod
-    def grid_mapping_name(self):
-        """The value of the 'grid_mapping_name' attribute."""
-        pass
 
     @property
     @abstractmethod
@@ -531,10 +530,7 @@ class AlbersEqualArea(ConicGridMapping):
 
     """
 
-    @property
-    def grid_mapping_name(self):
-        """The value of the 'grid_mapping_name' attribute."""
-        return "albers_conical_equal_area"
+    grid_mapping_name = "albers_conical_equal_area"
 
     @property
     def proj_id(self):
@@ -592,10 +588,7 @@ class AzimuthalEquidistant(AzimuthalGridMapping):
 
     """
 
-    @property
-    def grid_mapping_name(self):
-        """The value of the 'grid_mapping_name' attribute."""
-        return "azimuthal_equidistant"
+    grid_mapping_name = "azimuthal_equidistant"
 
     @property
     def proj_id(self):
@@ -677,6 +670,8 @@ class Geostationary(PerspectiveGridMapping):
 
     """
 
+    grid_mapping_name = "geostationary"
+
     def __init__(
         self,
         perspective_point_height,
@@ -711,11 +706,6 @@ class Geostationary(PerspectiveGridMapping):
         # Values "x" and "y" are not case-sensitive, so convert to lower-case
         self.sweep_angle_axis = sweep_angle_axis.lower()
         self.fixed_angle_axis = fixed_angle_axis.lower()
-
-    @property
-    def grid_mapping_name(self):
-        """The value of the 'grid_mapping_name' attribute."""
-        return "geostationary"
 
     @property
     def proj_id(self):
@@ -773,10 +763,7 @@ class LambertAzimuthalEqualArea(AzimuthalGridMapping):
 
     """
 
-    @property
-    def grid_mapping_name(self):
-        """The value of the 'grid_mapping_name' attribute."""
-        return "lambert_azimuthal_equal_area"
+    grid_mapping_name = "lambert_azimuthal_equal_area"
 
     @property
     def proj_id(self):
@@ -848,10 +835,7 @@ class LambertConformalConic(ConicGridMapping):
 
     """
 
-    @property
-    def grid_mapping_name(self):
-        """The value of the 'grid_mapping_name' attribute."""
-        return "lambert_conformal_conic"
+    grid_mapping_name = "lambert_conformal_conic"
 
     @property
     def proj_id(self):
@@ -920,6 +904,8 @@ class LambertCylindricalEqualArea(CylindricalGridMapping):
 
     """
 
+    grid_mapping_name = "lambert_cylindrical_equal_area"
+
     def __init__(
         self,
         false_easting=0.0,
@@ -936,11 +922,6 @@ class LambertCylindricalEqualArea(CylindricalGridMapping):
         self.scale_factor_at_projection_origin = (
             scale_factor_at_projection_origin
         )
-
-    @property
-    def grid_mapping_name(self):
-        """The value of the 'grid_mapping_name' attribute."""
-        return "lambert_cylindrical_equal_area"
 
     @property
     def proj_id(self):
@@ -1009,6 +990,8 @@ class Mercator(CylindricalGridMapping):
 
     """
 
+    grid_mapping_name = "mercator"
+
     def __init__(
         self,
         false_easting=0.0,
@@ -1025,11 +1008,6 @@ class Mercator(CylindricalGridMapping):
         self.scale_factor_at_projection_origin = (
             scale_factor_at_projection_origin
         )
-
-    @property
-    def grid_mapping_name(self):
-        """The value of the 'grid_mapping_name' attribute."""
-        return "mercator"
 
     @property
     def proj_id(self):
@@ -1101,6 +1079,8 @@ class ObliqueMercator(CylindricalGridMapping):
 
     """
 
+    grid_mapping_name = "oblique_mercator"
+
     def __init__(
         self,
         azimuth_of_central_line=0.0,
@@ -1119,11 +1099,6 @@ class ObliqueMercator(CylindricalGridMapping):
         self.scale_factor_at_projection_origin = (
             scale_factor_at_projection_origin
         )
-
-    @property
-    def grid_mapping_name(self):
-        """The value of the 'grid_mapping_name' attribute."""
-        return "oblique_mercator"
 
     @property
     def proj_id(self):
@@ -1181,10 +1156,7 @@ class Orthographic(AzimuthalGridMapping):
 
     """
 
-    @property
-    def grid_mapping_name(self):
-        """The value of the 'grid_mapping_name' attribute."""
-        return "orthographic"
+    grid_mapping_name = "orthographic"
 
     @property
     def proj_id(self):
@@ -1269,6 +1241,8 @@ class PolarStereographic(AzimuthalGridMapping):
 
     """
 
+    grid_mapping_name = "polar_stereographic"
+
     def __init__(
         self,
         latitude_of_projection_origin=0.0,
@@ -1307,11 +1281,6 @@ class PolarStereographic(AzimuthalGridMapping):
         self.scale_factor_at_projection_origin = (
             scale_factor_at_projection_origin
         )
-
-    @property
-    def grid_mapping_name(self):
-        """The value of the 'grid_mapping_name' attribute."""
-        return "polar_stereographic"
 
     @property
     def proj_id(self):
@@ -1365,6 +1334,8 @@ class RotatedLatitudeLongitude(LatLonGridMapping):
 
     """
 
+    grid_mapping_name = "rotated_latitude_longitude"
+
     def __init__(
         self,
         grid_north_pole_latitude,
@@ -1377,11 +1348,6 @@ class RotatedLatitudeLongitude(LatLonGridMapping):
         self.grid_north_pole_latitude = grid_north_pole_latitude
         self.grid_north_pole_longitude = grid_north_pole_longitude
         self.north_pole_grid_longitude = north_pole_grid_longitude
-
-    @property
-    def grid_mapping_name(self):
-        """The value of the 'grid_mapping_name' attribute."""
-        return "rotated_latitude_longitude"
 
     @property
     def proj_id(self):
@@ -1409,10 +1375,7 @@ class LatitudeLongitude(LatLonGridMapping):
 
     """
 
-    @property
-    def grid_mapping_name(self):
-        """The value of the 'grid_mapping_name' attribute."""
-        return "latitude_longitude"
+    grid_mapping_name = "latitude_longitude"
 
     @property
     def proj_id(self):
@@ -1462,6 +1425,8 @@ class Sinusoidal(GridMapping):
 
     """
 
+    grid_mapping_name = "sinusoidal"
+
     def __init__(
         self,
         longitude_of_projection_origin=0.0,
@@ -1474,11 +1439,6 @@ class Sinusoidal(GridMapping):
         self.longitude_of_projection_origin = longitude_of_projection_origin
         self.false_easting = false_easting
         self.false_northing = false_northing
-
-    @property
-    def grid_mapping_name(self):
-        """The value of the 'grid_mapping_name' attribute."""
-        return "sinusoidal"
 
     @property
     def proj_id(self):
@@ -1540,6 +1500,8 @@ class Stereographic(AzimuthalGridMapping):
 
     """
 
+    grid_mapping_name = "stereographic"
+
     def __init__(
         self,
         false_easting=0.0,
@@ -1560,11 +1522,6 @@ class Stereographic(AzimuthalGridMapping):
         self.scale_factor_at_projection_origin = (
             scale_factor_at_projection_origin
         )
-
-    @property
-    def grid_mapping_name(self):
-        """The value of the 'grid_mapping_name' attribute."""
-        return "stereographic"
 
     @property
     def proj_id(self):
@@ -1626,6 +1583,8 @@ class TransverseMercator(CylindricalGridMapping):
 
     """
 
+    grid_mapping_name = "transverse_mercator"
+
     def __init__(
         self,
         scale_factor_at_central_meridian=1.0,
@@ -1642,11 +1601,6 @@ class TransverseMercator(CylindricalGridMapping):
         )
         self.longitude_of_central_meridian = longitude_of_central_meridian
         self.latitude_of_projection_origin = latitude_of_projection_origin
-
-    @property
-    def grid_mapping_name(self):
-        """The value of the 'grid_mapping_name' attribute."""
-        return "transverse_mercator"
 
     @property
     def proj_id(self):
@@ -1709,10 +1663,7 @@ class VerticalPerspective(PerspectiveGridMapping):
 
     """
 
-    @property
-    def grid_mapping_name(self):
-        """The value of the 'grid_mapping_name' attribute."""
-        return "vertical_perspective"
+    grid_mapping_name = "vertical_perspective"
 
     @property
     def proj_id(self):
@@ -1735,7 +1686,7 @@ _all_abstract_grid_mappings = (
     LatLonGridMapping,
     PerspectiveGridMapping,
 )
-# Representing all Grid Mappings repsented by the CF Conventions (APpendix F)
+# Representing all Grid Mappings repsented by the CF Conventions (Appendix F)
 _all_concrete_grid_mappings = (
     AlbersEqualArea,
     AzimuthalEquidistant,
@@ -1754,3 +1705,14 @@ _all_concrete_grid_mappings = (
     TransverseMercator,
     VerticalPerspective,
 )
+
+
+def _get_cf_grid_mapping_from_name(gm_name):
+    """TODO."""
+    cf_supported_gm_names = {
+        gm.grid_mapping_name: gm for gm in _all_concrete_grid_mappings
+    }
+    if gm_name in cf_supported_gm_names:
+        return cf_supported_gm_names[gm_name]
+    else:
+        return

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -1336,8 +1336,7 @@ class RotatedLatitudeLongitude(LatLonGridMapping):
             units of decimal degrees, where forming a string by adding
             a suffix character indicates alternative units of
             radians if the suffix is 'R' or 'r'. If a string, a suffix
-            of 'd', 'D' or '°' confirm units of decimal degrees. The default
-            is 0.0 decimal degrees.
+            of 'd', 'D' or '°' confirm units of decimal degrees.
 
         grid_north_pole_longitude: number or `str`
             Longitude of the North pole of the unrotated source CRS,
@@ -1345,8 +1344,7 @@ class RotatedLatitudeLongitude(LatLonGridMapping):
             units of decimal degrees, where forming a string by adding
             a suffix character indicates alternative units of
             radians if the suffix is 'R' or 'r'. If a string, a suffix
-            of 'd', 'D' or '°' confirm units of decimal degrees. The default
-            is 0.0 decimal degrees.
+            of 'd', 'D' or '°' confirm units of decimal degrees.
 
         north_pole_grid_longitude: number or `str`, optional
             The longitude of projection center (PROJ 'lon_0' value), in

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -2,8 +2,7 @@ from abc import ABC, abstractmethod
 
 from pyproj import CRS
 
-
-PROJ_PREFIX="+proj"
+PROJ_PREFIX = "+proj"
 ALL_GRID_MAPPING_ATTR_NAMES = {
     "grid_mapping_name",
     # *Those which describe the ellipsoid and prime meridian:*
@@ -98,6 +97,8 @@ the values documented as defaults in the docstrings are taken from this:
 """
 WGS1984_CF_ATTR_DEFAULTS = CRS.from_proj4("+proj=merc").to_cf()
 
+DUMMY_PARAMS = {"a": "b", "c": 0.0}  # TODOPARAMETERS, drop this
+
 
 def _convert_units_cf_to_proj(cf_units):
     """Take CF units and convert them to equivalent units under PROJ."""
@@ -122,6 +123,14 @@ def _make_proj_string_comp(spec):
     """
     proj_string = ""
     for comp, value in spec.items():
+        if not isinstance(value, str):
+            try:
+                value = str(value)
+            except TypeError:
+                raise TypeError(
+                    "Can't create proj-string due to non-representable "
+                    f"value {value} for key {comp}"
+                )
         proj_string += f" +{comp}={value}"
     return proj_string
 
@@ -419,6 +428,7 @@ class LatLonGridMapping(GridMapping):
     .. versionadded:: GMVER
 
     """
+
     pass
 
 
@@ -524,7 +534,8 @@ class AlbersEqualArea(ConicGridMapping):
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
-        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
+        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
+        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
 
 
 class AzimuthalEquidistant(AzimuthalGridMapping):
@@ -584,7 +595,8 @@ class AzimuthalEquidistant(AzimuthalGridMapping):
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
-        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
+        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
+        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
 
 
 class Geostationary(PerspectiveGridMapping):
@@ -703,7 +715,8 @@ class Geostationary(PerspectiveGridMapping):
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
-        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
+        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
+        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
 
 
 class LambertAzimuthalEqualArea(AzimuthalGridMapping):
@@ -763,7 +776,8 @@ class LambertAzimuthalEqualArea(AzimuthalGridMapping):
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
-        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
+        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
+        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
 
 
 class LambertConformalConic(ConicGridMapping):
@@ -837,7 +851,8 @@ class LambertConformalConic(ConicGridMapping):
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
-        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
+        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
+        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
 
 
 class LambertCylindricalEqualArea(CylindricalGridMapping):
@@ -905,9 +920,7 @@ class LambertCylindricalEqualArea(CylindricalGridMapping):
         longitude_of_central_meridian=0.0,
         **kwargs,
     ):
-        super().__init__(
-            false_easting=0.0, false_northing=0.0, **kwargs
-        )
+        super().__init__(false_easting=0.0, false_northing=0.0, **kwargs)
 
         self.standard_parallel = standard_parallel
         self.longitude_of_central_meridian = longitude_of_central_meridian
@@ -927,7 +940,8 @@ class LambertCylindricalEqualArea(CylindricalGridMapping):
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
-        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
+        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
+        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
 
 
 class Mercator(CylindricalGridMapping):
@@ -995,9 +1009,7 @@ class Mercator(CylindricalGridMapping):
         scale_factor_at_projection_origin=1.0,
         **kwargs,
     ):
-        super().__init__(
-            false_easting=0.0, false_northing=0.0, **kwargs
-        )
+        super().__init__(false_easting=0.0, false_northing=0.0, **kwargs)
 
         self.standard_parallel = standard_parallel
         self.longitude_of_projection_origin = longitude_of_projection_origin
@@ -1017,7 +1029,8 @@ class Mercator(CylindricalGridMapping):
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
-        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
+        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
+        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
 
 
 class ObliqueMercator(CylindricalGridMapping):
@@ -1089,9 +1102,7 @@ class ObliqueMercator(CylindricalGridMapping):
         false_northing=0.0,
         **kwargs,
     ):
-        super().__init__(
-            false_easting=0.0, false_northing=0.0, **kwargs
-        )
+        super().__init__(false_easting=0.0, false_northing=0.0, **kwargs)
 
         self.azimuth_of_central_line = azimuth_of_central_line
         self.latitude_of_projection_origin = latitude_of_projection_origin
@@ -1112,7 +1123,8 @@ class ObliqueMercator(CylindricalGridMapping):
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
-        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
+        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
+        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
 
 
 class Orthographic(AzimuthalGridMapping):
@@ -1172,7 +1184,8 @@ class Orthographic(AzimuthalGridMapping):
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
-        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
+        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
+        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
 
 
 class PolarStereographic(AzimuthalGridMapping):
@@ -1298,7 +1311,8 @@ class PolarStereographic(AzimuthalGridMapping):
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
-        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
+        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
+        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
 
 
 class RotatedLatitudeLongitude(LatLonGridMapping):
@@ -1369,7 +1383,8 @@ class RotatedLatitudeLongitude(LatLonGridMapping):
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
-        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
+        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
+        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
 
 
 class LatitudeLongitude(LatLonGridMapping):
@@ -1399,7 +1414,8 @@ class LatitudeLongitude(LatLonGridMapping):
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
-        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
+        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
+        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
 
 
 class Sinusoidal(GridMapping):
@@ -1464,7 +1480,8 @@ class Sinusoidal(GridMapping):
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
-        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
+        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
+        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
 
 
 class Stereographic(AzimuthalGridMapping):
@@ -1549,7 +1566,8 @@ class Stereographic(AzimuthalGridMapping):
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
-        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
+        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
+        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
 
 
 class TransverseMercator(CylindricalGridMapping):
@@ -1610,9 +1628,7 @@ class TransverseMercator(CylindricalGridMapping):
         false_northing=0.0,
         **kwargs,
     ):
-        super().__init__(
-            false_easting=0.0, false_northing=0.0, **kwargs
-        )
+        super().__init__(false_easting=0.0, false_northing=0.0, **kwargs)
 
         self.scale_factor_at_central_meridian = (
             scale_factor_at_central_meridian
@@ -1632,7 +1648,8 @@ class TransverseMercator(CylindricalGridMapping):
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
-        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
+        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
+        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"
 
 
 class VerticalPerspective(PerspectiveGridMapping):
@@ -1697,4 +1714,5 @@ class VerticalPerspective(PerspectiveGridMapping):
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
-        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
+        parameters = _make_proj_string_comp(DUMMY_PARAMS)  # TODOPARAMETERS
+        return f"{PROJ_PREFIX}={self.proj_id}{parameters}"

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -1801,7 +1801,32 @@ _all_concrete_grid_mappings = (
 
 
 def _get_cf_grid_mapping_from_name(gm_name):
-    """TODO."""
+    """Return the CF Grid Mapping class for a 'grid_mapping_name'.
+
+        .. versionadded:: GMVER
+
+        :Parameters:
+
+            gm_name: `str`
+                The value of the 'grid_mapping_name' attribute
+                to convert to the equivalent CF Grid Mapping class.
+
+        :Returns:
+
+                `cf.GridMapping`
+                     The CF Grid Mapping class corresponding to
+                     the input 'grid_mapping_name' attribute.
+
+        **Examples**
+
+        >>> cf._get_cf_grid_mapping_from_name("vertical_perspective")
+        cf.gridmappings.VerticalPerspective
+
+        >>>  cf._get_cf_grid_mapping_from_name("lambert_conformal_conic")
+        cf.gridmappings.LambertConformalConic
+
+
+    """
     cf_supported_gm_names = {
         gm.grid_mapping_name: gm for gm in _all_concrete_grid_mappings
     }

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -106,46 +106,57 @@ class AzimuthalGridMapping(GridMapping):
     """TODO."""
 
     def __init__(
-        self, longitude_of_projection_origin, latitude_of_projection_origin
+        self,
+        longitude_of_projection_origin,
+        latitude_of_projection_origin,
+        *args,
+        **kwargs,
     ):
-        super().__init__()
+        super().__init__(*args, **kwargs)
 
 
 class ConicGridMapping(GridMapping):
     """TODO."""
 
-    def __init__(self, standard_parallel, longitude_of_central_meridian):
-        super().__init__()
+    def __init__(
+        self, standard_parallel, longitude_of_central_meridian, *args, **kwargs
+    ):
+        super().__init__(*args, **kwargs)
 
 
 class CylindricalGridMapping(GridMapping):
     """TODO."""
 
-    def __init__(self, false_easting, false_northing):
-        super().__init__()
+    def __init__(self, false_easting, false_northing, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
 
 class LatLonGridMapping(GridMapping):
     """TODO."""
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
 
 class PerspectiveGridMapping(AzimuthalGridMapping):
     """TODO."""
 
     def __init__(
-        self, false_easting, false_northing, perspective_point_height
+        self,
+        false_easting,
+        false_northing,
+        perspective_point_height,
+        *args,
+        **kwargs,
     ):
-        super().__init__()
+        super().__init__(*args, **kwargs)
 
 
 class StereographicGridMapping(AzimuthalGridMapping):
     """TODO."""
 
-    def __init__(self, false_easting, false_northing):
-        super().__init__()
+    def __init__(self, false_easting, false_northing, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
 
 class AlbersEqualArea(ConicGridMapping):
@@ -165,8 +176,17 @@ class AlbersEqualArea(ConicGridMapping):
 
     """
 
-    def __init__(self):
-        super().__init__("albers_conical_equal_area", "aea")
+    def __init__(
+        self,
+        standard_parallel,
+        longitude_of_central_meridian,
+        atitude_of_projection_origin,
+        false_easting,
+        false_northing,
+        *args,
+        **kwargs,
+    ):
+        super().__init__("albers_conical_equal_area", "aea", *args, **kwargs)
 
 
 class AzimuthalEquidistant(AzimuthalGridMapping):
@@ -186,8 +206,16 @@ class AzimuthalEquidistant(AzimuthalGridMapping):
 
     """
 
-    def __init__(self):
-        super().__init__("azimuthal_equidistant", "aeqd")
+    def __init__(
+        self,
+        longitude_of_projection_origin,
+        latitude_of_projection_origin,
+        false_easting,
+        false_northing,
+        *args,
+        **kwargs,
+    ):
+        super().__init__("azimuthal_equidistant", "aeqd", *args, **kwargs)
 
 
 class Geostationary(PerspectiveGridMapping):
@@ -207,8 +235,19 @@ class Geostationary(PerspectiveGridMapping):
 
     """
 
-    def __init__(self):
-        super().__init__("geostationary", "geos")
+    def __init__(
+        self,
+        latitude_of_projection_origin,
+        longitude_of_projection_origin,
+        perspective_point_height,
+        false_easting,
+        false_northing,
+        sweep_angle_axis,
+        fixed_angle_axis,
+        *args,
+        **kwargs,
+    ):
+        super().__init__("geostationary", "geos", *args, **kwargs)
 
 
 class LambertAzimuthalEqualArea(AzimuthalGridMapping):
@@ -228,8 +267,18 @@ class LambertAzimuthalEqualArea(AzimuthalGridMapping):
 
     """
 
-    def __init__(self):
-        super().__init__("lambert_azimuthal_equal_area", "laea")
+    def __init__(
+        self,
+        longitude_of_projection_origin,
+        latitude_of_projection_origin,
+        false_easting,
+        false_northing,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(
+            "lambert_azimuthal_equal_area", "laea", *args, **kwargs
+        )
 
 
 class LambertConformalConic(ConicGridMapping):
@@ -249,8 +298,17 @@ class LambertConformalConic(ConicGridMapping):
 
     """
 
-    def __init__(self):
-        super().__init__("lambert_conformal_conic", "lcc")
+    def __init__(
+        self,
+        standard_parallel,
+        longitude_of_central_meridian,
+        latitude_of_projection_origin,
+        false_easting,
+        false_northing,
+        *args,
+        **kwargs,
+    ):
+        super().__init__("lambert_conformal_conic", "lcc", *args, **kwargs)
 
 
 class LambertCylindricalEqualArea(CylindricalGridMapping):
@@ -270,8 +328,19 @@ class LambertCylindricalEqualArea(CylindricalGridMapping):
 
     """
 
-    def __init__(self):
-        super().__init__("lambert_cylindrical_equal_area", "cea")
+    def __init__(
+        self,
+        longitude_of_central_meridian,
+        standard_parallel,
+        scale_factor_at_projection_origin,
+        false_easting,
+        false_northing,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(
+            "lambert_cylindrical_equal_area", "cea", *args, **kwargs
+        )
 
 
 class Mercator(CylindricalGridMapping):
@@ -291,8 +360,17 @@ class Mercator(CylindricalGridMapping):
 
     """
 
-    def __init__(self):
-        super().__init__("mercator", "merc")
+    def __init__(
+        self,
+        longitude_of_projection_origin,
+        standard_parallel,
+        scale_factor_at_projection_origin,
+        false_easting,
+        false_northing,
+        *args,
+        **kwargs,
+    ):
+        super().__init__("mercator", "merc", *args, **kwargs)
 
 
 class ObliqueMercator(CylindricalGridMapping):
@@ -312,8 +390,18 @@ class ObliqueMercator(CylindricalGridMapping):
 
     """
 
-    def __init__(self):
-        super().__init__("oblique_mercator", "omerc")
+    def __init__(
+        self,
+        azimuth_of_central_line,
+        latitude_of_projection_origin,
+        longitude_of_projection_origin,
+        scale_factor_at_projection_origin,
+        false_easting,
+        false_northing,
+        *args,
+        **kwargs,
+    ):
+        super().__init__("oblique_mercator", "omerc", *args, **kwargs)
 
 
 class Orthographic(AzimuthalGridMapping):
@@ -333,8 +421,16 @@ class Orthographic(AzimuthalGridMapping):
 
     """
 
-    def __init__(self):
-        super().__init__("orthographic", "ortho")
+    def __init__(
+        self,
+        longitude_of_projection_origin,
+        latitude_of_projection_origin,
+        false_easting,
+        false_northing,
+        *args,
+        **kwargs,
+    ):
+        super().__init__("orthographic", "ortho", *args, **kwargs)
 
 
 class PolarStereographic(StereographicGridMapping):
@@ -354,8 +450,18 @@ class PolarStereographic(StereographicGridMapping):
 
     """
 
-    def __init__(self):
-        super().__init__("polar_stereographic", "ups")
+    def __init__(
+        self,
+        straight_vertical_longitude_from_pole,
+        latitude_of_projection_origin,
+        standard_parallel,
+        scale_factor_at_projection_origin,
+        false_easting,
+        false_northing,
+        *args,
+        **kwargs,
+    ):
+        super().__init__("polar_stereographic", "ups", *args, **kwargs)
 
 
 class RotatedLatitudeLongitude(LatLonGridMapping):
@@ -375,8 +481,15 @@ class RotatedLatitudeLongitude(LatLonGridMapping):
 
     """
 
-    def __init__(self):
-        super().__init__("rotated_latitude_longitude", "eqc")
+    def __init__(
+        self,
+        grid_north_pole_latitude,
+        grid_north_pole_longitude,
+        north_pole_grid_longitude,
+        *args,
+        **kwargs,
+    ):
+        super().__init__("rotated_latitude_longitude", "eqc", *args, **kwargs)
 
 
 class LatitudeLongitude(RotatedLatitudeLongitude):
@@ -400,8 +513,8 @@ class LatitudeLongitude(RotatedLatitudeLongitude):
 
     """
 
-    def __init__(self):
-        super().__init__("latitude_longitude", "eqc")
+    def __init__(self, *args, **kwargs):
+        super().__init__("latitude_longitude", "eqc", *args, **kwargs)
 
 
 class Sinusoidal(GridMapping):
@@ -421,8 +534,15 @@ class Sinusoidal(GridMapping):
 
     """
 
-    def __init__(self):
-        super().__init__("sinusoidal", "sinu")
+    def __init__(
+        self,
+        longitude_of_projection_origin,
+        false_easting,
+        false_northing,
+        *args,
+        **kwargs,
+    ):
+        super().__init__("sinusoidal", "sinu", *args, **kwargs)
 
 
 class Stereographic(StereographicGridMapping):
@@ -442,8 +562,17 @@ class Stereographic(StereographicGridMapping):
 
     """
 
-    def __init__(self):
-        super().__init__("stereographic", "stere")
+    def __init__(
+        self,
+        longitude_of_projection_origin,
+        latitude_of_projection_origin,
+        scale_factor_at_projection_origin,
+        false_easting,
+        false_northing,
+        *args,
+        **kwargs,
+    ):
+        super().__init__("stereographic", "stere", *args, **kwargs)
 
 
 class TransverseMercator(CylindricalGridMapping):
@@ -463,8 +592,17 @@ class TransverseMercator(CylindricalGridMapping):
 
     """
 
-    def __init__(self):
-        super().__init__("transverse_mercator", "tmerc")
+    def __init__(
+        self,
+        scale_factor_at_central_meridian,
+        longitude_of_central_meridian,
+        latitude_of_projection_origin,
+        false_easting,
+        false_northing,
+        *args,
+        **kwargs,
+    ):
+        super().__init__("transverse_mercator", "tmerc", *args, **kwargs)
 
 
 class VerticalPerspective(PerspectiveGridMapping):
@@ -484,5 +622,14 @@ class VerticalPerspective(PerspectiveGridMapping):
 
     """
 
-    def __init__(self):
-        super().__init__("vertical_perspective", "nsper")
+    def __init__(
+        self,
+        latitude_of_projection_origin,
+        longitude_of_projection_origin,
+        perspective_point_height,
+        false_easting,
+        false_northing,
+        *args,
+        **kwargs,
+    ):
+        super().__init__("vertical_perspective", "nsper", *args, **kwargs)

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 from pyproj import CRS
 
 
+PROJ_PREFIX="+proj"
 ALL_GRID_MAPPING_ATTR_NAMES = {
     "grid_mapping_name",
     # *Those which describe the ellipsoid and prime meridian:*
@@ -46,6 +47,26 @@ ALL_GRID_MAPPING_ATTR_NAMES = {
     "projected_crs_name",
     "towgs84",  # ------------------------- PROJ '+towgs84' value
 }
+GRID_MAPPING_ATTR_TO_PROJ_STRING_COMP = {
+    "earth_radius": "R",
+    "inverse_flattening": "rf",
+    "prime_meridian_name": "pm",
+    "reference_ellipsoid_name": "ellps",
+    "semi_major_axis": "a",
+    "semi_minor_axis": "b",
+    "longitude_of_projection_origin": "lon_0",
+    "latitude_of_projection_origin": "lat_0",
+    "scale_factor_at_projection_origin": "k_0",
+    "false_easting": "x_0",
+    "false_northing": "y_0",
+    "sweep_angle_axis": "sweep",
+    "standard_parallel": ("lat_1", "lat_2"),
+    "perspective_point_height": "h",
+    "azimuth_of_central_line": "alpha",
+    "crs_wkt": "crs_wkt",
+    "towgs84": "towgs84",
+}
+
 
 """
 Define this first since it provides the default for several parameters,
@@ -111,6 +132,7 @@ class GridMapping(ABC):
         prime_meridian_name="Greenwich",
         longitude_of_prime_meridian=0.0,
         earth_radius=None,
+        **kwargs,
     ):
         """**Initialisation**
 
@@ -172,8 +194,15 @@ class GridMapping(ABC):
 
         """
 
+        for kwarg in kwargs:
+            if kwarg not in ALL_GRID_MAPPING_ATTR_NAMES:
+                raise ValueError(
+                    "Unrecognised map parameter provided for the "
+                    f"Grid Mapping: {kwarg}"
+                )
+
         # The attributes which describe the ellipsoid and prime meridian,
-        # which may be included, when applicable, with any grid mapping
+        # which may be included, when applicable, with any grid mapping.
         self.earth_radius = earth_radius
         self.inverse_flattening = inverse_flattening
         self.longitude_of_prime_meridian = longitude_of_prime_meridian
@@ -194,7 +223,6 @@ class GridMapping(ABC):
         """The PROJ projection identifier shorthand name."""
         pass
 
-    @property
     @abstractmethod
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
@@ -467,6 +495,10 @@ class AlbersEqualArea(ConicGridMapping):
         """The PROJ projection identifier shorthand name."""
         return "aea"
 
+    def get_proj_string(self):
+        """The value of the PROJ proj-string defining the projection."""
+        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
+
 
 class AzimuthalEquidistant(AzimuthalGridMapping):
     """The Azimuthal Equidistant grid mapping.
@@ -522,6 +554,10 @@ class AzimuthalEquidistant(AzimuthalGridMapping):
     def proj_id(self):
         """The PROJ projection identifier shorthand name."""
         return "aeqd"
+
+    def get_proj_string(self):
+        """The value of the PROJ proj-string defining the projection."""
+        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
 
 
 class Geostationary(PerspectiveGridMapping):
@@ -638,6 +674,10 @@ class Geostationary(PerspectiveGridMapping):
         """The PROJ projection identifier shorthand name."""
         return "geos"
 
+    def get_proj_string(self):
+        """The value of the PROJ proj-string defining the projection."""
+        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
+
 
 class LambertAzimuthalEqualArea(AzimuthalGridMapping):
     """The Lambert Azimuthal Equal Area grid mapping.
@@ -693,6 +733,10 @@ class LambertAzimuthalEqualArea(AzimuthalGridMapping):
     def proj_id(self):
         """The PROJ projection identifier shorthand name."""
         return "laea"
+
+    def get_proj_string(self):
+        """The value of the PROJ proj-string defining the projection."""
+        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
 
 
 class LambertConformalConic(ConicGridMapping):
@@ -763,6 +807,10 @@ class LambertConformalConic(ConicGridMapping):
     def proj_id(self):
         """The PROJ projection identifier shorthand name."""
         return "lcc"
+
+    def get_proj_string(self):
+        """The value of the PROJ proj-string defining the projection."""
+        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
 
 
 class LambertCylindricalEqualArea(CylindricalGridMapping):
@@ -850,6 +898,10 @@ class LambertCylindricalEqualArea(CylindricalGridMapping):
         """The PROJ projection identifier shorthand name."""
         return "cea"
 
+    def get_proj_string(self):
+        """The value of the PROJ proj-string defining the projection."""
+        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
+
 
 class Mercator(CylindricalGridMapping):
     """The Mercator grid mapping.
@@ -935,6 +987,10 @@ class Mercator(CylindricalGridMapping):
     def proj_id(self):
         """The PROJ projection identifier shorthand name."""
         return "merc"
+
+    def get_proj_string(self):
+        """The value of the PROJ proj-string defining the projection."""
+        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
 
 
 class ObliqueMercator(CylindricalGridMapping):
@@ -1027,6 +1083,10 @@ class ObliqueMercator(CylindricalGridMapping):
         """The PROJ projection identifier shorthand name."""
         return "omerc"
 
+    def get_proj_string(self):
+        """The value of the PROJ proj-string defining the projection."""
+        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
+
 
 class Orthographic(AzimuthalGridMapping):
     """The Orthographic grid mapping.
@@ -1082,6 +1142,10 @@ class Orthographic(AzimuthalGridMapping):
     def proj_id(self):
         """The PROJ projection identifier shorthand name."""
         return "ortho"
+
+    def get_proj_string(self):
+        """The value of the PROJ proj-string defining the projection."""
+        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
 
 
 class PolarStereographic(AzimuthalGridMapping):
@@ -1205,6 +1269,10 @@ class PolarStereographic(AzimuthalGridMapping):
         """The PROJ projection identifier shorthand name."""
         return "ups"
 
+    def get_proj_string(self):
+        """The value of the PROJ proj-string defining the projection."""
+        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
+
 
 class RotatedLatitudeLongitude(LatLonGridMapping):
     """The Rotated Latitude-Longitude grid mapping.
@@ -1272,6 +1340,10 @@ class RotatedLatitudeLongitude(LatLonGridMapping):
         """The PROJ projection identifier shorthand name."""
         return "latlong"
 
+    def get_proj_string(self):
+        """The value of the PROJ proj-string defining the projection."""
+        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
+
 
 class LatitudeLongitude(LatLonGridMapping):
     """The Latitude-Longitude grid mapping.
@@ -1297,6 +1369,10 @@ class LatitudeLongitude(LatLonGridMapping):
     def proj_id(self):
         """The PROJ projection identifier shorthand name."""
         return "latlong"
+
+    def get_proj_string(self):
+        """The value of the PROJ proj-string defining the projection."""
+        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
 
 
 class Sinusoidal(GridMapping):
@@ -1358,6 +1434,10 @@ class Sinusoidal(GridMapping):
     def proj_id(self):
         """The PROJ projection identifier shorthand name."""
         return "sinu"
+
+    def get_proj_string(self):
+        """The value of the PROJ proj-string defining the projection."""
+        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
 
 
 class Stereographic(AzimuthalGridMapping):
@@ -1440,6 +1520,10 @@ class Stereographic(AzimuthalGridMapping):
         """The PROJ projection identifier shorthand name."""
         return "stere"
 
+    def get_proj_string(self):
+        """The value of the PROJ proj-string defining the projection."""
+        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
+
 
 class TransverseMercator(CylindricalGridMapping):
     """The Transverse Mercator grid mapping.
@@ -1519,6 +1603,10 @@ class TransverseMercator(CylindricalGridMapping):
         """The PROJ projection identifier shorthand name."""
         return "tmerc"
 
+    def get_proj_string(self):
+        """The value of the PROJ proj-string defining the projection."""
+        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"
+
 
 class VerticalPerspective(PerspectiveGridMapping):
     """The Vertical (or Near-sided) Perspective grid mapping.
@@ -1579,3 +1667,7 @@ class VerticalPerspective(PerspectiveGridMapping):
     def proj_id(self):
         """The PROJ projection identifier shorthand name."""
         return "nsper"
+
+    def get_proj_string(self):
+        """The value of the PROJ proj-string defining the projection."""
+        return f"{PROJ_PREFIX}={self.proj_id} TODOPARAMETERS"

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -162,7 +162,7 @@ def _convert_units_proj_to_cf(proj_val_with_units, context=None):
     # indicating decimal degrees or radians with PROJ. Be strict about an
     # exact regex match, because anything not following the pattern (e.g.
     # something with extra letters) will be ambiguous for PROJ units.
-    valid_form = re.compile("(\d+(\.\d+)?)([rRdD°]?)")
+    valid_form = re.compile("(-?\d+(\.\d+)?)([rRdD°]?)")
     form = re.fullmatch(valid_form, proj_val_with_units)
     if form:
         comps = form.groups()

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -124,11 +124,21 @@ class AzimuthalGridMapping(GridMapping):
 
     :Parameters:
 
-        longitude_of_projection_origin: TODO
-            TODO
+        longitude_of_projection_origin: number or `str`, optional
+            The longitude of projection center (PROJ 'lon_0' value), in
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            is 0.0 decimal degrees.
 
-        latitude_of_projection_origin: TODO
-            TODO
+        latitude_of_projection_origin: number or `str`, optional
+            The latitude of projection center (PROJ 'lat_0' value), in
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            is 0.0 decimal degrees.
 
         false_easting: number, optional
             The false easting (PROJ 'x_0') value, in units of metres.
@@ -142,8 +152,8 @@ class AzimuthalGridMapping(GridMapping):
 
     def __init__(
         self,
-        longitude_of_projection_origin,
-        latitude_of_projection_origin,
+        longitude_of_projection_origin=0.0,
+        latitude_of_projection_origin=0.0,
         false_easting=0.0,
         false_northing=0.0,
         *args,
@@ -170,8 +180,13 @@ class ConicGridMapping(GridMapping):
         longitude_of_central_meridian: TODO
             TODO
 
-        latitude_of_projection_origin: TODO
-            TODO
+        latitude_of_projection_origin: number or `str`, optional
+            The latitude of projection center (PROJ 'lat_0' value), in
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            is 0.0 decimal degrees.
 
         false_easting: number, optional
             The false easting (PROJ 'x_0') value, in units of metres.
@@ -300,8 +315,13 @@ class AlbersEqualArea(ConicGridMapping):
         longitude_of_central_meridian: TODO
             TODO
 
-        latitude_of_projection_origin: TODO
-            TODO
+        latitude_of_projection_origin: number or `str`, optional
+            The latitude of projection center (PROJ 'lat_0' value), in
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            is 0.0 decimal degrees.
 
         false_easting: number, optional
             The false easting (PROJ 'x_0') value, in units of metres.
@@ -317,7 +337,7 @@ class AlbersEqualArea(ConicGridMapping):
         self,
         standard_parallel,
         longitude_of_central_meridian,
-        latitude_of_projection_origin,
+        latitude_of_projection_origin=0.0,
         false_easting=0.0,
         false_northing=0.0,
         *args,
@@ -345,11 +365,21 @@ class AzimuthalEquidistant(AzimuthalGridMapping):
 
     :Parameters:
 
-        longitude_of_projection_origin: TODO
-            TODO
+        longitude_of_projection_origin: number or `str`, optional
+            The longitude of projection center (PROJ 'lon_0' value), in
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            is 0.0 decimal degrees.
 
-        latitude_of_projection_origin: TODO
-            TODO
+        latitude_of_projection_origin: number or `str`, optional
+            The latitude of projection center (PROJ 'lat_0' value), in
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            is 0.0 decimal degrees.
 
         false_easting: number, optional
             The false easting (PROJ 'x_0') value, in units of metres.
@@ -363,8 +393,8 @@ class AzimuthalEquidistant(AzimuthalGridMapping):
 
     def __init__(
         self,
-        longitude_of_projection_origin,
-        latitude_of_projection_origin,
+        longitude_of_projection_origin=0.0,
+        latitude_of_projection_origin=0.0,
         false_easting=0.0,
         false_northing=0.0,
         *args,
@@ -392,11 +422,21 @@ class Geostationary(PerspectiveGridMapping):
 
     :Parameters:
 
-        longitude_of_projection_origin: TODO
-            TODO
+        longitude_of_projection_origin: number or `str`, optional
+            The longitude of projection center (PROJ 'lon_0' value), in
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            is 0.0 decimal degrees.
 
-        latitude_of_projection_origin: TODO
-            TODO
+        latitude_of_projection_origin: number or `str`, optional
+            The latitude of projection center (PROJ 'lat_0' value), in
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            is 0.0 decimal degrees.
 
         false_easting: number, optional
             The false easting (PROJ 'x_0') value, in units of metres.
@@ -419,11 +459,11 @@ class Geostationary(PerspectiveGridMapping):
 
     def __init__(
         self,
-        longitude_of_projection_origin,
-        latitude_of_projection_origin,
         perspective_point_height,
         sweep_angle_axis,
         fixed_angle_axis,
+        longitude_of_projection_origin=0.0,
+        latitude_of_projection_origin=0.0,
         false_easting=0.0,
         false_northing=0.0,
         *args,
@@ -454,11 +494,21 @@ class LambertAzimuthalEqualArea(AzimuthalGridMapping):
 
     :Parameters:
 
-        longitude_of_projection_origin: TODO
-            TODO
+        longitude_of_projection_origin: number or `str`, optional
+            The longitude of projection center (PROJ 'lon_0' value), in
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            is 0.0 decimal degrees.
 
-        latitude_of_projection_origin: TODO
-            TODO
+        latitude_of_projection_origin: number or `str`, optional
+            The latitude of projection center (PROJ 'lat_0' value), in
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            is 0.0 decimal degrees.
 
         false_easting: number, optional
             The false easting (PROJ 'x_0') value, in units of metres.
@@ -472,8 +522,8 @@ class LambertAzimuthalEqualArea(AzimuthalGridMapping):
 
     def __init__(
         self,
-        longitude_of_projection_origin,
-        latitude_of_projection_origin,
+        longitude_of_projection_origin=0.0,
+        latitude_of_projection_origin=0.0,
         false_easting=0.0,
         false_northing=0.0,
         *args,
@@ -506,11 +556,21 @@ class LambertConformalConic(ConicGridMapping):
         standard_parallel: TODO
             TODO
 
-        longitude_of_central_meridian: TODO
-            TODO
+        longitude_of_projection_origin: number or `str`, optional
+            The longitude of projection center (PROJ 'lon_0' value), in
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            is 0.0 decimal degrees.
 
-        latitude_of_projection_origin: TODO
-            TODO
+        latitude_of_projection_origin: number or `str`, optional
+            The latitude of projection center (PROJ 'lat_0' value), in
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            is 0.0 decimal degrees.
 
         false_easting: number, optional
             The false easting (PROJ 'x_0') value, in units of metres.
@@ -525,8 +585,8 @@ class LambertConformalConic(ConicGridMapping):
     def __init__(
         self,
         standard_parallel,
-        longitude_of_central_meridian,
-        latitude_of_projection_origin,
+        longitude_of_central_meridian=0.0,
+        latitude_of_projection_origin=0.0,
         false_easting=0.0,
         false_northing=0.0,
         *args,
@@ -624,8 +684,13 @@ class Mercator(CylindricalGridMapping):
         standard_parallel: TODO
             TODO
 
-        longitude_of_projection_origin: TODO
-            TODO
+        longitude_of_projection_origin: number or `str`, optional
+            The longitude of projection center (PROJ 'lon_0' value), in
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            is 0.0 decimal degrees.
 
         scale_factor_at_projection_origin: TODO
             TODO
@@ -635,8 +700,8 @@ class Mercator(CylindricalGridMapping):
     def __init__(
         self,
         standard_parallel,
-        longitude_of_projection_origin,
         scale_factor_at_projection_origin,
+        longitude_of_projection_origin=0.0,
         false_easting=0.0,
         false_northing=0.0,
         *args,
@@ -681,11 +746,21 @@ class ObliqueMercator(CylindricalGridMapping):
         azimuth_of_central_line: TODO
             TODO
 
-        latitude_of_projection_origin: TODO
-            TODO
+        longitude_of_projection_origin: number or `str`, optional
+            The longitude of projection center (PROJ 'lon_0' value), in
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            is 0.0 decimal degrees.
 
-        longitude_of_projection_origin: TODO
-            TODO
+        latitude_of_projection_origin: number or `str`, optional
+            The latitude of projection center (PROJ 'lat_0' value), in
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            is 0.0 decimal degrees.
 
         scale_factor_at_projection_origin: TODO
             TODO
@@ -695,8 +770,8 @@ class ObliqueMercator(CylindricalGridMapping):
     def __init__(
         self,
         azimuth_of_central_line,
-        latitude_of_projection_origin,
-        longitude_of_projection_origin,
+        latitude_of_projection_origin=0.0,
+        longitude_of_projection_origin=0.0,
         scale_factor_at_projection_origin,
         false_easting=0.0,
         false_northing=0.0,
@@ -732,11 +807,21 @@ class Orthographic(AzimuthalGridMapping):
 
     :Parameters:
 
-        longitude_of_projection_origin: TODO
-            TODO
+        longitude_of_projection_origin: number or `str`, optional
+            The longitude of projection center (PROJ 'lon_0' value), in
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            is 0.0 decimal degrees.
 
-        latitude_of_projection_origin: TODO
-            TODO
+        latitude_of_projection_origin: number or `str`, optional
+            The latitude of projection center (PROJ 'lat_0' value), in
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            is 0.0 decimal degrees.
 
         false_easting: number, optional
             The false easting (PROJ 'x_0') value, in units of metres.
@@ -750,8 +835,8 @@ class Orthographic(AzimuthalGridMapping):
 
     def __init__(
         self,
-        longitude_of_projection_origin,
-        latitude_of_projection_origin,
+        longitude_of_projection_origin=0.0,
+        latitude_of_projection_origin=0.0,
         false_easting=0.0,
         false_northing=0.0,
         *args,
@@ -782,11 +867,21 @@ class PolarStereographic(AzimuthalGridMapping):
         straight_vertical_longitude_from_pole: TODO
             TODO
 
-        longitude_of_projection_origin: TODO
-            TODO
+        longitude_of_projection_origin: number or `str`, optional
+            The longitude of projection center (PROJ 'lon_0' value), in
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            is 0.0 decimal degrees.
 
-        latitude_of_projection_origin: TODO
-            TODO
+        latitude_of_projection_origin: number or `str`, optional
+            The latitude of projection center (PROJ 'lat_0' value), in
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            is 0.0 decimal degrees.
 
         scale_factor_at_projection_origin: TODO
             TODO
@@ -806,10 +901,10 @@ class PolarStereographic(AzimuthalGridMapping):
 
     def __init__(
         self,
-        latitude_of_projection_origin,
         standard_parallel,
         scale_factor_at_projection_origin,
-        longitude_of_projection_origin=None,
+        latitude_of_projection_origin=0.0,
+        longitude_of_projection_origin=0.0,
         straight_vertical_longitude_from_pole=None,
         false_easting=0.0,
         false_northing=0.0,
@@ -928,8 +1023,13 @@ class Sinusoidal(GridMapping):
 
     :Parameters:
 
-        longitude_of_projection_origin: TODO
-            TODO
+        longitude_of_projection_origin: number or `str`, optional
+            The longitude of projection center (PROJ 'lon_0' value), in
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            is 0.0 decimal degrees.
 
         false_easting: number, optional
             The false easting (PROJ 'x_0') value, in units of metres.
@@ -943,7 +1043,7 @@ class Sinusoidal(GridMapping):
 
     def __init__(
         self,
-        longitude_of_projection_origin,
+        longitude_of_projection_origin=0.0,
         false_easting=0.0,
         false_northing=0.0,
         *args,
@@ -975,11 +1075,21 @@ class Stereographic(AzimuthalGridMapping):
 
     :Parameters:
 
-        longitude_of_projection_origin: TODO
-            TODO
+        longitude_of_projection_origin: number or `str`, optional
+            The longitude of projection center (PROJ 'lon_0' value), in
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            is 0.0 decimal degrees.
 
-        latitude_of_projection_origin: TODO
-            TODO
+        latitude_of_projection_origin: number or `str`, optional
+            The latitude of projection center (PROJ 'lat_0' value), in
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            is 0.0 decimal degrees.
 
         false_easting: number, optional
             The false easting (PROJ 'x_0') value, in units of metres.
@@ -996,11 +1106,11 @@ class Stereographic(AzimuthalGridMapping):
 
     def __init__(
         self,
-        longitude_of_projection_origin,
-        latitude_of_projection_origin,
         scale_factor_at_projection_origin,
         false_easting=0.0,
         false_northing=0.0,
+        longitude_of_projection_origin=0.0,
+        latitude_of_projection_origin=0.0,
         *args,
         **kwargs,
     ):
@@ -1044,8 +1154,13 @@ class TransverseMercator(CylindricalGridMapping):
         longitude_of_central_meridian: TODO
             TODO
 
-        latitude_of_projection_origin: TODO
-            TODO
+        latitude_of_projection_origin: number or `str`, optional
+            The latitude of projection center (PROJ 'lat_0' value), in
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            is 0.0 decimal degrees.
 
     """
 
@@ -1053,7 +1168,7 @@ class TransverseMercator(CylindricalGridMapping):
         self,
         scale_factor_at_central_meridian,
         longitude_of_central_meridian,
-        latitude_of_projection_origin,
+        latitude_of_projection_origin=0.0,
         false_easting=0.0,
         false_northing=0.0,
         *args,
@@ -1087,11 +1202,21 @@ class VerticalPerspective(PerspectiveGridMapping):
 
     :Parameters:
 
-        longitude_of_projection_origin: TODO
-            TODO
+        longitude_of_projection_origin: number or `str`, optional
+            The longitude of projection center (PROJ 'lon_0' value), in
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            is 0.0 decimal degrees.
 
-        latitude_of_projection_origin: TODO
-            TODO
+        latitude_of_projection_origin: number or `str`, optional
+            The latitude of projection center (PROJ 'lat_0' value), in
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            is 0.0 decimal degrees.
 
         false_easting: number, optional
             The false easting (PROJ 'x_0') value, in units of metres.
@@ -1108,9 +1233,9 @@ class VerticalPerspective(PerspectiveGridMapping):
 
     def __init__(
         self,
-        longitude_of_projection_origin,
-        latitude_of_projection_origin,
         perspective_point_height,
+        longitude_of_projection_origin=0.0,
+        latitude_of_projection_origin=0.0,
         false_easting=0.0,
         false_northing=0.0,
         *args,

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -253,6 +253,13 @@ class GridMapping(ABC):
         """The value of the 'grid_mapping_name' attribute."""
         return
 
+    @property
+    @classmethod
+    @abstractmethod
+    def proj_id(cls):
+        """The PROJ projection identifier shorthand name."""
+        return
+
     def __repr__(self):
         """x.__repr__() <==> repr(x)"""
         # Report parent GridMapping class to indicate classification,
@@ -275,12 +282,6 @@ class GridMapping(ABC):
     def __hash__(self, other):
         """The rich comparison operator ``==``."""
         return hash(self.get_proj_string())
-
-    @property
-    @abstractmethod
-    def proj_id(self):
-        """The PROJ projection identifier shorthand name."""
-        pass
 
     @abstractmethod
     def get_proj_string(self):
@@ -531,11 +532,7 @@ class AlbersEqualArea(ConicGridMapping):
     """
 
     grid_mapping_name = "albers_conical_equal_area"
-
-    @property
-    def proj_id(self):
-        """The PROJ projection identifier shorthand name."""
-        return "aea"
+    proj_id = "aea"
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
@@ -589,11 +586,7 @@ class AzimuthalEquidistant(AzimuthalGridMapping):
     """
 
     grid_mapping_name = "azimuthal_equidistant"
-
-    @property
-    def proj_id(self):
-        """The PROJ projection identifier shorthand name."""
-        return "aeqd"
+    proj_id = "aeqd"
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
@@ -671,6 +664,7 @@ class Geostationary(PerspectiveGridMapping):
     """
 
     grid_mapping_name = "geostationary"
+    proj_id = "geos"
 
     def __init__(
         self,
@@ -706,11 +700,6 @@ class Geostationary(PerspectiveGridMapping):
         # Values "x" and "y" are not case-sensitive, so convert to lower-case
         self.sweep_angle_axis = sweep_angle_axis.lower()
         self.fixed_angle_axis = fixed_angle_axis.lower()
-
-    @property
-    def proj_id(self):
-        """The PROJ projection identifier shorthand name."""
-        return "geos"
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
@@ -764,11 +753,7 @@ class LambertAzimuthalEqualArea(AzimuthalGridMapping):
     """
 
     grid_mapping_name = "lambert_azimuthal_equal_area"
-
-    @property
-    def proj_id(self):
-        """The PROJ projection identifier shorthand name."""
-        return "laea"
+    proj_id = "laea"
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
@@ -836,11 +821,7 @@ class LambertConformalConic(ConicGridMapping):
     """
 
     grid_mapping_name = "lambert_conformal_conic"
-
-    @property
-    def proj_id(self):
-        """The PROJ projection identifier shorthand name."""
-        return "lcc"
+    proj_id = "lcc"
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
@@ -905,6 +886,7 @@ class LambertCylindricalEqualArea(CylindricalGridMapping):
     """
 
     grid_mapping_name = "lambert_cylindrical_equal_area"
+    proj_id = "cea"
 
     def __init__(
         self,
@@ -922,11 +904,6 @@ class LambertCylindricalEqualArea(CylindricalGridMapping):
         self.scale_factor_at_projection_origin = (
             scale_factor_at_projection_origin
         )
-
-    @property
-    def proj_id(self):
-        """The PROJ projection identifier shorthand name."""
-        return "cea"
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
@@ -991,6 +968,7 @@ class Mercator(CylindricalGridMapping):
     """
 
     grid_mapping_name = "mercator"
+    proj_id = "merc"
 
     def __init__(
         self,
@@ -1008,11 +986,6 @@ class Mercator(CylindricalGridMapping):
         self.scale_factor_at_projection_origin = (
             scale_factor_at_projection_origin
         )
-
-    @property
-    def proj_id(self):
-        """The PROJ projection identifier shorthand name."""
-        return "merc"
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
@@ -1080,6 +1053,7 @@ class ObliqueMercator(CylindricalGridMapping):
     """
 
     grid_mapping_name = "oblique_mercator"
+    proj_id = "omerc"
 
     def __init__(
         self,
@@ -1099,11 +1073,6 @@ class ObliqueMercator(CylindricalGridMapping):
         self.scale_factor_at_projection_origin = (
             scale_factor_at_projection_origin
         )
-
-    @property
-    def proj_id(self):
-        """The PROJ projection identifier shorthand name."""
-        return "omerc"
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
@@ -1157,11 +1126,7 @@ class Orthographic(AzimuthalGridMapping):
     """
 
     grid_mapping_name = "orthographic"
-
-    @property
-    def proj_id(self):
-        """The PROJ projection identifier shorthand name."""
-        return "ortho"
+    proj_id = "ortho"
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
@@ -1242,6 +1207,7 @@ class PolarStereographic(AzimuthalGridMapping):
     """
 
     grid_mapping_name = "polar_stereographic"
+    proj_id = "ups"
 
     def __init__(
         self,
@@ -1281,11 +1247,6 @@ class PolarStereographic(AzimuthalGridMapping):
         self.scale_factor_at_projection_origin = (
             scale_factor_at_projection_origin
         )
-
-    @property
-    def proj_id(self):
-        """The PROJ projection identifier shorthand name."""
-        return "ups"
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
@@ -1335,6 +1296,7 @@ class RotatedLatitudeLongitude(LatLonGridMapping):
     """
 
     grid_mapping_name = "rotated_latitude_longitude"
+    proj_id = "latlong"
 
     def __init__(
         self,
@@ -1348,11 +1310,6 @@ class RotatedLatitudeLongitude(LatLonGridMapping):
         self.grid_north_pole_latitude = grid_north_pole_latitude
         self.grid_north_pole_longitude = grid_north_pole_longitude
         self.north_pole_grid_longitude = north_pole_grid_longitude
-
-    @property
-    def proj_id(self):
-        """The PROJ projection identifier shorthand name."""
-        return "latlong"
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
@@ -1376,11 +1333,7 @@ class LatitudeLongitude(LatLonGridMapping):
     """
 
     grid_mapping_name = "latitude_longitude"
-
-    @property
-    def proj_id(self):
-        """The PROJ projection identifier shorthand name."""
-        return "latlong"
+    proj_id = "latlong"
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
@@ -1426,6 +1379,7 @@ class Sinusoidal(GridMapping):
     """
 
     grid_mapping_name = "sinusoidal"
+    proj_id = "sinu"
 
     def __init__(
         self,
@@ -1439,11 +1393,6 @@ class Sinusoidal(GridMapping):
         self.longitude_of_projection_origin = longitude_of_projection_origin
         self.false_easting = false_easting
         self.false_northing = false_northing
-
-    @property
-    def proj_id(self):
-        """The PROJ projection identifier shorthand name."""
-        return "sinu"
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
@@ -1501,6 +1450,7 @@ class Stereographic(AzimuthalGridMapping):
     """
 
     grid_mapping_name = "stereographic"
+    proj_id = "stere"
 
     def __init__(
         self,
@@ -1522,11 +1472,6 @@ class Stereographic(AzimuthalGridMapping):
         self.scale_factor_at_projection_origin = (
             scale_factor_at_projection_origin
         )
-
-    @property
-    def proj_id(self):
-        """The PROJ projection identifier shorthand name."""
-        return "stere"
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
@@ -1584,6 +1529,7 @@ class TransverseMercator(CylindricalGridMapping):
     """
 
     grid_mapping_name = "transverse_mercator"
+    proj_id = "tmerc"
 
     def __init__(
         self,
@@ -1601,11 +1547,6 @@ class TransverseMercator(CylindricalGridMapping):
         )
         self.longitude_of_central_meridian = longitude_of_central_meridian
         self.latitude_of_projection_origin = latitude_of_projection_origin
-
-    @property
-    def proj_id(self):
-        """The PROJ projection identifier shorthand name."""
-        return "tmerc"
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""
@@ -1664,11 +1605,7 @@ class VerticalPerspective(PerspectiveGridMapping):
     """
 
     grid_mapping_name = "vertical_perspective"
-
-    @property
-    def proj_id(self):
-        """The PROJ projection identifier shorthand name."""
-        return "nsper"
+    proj_id = "nsper"
 
     def get_proj_string(self):
         """The value of the PROJ proj-string defining the projection."""

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -10,50 +10,61 @@ from .units import Units
 
 
 PROJ_PREFIX = "+proj"
+
+# Grid Mapping valid attribute names. Taken from the list given in
+# 'Table F.1. Grid Mapping Attributes' in Appendix F: Grid Mappings'
+# of the Conventions document.
+#
+# Values indicate if attribute values are expected to be numeric (instead
+# of string) for the given attribute key (the table defines this via N, S).
 ALL_GRID_MAPPING_ATTR_NAMES = {
-    "grid_mapping_name",
+    "grid_mapping_name": False,
     # *Those which describe the ellipsoid and prime meridian:*
-    "earth_radius",  # -------------------- PROJ '+R' value
-    "inverse_flattening",  # -------------- PROJ '+rf' value
-    "longitude_of_prime_meridian",
-    "prime_meridian_name",  # ------------- PROJ '+pm' value
-    "reference_ellipsoid_name",  # -------- PROJ '+ellps' value
-    "semi_major_axis",  # ----------------- PROJ '+a' value
-    "semi_minor_axis",  # ----------------- PROJ '+b' value
+    "earth_radius": True,
+    "inverse_flattening": True,
+    "longitude_of_prime_meridian": True,
+    "prime_meridian_name": False,
+    "reference_ellipsoid_name": False,
+    "semi_major_axis": True,
+    "semi_minor_axis": True,
     # *Specific/applicable to only given grid mapping(s):*
     # ...projection origin related:
-    "longitude_of_projection_origin",  # -- PROJ '+lon_0' value
-    "latitude_of_projection_origin",  # --- PROJ '+lat_0' value
-    "scale_factor_at_projection_origin",  # PROJ '+k_0' value
+    "longitude_of_projection_origin": True,
+    "latitude_of_projection_origin": True,
+    "scale_factor_at_projection_origin": True,
     # ...false-Xings:
-    "false_easting",  # ------------------- PROJ '+x_0' value
-    "false_northing",  # ------------------ PROJ '+y_0' value
+    "false_easting": True,
+    "false_northing": True,
     # ...angle axis related:
-    "sweep_angle_axis",  # ---------------- PROJ '+sweep' value
-    "fixed_angle_axis",
+    "sweep_angle_axis": False,
+    "fixed_angle_axis": False,
     # ...central meridian related:
-    "longitude_of_central_meridian",
-    "scale_factor_at_central_meridian",
+    "longitude_of_central_meridian": True,
+    "scale_factor_at_central_meridian": True,
     # ...pole coordinates related:
-    "grid_north_pole_latitude",
-    "grid_north_pole_longitude",
-    "north_pole_grid_longitude",
+    "grid_north_pole_latitude": True,
+    "grid_north_pole_longitude": True,
+    "north_pole_grid_longitude": True,
     # ...other:
-    "standard_parallel",  # --------------- PROJ ['+lat_1', '+lat_2'] values
-    "perspective_point_height",  # -------- PROJ '+h' value
-    "azimuth_of_central_line",  # --------- PROJ '+alpha' (ignore '+gamma')
-    "straight_vertical_longitude_from_pole",
+    "standard_parallel": True,
+    "perspective_point_height": True,
+    "azimuth_of_central_line": True,
+    "straight_vertical_longitude_from_pole": True,
     # *Other, not needed for a specific grid mapping but also listed
     # in 'Table F.1. Grid Mapping Attributes':*
-    "crs_wkt",  # ------------------------- PROJ 'crs_wkt' value
-    "geographic_crs_name",
-    "geoid_name",
-    "geopotential_datum_name",
-    "horizontal_datum_name",
-    "projected_crs_name",
-    "towgs84",  # ------------------------- PROJ '+towgs84' value
+    "crs_wkt": False,
+    "geographic_crs_name": False,
+    "geoid_name": False,
+    "geopotential_datum_name": False,
+    "horizontal_datum_name": False,
+    "projected_crs_name": False,
+    "towgs84": True,
 }
-GRID_MAPPING_ATTR_TO_PROJ_STRING_COMP = {
+
+# Indicates what PROJ string ID component(s) refer(s) to the grid mapping
+# attribute in question when '+' is added as a suffix, for example
+# 'earth_radius' is '+R' and 'inverse_flattening' is '+rf'
+GRID_MAPPING_ATTR_TO_PROJ_STRING_COMP_VALUES = {
     "earth_radius": "R",
     "inverse_flattening": "rf",
     "prime_meridian_name": "pm",
@@ -68,7 +79,7 @@ GRID_MAPPING_ATTR_TO_PROJ_STRING_COMP = {
     "sweep_angle_axis": "sweep",
     "standard_parallel": ("lat_1", "lat_2"),
     "perspective_point_height": "h",
-    "azimuth_of_central_line": "alpha",
+    "azimuth_of_central_line": ("alpha", "gamma"),
     "crs_wkt": "crs_wkt",
     "towgs84": "towgs84",
 }

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -1,0 +1,442 @@
+ALL_GRID_MAPPING_ATTR_NAMES = {
+        "grid_mapping_name",
+        # *Those which describe the ellipsoid and prime meridian:*
+        "earth_radius",
+        "inverse_flattening",
+        "longitude_of_prime_meridian",
+        "prime_meridian_name",
+        "reference_ellipsoid_name",
+        "semi_major_axis",
+        "semi_minor_axis",
+        # *Specific/applicable to only given grid mapping(s):*
+        # ...projection origin related:
+        "longitude_of_projection_origin",
+        "latitude_of_projection_origin",
+        "scale_factor_at_projection_origin",
+        # ...false-Xings:
+        "false_easting",
+        "false_northing",
+        # ...angle axis related:
+        "sweep_angle_axis",
+        "fixed_angle_axis",
+        # ...central meridian related:
+        "longitude_of_central_meridian",
+        "scale_factor_at_central_meridian",
+        # ...pole coordinates related:
+        "grid_north_pole_latitude",
+        "grid_north_pole_longitude",
+        "north_pole_grid_longitude",
+        # ...other:
+        "standard_parallel",
+        "perspective_point_height",
+        "azimuth_of_central_line",
+        "straight_vertical_longitude_from_pole",
+        # *Other, not needed for a specific grid mapping but also listed
+        # in 'Table F.1. Grid Mapping Attributes':*
+        "crs_wkt",
+        "geographic_crs_name",
+        "geoid_name",
+        "geopotential_datum_name",
+        "horizontal_datum_name",
+        "inverse_flattening",
+        "projected_crs_name",
+        "towgs84",
+    }
+
+
+class GridMapping:
+    """A container for a Grid Mapping recognised by the CF Conventions."""
+
+    def __init__(
+        self,
+        grid_mapping_name,
+        proj_id,
+        earth_radius=None,
+        inverse_flattening=None,
+        longitude_of_prime_meridian=None,
+        prime_meridian_name=None,
+        reference_ellipsoid_name=None,
+        semi_major_axis=None,
+        semi_minor_axis=None,
+    ):
+        """**Initialisation**
+
+        :Parameters:
+
+            grid_mapping_name: string
+                TODO
+
+            proj_id: string
+                TODO
+
+            earth_radius: number, optional
+                TODO
+
+            inverse_flattening: TODO, optional
+                TODO
+
+            longitude_of_prime_meridian: TODO, optional
+                TODO
+
+            prime_meridian_name: TODO, optional
+                TODO
+
+            reference_ellipsoid_name: TODO, optional
+                TODO
+
+            semi_major_axis: TODO, optional
+                TODO
+
+            semi_minor_axis: TODO, optional
+                TODO
+
+        """
+        raise NotImplementedError(
+            "Must define a specific Grid Mapping via setting its CF "
+            "Conventions 'grid_mapping_name' attribute value with the "
+            "grid_mapping_name parameter, as well as the corresponding "
+            "base PROJ '+proj' identifier with the proj_id parameter."
+        )
+
+
+class AlbersEqualArea(GridMapping):
+    """The Albers Equal Area grid mapping.
+
+    See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
+    this grid mapping:
+
+    http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/
+    cf-conventions.html#_albers_equal_area
+
+    or the corresponding PROJ projection page:
+
+    https://proj.org/en/9.2/operations/projections/aea.html
+
+    for more information.
+
+    """
+
+    def __init__(self):
+        super().__init__("albers_conical_equal_area", "aea")
+
+
+class AzimuthalEquidistant(GridMapping):
+    """The Azimuthal Equidistant grid mapping.
+
+    See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
+    this grid mapping:
+
+    http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/
+    cf-conventions.html#azimuthal-equidistant
+
+    or the corresponding PROJ projection page:
+
+    https://proj.org/en/9.2/operations/projections/aeqd.html
+
+    for more information.
+
+    """
+
+    def __init__(self):
+        super().__init__("azimuthal_equidistant", "aeqd")
+
+
+class Geostationary(GridMapping):
+    """The Geostationary Satellite View grid mapping.
+
+    See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
+    this grid mapping:
+
+    http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/
+    cf-conventions.html#_geostationary_projection
+
+    or the corresponding PROJ projection page:
+
+    https://proj.org/en/9.2/operations/projections/geos.html
+
+    for more information.
+
+    """
+
+    def __init__(self):
+        super().__init__("geostationary", "geos")
+
+
+class LambertAzimuthalEqualArea(GridMapping):
+    """The Lambert Azimuthal Equal Area grid mapping.
+
+    See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
+    this grid mapping:
+
+    http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/
+    cf-conventions.html#lambert-azimuthal-equal-area
+
+    or the corresponding PROJ projection page:
+
+    https://proj.org/en/9.2/operations/projections/laea.html
+
+    for more information.
+
+    """
+
+    def __init__(self):
+        super().__init__("lambert_azimuthal_equal_area", "laea")
+
+
+class LambertConformalConic(GridMapping):
+    """The Lambert Conformal Conic grid mapping.
+
+    See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
+    this grid mapping:
+
+    http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/
+    cf-conventions.html#_lambert_conformal
+
+    or the corresponding PROJ projection page:
+
+    https://proj.org/en/9.2/operations/projections/lcc.html
+
+    for more information.
+
+    """
+
+    def __init__(self):
+        super().__init__("lambert_conformal_conic", "lcc")
+
+
+class LambertCylindricalEqualArea(GridMapping):
+    """The Equal Area Cylindrical grid mapping.
+
+    See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
+    this grid mapping:
+
+    http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/
+    cf-conventions.html#_lambert_cylindrical_equal_area
+
+    or the corresponding PROJ projection page:
+
+    https://proj.org/en/9.2/operations/projections/cea.html
+
+    for more information.
+
+    """
+
+    def __init__(self):
+        super().__init__("lambert_cylindrical_equal_area", "cea")
+
+
+class LatitudeLongitude(GridMapping):
+    """The Latitude-Longitude i.e. Plate Carrée grid mapping.
+
+    For alternative names, see e.g:
+
+    https://en.wikipedia.org/wiki/Equirectangular_projection
+
+    See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
+    this grid mapping:
+
+    http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/
+    cf-conventions.html#_latitude_longitude
+
+    or the corresponding PROJ projection page:
+
+    https://proj.org/en/9.2/operations/projections/eqc.html
+
+    for more information.
+
+    """
+
+    def __init__(self):
+        super().__init__("latitude_longitude", "eqc")
+
+
+class Mercator(GridMapping):
+    """The Mercator grid mapping.
+
+    See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
+    this grid mapping:
+
+    http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/
+    cf-conventions.html#_mercator
+
+    or the corresponding PROJ projection page:
+
+    https://proj.org/en/9.2/operations/projections/merc.html
+
+    for more information.
+
+    """
+
+    def __init__(self):
+        super().__init__("mercator", "merc")
+
+
+class ObliqueMercator(GridMapping):
+    """The Oblique Mercator grid mapping.
+
+    See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
+    this grid mapping:
+
+    http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/
+    cf-conventions.html#_oblique_mercator
+
+    or the corresponding PROJ projection page:
+
+    https://proj.org/en/9.2/operations/projections/omerc.html
+
+    for more information.
+
+    """
+
+    def __init__(self):
+        super().__init__("oblique_mercator", "omerc")
+
+
+class Orthographic(GridMapping):
+    """The Orthographic grid mapping.
+
+    See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
+    this grid mapping:
+
+    http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/
+    cf-conventions.html#_orthographic
+
+    or the corresponding PROJ projection page:
+
+    https://proj.org/en/9.2/operations/projections/ortho.html
+
+    for more information.
+
+    """
+
+    def __init__(self):
+        super().__init__("orthographic", "ortho")
+
+
+class PolarStereographic(GridMapping):
+    """The Universal Polar Stereographic grid mapping.
+
+    See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
+    this grid mapping:
+
+    http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/
+    cf-conventions.html#polar-stereographic
+
+    or the corresponding PROJ projection page:
+
+    https://proj.org/en/9.2/operations/projections/ups.html
+
+    for more information.
+
+    """
+
+    def __init__(self):
+        super().__init__("polar_stereographic", "ups")
+
+
+class RotatedLatitudeLongitude(GridMapping):
+    """The Rotated Latitude-Longitude grid mapping.
+
+    See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
+    this grid mapping:
+
+    http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/
+    cf-conventions.html#_rotated_pole
+
+    or the corresponding PROJ projection page:
+
+    https://proj.org/en/9.2/operations/projections/eqc.html
+
+    for more information.
+
+    Note: this grid mapping relates to the Latitude-Longitude i.e. Plate
+    Carrée grid mapping in that it... TODO.
+
+    """
+
+    def __init__(self):
+        super().__init__("rotated_latitude_longitude", "eqc")
+
+
+class Sinusoidal(GridMapping):
+    """The Sinusoidal (Sanson-Flamsteed) grid mapping.
+
+    See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
+    this grid mapping:
+
+    http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/
+    cf-conventions.html#_sinusoidal
+
+    or the corresponding PROJ projection page:
+
+    https://proj.org/en/9.2/operations/projections/sinu.html
+
+    for more information.
+
+    """
+
+    def __init__(self):
+        super().__init__("sinusoidal", "sinu")
+
+
+class Stereographic(GridMapping):
+    """The Stereographic grid mapping.
+
+    See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
+    this grid mapping:
+
+    http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/
+    cf-conventions.html#_stereographic
+
+    or the corresponding PROJ projection page:
+
+    https://proj.org/en/9.2/operations/projections/stere.html
+
+    for more information.
+
+    """
+
+    def __init__(self):
+        super().__init__("stereographic", "stere")
+
+
+class TransverseMercator(GridMapping):
+    """The Transverse Mercator grid mapping.
+
+    See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
+    this grid mapping:
+
+    http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/
+    cf-conventions.html#_transverse_mercator
+
+    or the corresponding PROJ projection page:
+
+    https://proj.org/en/9.2/operations/projections/tmerc.html
+
+    for more information.
+
+    """
+
+    def __init__(self):
+        super().__init__("transverse_mercator", "tmerc")
+
+
+class VerticalPerspective(GridMapping):
+    """The Vertical (or Near-sided) Perspective grid mapping.
+
+    See the CF Conventions document 'Appendix F: Grid Mappings' sub-section on
+    this grid mapping:
+
+    http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/
+    cf-conventions.html#vertical-perspective
+
+    or the corresponding PROJ projection page:
+
+    https://proj.org/en/9.2/operations/projections/nsper.html
+
+    for more information.
+
+    """
+
+    def __init__(self):
+        super().__init__("vertical_perspective", "nsper")

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -218,11 +218,18 @@ class ConicGridMapping(GridMapping):
             units of decimal degrees, where forming a string by adding
             a suffix character can indicates alternative units of
             radians if the suffix is 'R' or 'r'. If a string, a suffix
-            of 'd', 'D' or '°' confirm units of decimal degrees. The default
-            for both values is 0.0 decimal degrees.
+            of 'd', 'D' or '°' confirm units of decimal degrees.
 
-        longitude_of_central_meridian: TODO
-            TODO
+            The default is (0.0, 0.0), that is 0.0 decimal degrees
+            for the first and second standard parallel values.
+
+        longitude_of_central_meridian: number or `str`, optional
+            The longitude of (natural) origin i.e. central meridian, in
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            is 0.0 decimal degrees.
 
         latitude_of_projection_origin: number or `str`, optional
             The latitude of projection center (PROJ 'lat_0' value), in
@@ -244,9 +251,9 @@ class ConicGridMapping(GridMapping):
 
     def __init__(
         self,
-        standard_parallel,
-        longitude_of_central_meridian,
-        latitude_of_projection_origin,
+        standard_parallel=(0.0, 0.0),
+        longitude_of_central_meridian=0.0,
+        latitude_of_projection_origin=0.0,
         false_easting=0.0,
         false_northing=0.0,
         *args,
@@ -369,8 +376,13 @@ class AlbersEqualArea(ConicGridMapping):
             The default is (0.0, 0.0), that is 0.0 decimal degrees
             for the first and second standard parallel values.
 
-        longitude_of_central_meridian: TODO
-            TODO
+        longitude_of_central_meridian: number or `str`, optional
+            The longitude of (natural) origin i.e. central meridian, in
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            is 0.0 decimal degrees.
 
         latitude_of_projection_origin: number or `str`, optional
             The latitude of projection center (PROJ 'lat_0' value), in
@@ -392,7 +404,7 @@ class AlbersEqualArea(ConicGridMapping):
 
     def __init__(
         self,
-        longitude_of_central_meridian,
+        longitude_of_central_meridian=0.0,
         standard_parallel=(0.0, 0.0),
         latitude_of_projection_origin=0.0,
         false_easting=0.0,
@@ -645,8 +657,10 @@ class LambertConformalConic(ConicGridMapping):
             units of decimal degrees, where forming a string by adding
             a suffix character can indicates alternative units of
             radians if the suffix is 'R' or 'r'. If a string, a suffix
-            of 'd', 'D' or '°' confirm units of decimal degrees. The default
-            for both values is 0.0 decimal degrees.
+            of 'd', 'D' or '°' confirm units of decimal degrees.
+
+            The default is (0.0, 0.0), that is 0.0 decimal degrees
+            for the first and second standard parallel values.
 
         longitude_of_projection_origin: number or `str`, optional
             The longitude of projection center (PROJ 'lon_0' value), in
@@ -723,11 +737,18 @@ class LambertCylindricalEqualArea(CylindricalGridMapping):
             units of decimal degrees, where forming a string by adding
             a suffix character can indicates alternative units of
             radians if the suffix is 'R' or 'r'. If a string, a suffix
-            of 'd', 'D' or '°' confirm units of decimal degrees. The default
-            for both values is 0.0 decimal degrees.
+            of 'd', 'D' or '°' confirm units of decimal degrees.
 
-        longitude_of_central_meridian: TODO
-            TODO
+            The default is (0.0, 0.0), that is 0.0 decimal degrees
+            for the first and second standard parallel values.
+
+        longitude_of_central_meridian: number or `str`, optional
+            The longitude of (natural) origin i.e. central meridian, in
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            is 0.0 decimal degrees.
 
         scale_factor_at_projection_origin: number, optional
             The scale factor at natural origin (PROJ 'k_0' value). It
@@ -737,7 +758,7 @@ class LambertCylindricalEqualArea(CylindricalGridMapping):
 
     def __init__(
         self,
-        longitude_of_central_meridian,
+        longitude_of_central_meridian=0.0,
         standard_parallel=(0.0, 0.0),
         false_easting=0.0,
         false_northing=0.0,
@@ -792,8 +813,10 @@ class Mercator(CylindricalGridMapping):
             units of decimal degrees, where forming a string by adding
             a suffix character can indicates alternative units of
             radians if the suffix is 'R' or 'r'. If a string, a suffix
-            of 'd', 'D' or '°' confirm units of decimal degrees. The default
-            for both values is 0.0 decimal degrees.
+            of 'd', 'D' or '°' confirm units of decimal degrees.
+
+            The default is (0.0, 0.0), that is 0.0 decimal degrees
+            for the first and second standard parallel values.
 
         longitude_of_projection_origin: number or `str`, optional
             The longitude of projection center (PROJ 'lon_0' value), in
@@ -1017,8 +1040,10 @@ class PolarStereographic(AzimuthalGridMapping):
             units of decimal degrees, where forming a string by adding
             a suffix character can indicates alternative units of
             radians if the suffix is 'R' or 'r'. If a string, a suffix
-            of 'd', 'D' or '°' confirm units of decimal degrees. The default
-            for both values is 0.0 decimal degrees.
+            of 'd', 'D' or '°' confirm units of decimal degrees.
+
+            The default is (0.0, 0.0), that is 0.0 decimal degrees
+            for the first and second standard parallel values.
 
     """
 
@@ -1275,8 +1300,13 @@ class TransverseMercator(CylindricalGridMapping):
         scale_factor_at_central_meridian: TODO
             TODO
 
-        longitude_of_central_meridian: TODO
-            TODO
+        longitude_of_central_meridian: number or `str`, optional
+            The longitude of (natural) origin i.e. central meridian, in
+            units of decimal degrees, where forming a string by adding
+            a suffix character can indicates alternative units of
+            radians if the suffix is 'R' or 'r'. If a string, a suffix
+            of 'd', 'D' or '°' confirm units of decimal degrees. The default
+            is 0.0 decimal degrees.
 
         latitude_of_projection_origin: number or `str`, optional
             The latitude of projection center (PROJ 'lat_0' value), in
@@ -1291,7 +1321,7 @@ class TransverseMercator(CylindricalGridMapping):
     def __init__(
         self,
         scale_factor_at_central_meridian,
-        longitude_of_central_meridian,
+        longitude_of_central_meridian=0.0,
         latitude_of_projection_origin=0.0,
         false_easting=0.0,
         false_northing=0.0,

--- a/cf/gridmappings.py
+++ b/cf/gridmappings.py
@@ -172,12 +172,20 @@ def _convert_units_proj_to_cf(proj_val_with_units, context=None):
         else:
             value, *float_comp = comps
 
-        print("%%%%%%%", value, float_comp, suffix)
+        # Convert string value to relevant numeric form
+        if float_comp:
+            numeric_value = float(value)
+        else:
+            numeric_value = int(value)
 
         if suffix in ("r", "R"):  # radians units
-            cf_units = "radians"
-            # Convert to decimal so we can store the degree_X form from context:
-            # TODO
+            if context:
+                # Convert so we can store the degree_X form of the lat/lon context:
+                numeric_value = Units.conform(
+                    numeric_value, Units("radians"), Units("degrees"))
+            else:  # if no lat/lon context, leave as radians to avoid rounding etc.
+                cf_units = "radians"
+
         elif suffix and suffix not in ("d", "D", "°"):  # 'decimal degrees' units
             cf_compatible = False
     else:
@@ -188,12 +196,6 @@ def _convert_units_proj_to_cf(proj_val_with_units, context=None):
             f"Input PROJ input not valid: {proj_val_with_units}. "
             "Ensure valid PROJ units are supplied."
         )
-
-    # Convert string value to relevant numeric form
-    if float_comp:
-        numeric_value = float(value)
-    else:
-        numeric_value = int(value)
 
     return Data(numeric_value, Units(cf_units))
 

--- a/cf/test/test_Domain.py
+++ b/cf/test/test_Domain.py
@@ -295,6 +295,13 @@ class DomainTest(unittest.TestCase):
     def test_Domain_size(self):
         self.assertEqual(self.d.size, 90)
 
+    def test_Domain_get_grid_mappings(self):
+        self.assertEqual(
+            self.d.get_grid_mappings(), {
+                'coordinatereference1': 'rotated_latitude_longitude'
+            }
+        )
+
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())

--- a/cf/test/test_Domain.py
+++ b/cf/test/test_Domain.py
@@ -301,6 +301,11 @@ class DomainTest(unittest.TestCase):
                 'coordinatereference1': 'rotated_latitude_longitude'
             }
         )
+        self.assertEqual(
+            self.d.get_grid_mappings(as_class=True), {
+                'coordinatereference1': cf.RotatedLatitudeLongitude
+            }
+        )
 
 
 if __name__ == "__main__":

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -2614,6 +2614,19 @@ class FieldTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             f.auxiliary_to_dimension("latitude")
 
+    def test_Field_get_grid_mappings(self):
+        self.assertEqual(
+            self.f.get_grid_mappings(),
+            {'coordinatereference1': 'rotated_latitude_longitude'}
+        )
+        self.assertEqual(
+            self.f0.get_grid_mappings(), {}
+        )
+        self.assertEqual(
+            self.f1.get_grid_mappings(),
+            {'coordinatereference1': 'rotated_latitude_longitude'}
+        )
+
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -2620,11 +2620,14 @@ class FieldTest(unittest.TestCase):
             {'coordinatereference1': 'rotated_latitude_longitude'}
         )
         self.assertEqual(
+            self.f.get_grid_mappings(as_class=True),
+            {'coordinatereference1': cf.RotatedLatitudeLongitude}
+        )
+        self.assertEqual(
             self.f0.get_grid_mappings(), {}
         )
         self.assertEqual(
-            self.f1.get_grid_mappings(),
-            {'coordinatereference1': 'rotated_latitude_longitude'}
+            self.f0.get_grid_mappings(as_class=True), {}
         )
 
 

--- a/cf/test/test_gridmappings.py
+++ b/cf/test/test_gridmappings.py
@@ -126,6 +126,18 @@ class GridMappingsTest(unittest.TestCase):
                 (("45.0", None), cf.Data(45.0, units="degrees")),
                 (("45.0", "lat"), cf.Data(45.0, units="degrees_north")),
                 (("45.0", "lon"), cf.Data(45.0, units="degrees_east")),
+                # Check integer and no suffix
+                (("100", None), cf.Data(100, units="degrees")),
+                (("100", "lat"), cf.Data(100, units="degrees_north")),
+                (("100", "lon"), cf.Data(100, units="degrees_east")),
+                # Check "R" suffix
+                ((f"{0.5 * np.pi}R", None), cf.Data(0.5 * np.pi, units="radians")),
+                ((f"{0.5 * np.pi}R", "lat"), cf.Data(90.0, units="degrees_north")),
+                ((f"{0.5 * np.pi}R", "lon"), cf.Data(90.0, units="degrees_east")),
+                # Check >360 degrees (over a full revolution) and  "r" suffix
+                ((f"{3.0 * np.pi}r", None), cf.Data(3.0 * np.pi, units="radians")),
+                ((f"{3.0 * np.pi}r", "lat"), cf.Data(540.0, units="degrees_north")),
+                ((f"{3.0 * np.pi}r", "lon"), cf.Data(540.0, units="degrees_east")),
                 # Check integer value and "d" suffix
                 (("10d", None), cf.Data(10, units="degrees")),
                 (("10d", "lat"), cf.Data(10, units="degrees_north")),
@@ -134,22 +146,13 @@ class GridMappingsTest(unittest.TestCase):
                 (("200.123D", None), cf.Data(200.123, units="degrees")),
                 (("200.123D", "lat"), cf.Data(200.123, units="degrees_north")),
                 (("200.123D", "lon"), cf.Data(200.123, units="degrees_east")),
-                # Check "R" suffix
-                ((f"{0.5 * np.pi}R", None), cf.Data(0.5 * np.pi, units="radians")),
-                ((f"{0.5 * np.pi}R", "lat"), cf.Data(90.0, units="degrees_north")),
-                ((f"{0.5 * np.pi}R", "lon"), cf.Data(90.0, units="degrees_east")),
-                # Check >360 degrees (full revolution) and  "r" suffix
-                ((f"{3.0 * np.pi}r", None), cf.Data(3.0 * np.pi, units="radians")),
-                ((f"{3.0 * np.pi}r", "lat"), cf.Data(540.0, units="degrees_north")),
-                ((f"{3.0 * np.pi}r", "lon"), cf.Data(540.0, units="degrees_east")),
+                # Check negative numeric value and "°" suffix
+                (("-70.5°", None), cf.Data(-70.5, units="degrees")),
+                (("-70.5°", "lat"), cf.Data(-70.5, units="degrees_north")),
+                (("-70.5°", "lon"), cf.Data(-70.5, units="degrees_east")),
                 ]:
             _input, correct_output = input_with_correct_output
-            proj_arg, context_arg = _input
-            print("ARGS OF:", _input, correct_output, proj_arg, context_arg)
-            d = cf._convert_units_proj_to_cf(proj_arg, context_arg)
-            print("EXPECT:", correct_output)
-            print("GET:", d)
-            print()
+            d = cf._convert_units_proj_to_cf(*_input)
             self.assertTrue(d.equals(correct_output, verbose=2))
 
 if __name__ == "__main__":

--- a/cf/test/test_gridmappings.py
+++ b/cf/test/test_gridmappings.py
@@ -145,6 +145,31 @@ class GridMappingsTest(unittest.TestCase):
         )
 
     @unittest.skipUnless(pyproj_imported, "Requires pyproj package.")
+    def test_grid_mapping_map_parameter_validation(self):
+        """Test the validation of map parameters to Grid Mapping classes."""
+        g1 = cf.Mercator(
+            false_easting=10.0,
+            false_northing=cf.Data(-20, units="m"),
+            standard_parallel=(None, 50),
+            longitude_of_projection_origin=-40.0,
+            scale_factor_at_projection_origin=3.0,
+            prime_meridian_name="brussels",
+        )
+        self.assertEqual(g1.false_easting, cf.Data(10.0, "m"))
+        self.assertEqual(g1.false_northing, cf.Data(-20, "m"))
+        self.assertEqual(
+            g1.standard_parallel, (None, cf.Data(50, "degrees_north"))
+        )
+        self.assertEqual(
+            g1.longitude_of_projection_origin, cf.Data(-40.0, "degrees_east")
+        )
+        self.assertEqual(g1.scale_factor_at_projection_origin, cf.Data(3.0, 1))
+        self.assertEqual(g1.prime_meridian_name, "brussels")
+
+        # TODOGM extend this test a lot with testing like the above and
+        # with systematic coverage over valid inputs
+
+    @unittest.skipUnless(pyproj_imported, "Requires pyproj package.")
     def test_grid_mapping__get_cf_grid_mapping_from_name(self):
         """Test the '_get_cf_grid_mapping_from_name' function."""
         for gm_name, cf_gm_class in {

--- a/cf/test/test_gridmappings.py
+++ b/cf/test/test_gridmappings.py
@@ -19,10 +19,10 @@ except ImportError:
 
 # These are those of the above which have required positional arguments
 all_concrete_grid_mappings_req_args = {
-    "AlbersEqualArea": {"standard_parallel": 0.0},
+    "AlbersEqualArea": {"standard_parallel": (0.0, None)},
     "Geostationary": {"perspective_point_height": 1000},
     "VerticalPerspective": {"perspective_point_height": 1000},
-    "LambertConformalConic": {"standard_parallel": 0.0},
+    "LambertConformalConic": {"standard_parallel": (1.0, 1.0)},
     "RotatedLatitudeLongitude": {
         "grid_north_pole_latitude": 0.0,
         "grid_north_pole_longitude": 0.0,
@@ -118,7 +118,7 @@ class GridMappingsTest(unittest.TestCase):
                 example_minimal_args = all_concrete_grid_mappings_req_args[
                     cls.__name__
                 ]
-                g = cls(*example_minimal_args)
+                g = cls(**example_minimal_args)
             repr(g)
             str(g)
 

--- a/cf/test/test_gridmappings.py
+++ b/cf/test/test_gridmappings.py
@@ -109,12 +109,9 @@ class GridMappingsTest(unittest.TestCase):
     def test_grid_mapping_find_gm_class(self):
         """TODO."""
         for f in self.f_with_gm:
-            crefs = f.coordinate_references().values()
-            for cref in crefs:
-                gm = cref.coordinate_conversion.get_parameter(
-                    "grid_mapping_name", default=None
-                )
-                # TODO test that matches with GM class
+            gms = f.domain.get_grid_mappings()
+            print(gms)
+            # TODO test that matches with GM class
 
 
 if __name__ == "__main__":

--- a/cf/test/test_gridmappings.py
+++ b/cf/test/test_gridmappings.py
@@ -176,8 +176,25 @@ class GridMappingsTest(unittest.TestCase):
             (cf.Data(45, units="degreeE"), "45"),
         ]:
             _input, correct_output = input_with_correct_output
-            d = cf.convert_cf_angular_data_to_proj(_input)
-            self.assertEqual(d, correct_output)
+            p = cf.convert_cf_angular_data_to_proj(_input)
+            self.assertEqual(p, correct_output)
+
+        # Note that 'convert_cf_angular_data_to_proj' and
+        # 'convert_proj_angular_data_to_cf' are not strict inverse
+        # functions, since the former will convert to the *simplest*
+        # way to specify the PROJ input, namely with no suffix for
+        # degrees(_X) units and the 'R' suffix for radians, whereas
+        # the input might have 'D' or 'r' etc. instead.
+        #
+        # However, we check that inputs that are expected to be
+        # undone to their original form by operation of both
+        # functions, namely those with this 'simplest' PROJ form,
+        # do indeed get re-generated with operation of both:
+        for p in ("10", "-10", "0", "1R", "0.2R", "0.1R"):
+            p2 = cf.convert_cf_angular_data_to_proj(
+                cf.convert_proj_angular_data_to_cf(p)
+            )
+            self.assertEqual(p, p2)
 
 
 if __name__ == "__main__":

--- a/cf/test/test_gridmappings.py
+++ b/cf/test/test_gridmappings.py
@@ -2,11 +2,11 @@ import datetime
 import faulthandler
 import unittest
 
-# import numpy as np
-
-faulthandler.enable()  # to debug seg faults and timeouts
+import numpy as np
 
 import cf
+
+faulthandler.enable()  # to debug seg faults and timeouts
 
 pyproj_imported = False
 try:
@@ -119,6 +119,38 @@ class GridMappingsTest(unittest.TestCase):
                 cf._get_cf_grid_mapping_from_name(gm_name), cf_gm_class
             )
 
+    def test_grid_mapping__convert_units_proj_to_cf(self):
+        """TODO."""
+        for input_with_correct_output in [
+                # Check float value and no suffix
+                (("45.0", None), cf.Data(45.0, units="degrees")),
+                (("45.0", "lat"), cf.Data(45.0, units="degrees_north")),
+                (("45.0", "lon"), cf.Data(45.0, units="degrees_east")),
+                # Check integer value and "d" suffix
+                (("10d", None), cf.Data(10, units="degrees")),
+                (("10d", "lat"), cf.Data(10, units="degrees_north")),
+                (("10d", "lon"), cf.Data(10, units="degrees_east")),
+                # Check >180 float and "D" suffix
+                (("200.123D", None), cf.Data(200.123, units="degrees")),
+                (("200.123D", "lat"), cf.Data(200.123, units="degrees_north")),
+                (("200.123D", "lon"), cf.Data(200.123, units="degrees_east")),
+                # Check "R" suffix
+                ((f"{0.5 * np.pi}R", None), cf.Data(90, units="degrees")),
+                ((f"{0.5 * np.pi}R", "lat"), cf.Data(90, units="degrees_north")),
+                ((f"{0.5 * np.pi}R", "lon"), cf.Data(90, units="degrees_east")),
+                # Check >360 degrees (full revolution) and  "r" suffix
+                ((f"{3.0 * np.pi}r", None), cf.Data(180, units="degrees")),
+                ((f"{3.0 * np.pi}r", "lat"), cf.Data(180, units="degrees_north")),
+                ((f"{3.0 * np.pi}r", "lon"), cf.Data(180, units="degrees_east")),
+                ]:
+            _input, correct_output = input_with_correct_output
+            proj_arg, context_arg = _input
+            #print("ARGS OF:", _input, correct_output, proj_arg, context_arg)
+            d = cf._convert_units_proj_to_cf(proj_arg, context_arg)
+            #print("EXPECT:", correct_output)
+            #print("GET:", d)
+            #print()
+            self.assertTrue(d.equals(correct_output, verbose=2))
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())

--- a/cf/test/test_gridmappings.py
+++ b/cf/test/test_gridmappings.py
@@ -50,10 +50,11 @@ class GridMappingsTest(unittest.TestCase):
         "f7": cf.RotatedLatitudeLongitude,
     }
 
+    # TODO: ignore the below for now, in short will create a new test file
+    # with a Oblique Mercator GM
+    #
     # From a custom netCDF file with Oblique Mercator GM
-    # TODO generate this .nc via create_test_files.py and un-commit
-    # forced commit of the (data-free / header-only) netCDF file.
-    f_om = cf.read("oblique_mercator.nc")
+    # f_om = cf.read("oblique_mercator.nc")
 
     # Create some coordinate references with different GMs to test on:
     cr_aea = cf.CoordinateReference(

--- a/cf/test/test_gridmappings.py
+++ b/cf/test/test_gridmappings.py
@@ -31,12 +31,14 @@ all_concrete_grid_mappings_req_args = {
 
 
 class GridMappingsTest(unittest.TestCase):
-    """TODO."""
+    """Unit test for the GridMapping class and any derived classes."""
 
     # Of the example fields, only 1, 6 and 7 have any coordinate references
     # with a coordinate conversion, hence use these to test, plus 0 as an
     # example case of a field without a coordinate reference at all.
     f = cf.example_fields()
+    # TODOGM, could do with a new example field or two with a grid mapping
+    # other than those two below, for diversity and testing on etc.
     f0 = f[0]  # No coordinate reference
     f1 = f[1]  # 2, with grid mappings of [None, 'rotated_latitude_longitude']
     f6 = f[6]  # 1, with grid mapping of ['latitude_longitude']
@@ -94,7 +96,7 @@ class GridMappingsTest(unittest.TestCase):
 
     # @unittest.skipUnless(pyproj_imported, "Requires pyproj package.")
     def test_grid_mapping__repr__str__(self):
-        """TODO."""
+        """Test all means of GridMapping inspection.."""
         for cls in cf._all_concrete_grid_mappings:
             if cls.__name__ not in all_concrete_grid_mappings_req_args:
                 g = cls()
@@ -107,7 +109,7 @@ class GridMappingsTest(unittest.TestCase):
             str(g)
 
     def test_grid_mapping__get_cf_grid_mapping_from_name(self):
-        """TODO."""
+        """Test the '_get_cf_grid_mapping_from_name' function."""
         for gm_name, cf_gm_class in {
             "vertical_perspective": cf.VerticalPerspective,
             "oblique_mercator": cf.ObliqueMercator,

--- a/cf/test/test_gridmappings.py
+++ b/cf/test/test_gridmappings.py
@@ -94,9 +94,23 @@ class GridMappingsTest(unittest.TestCase):
         "+units=m +no_defs"
     )
 
-    # @unittest.skipUnless(pyproj_imported, "Requires pyproj package.")
+    @unittest.skipUnless(pyproj_imported, "Requires pyproj package.")
+    def test_grid_mapping__init__(self):
+        """Test GridMapping object initiation."""
+        for cls in cf._all_concrete_grid_mappings:
+            if cls.__name__ not in all_concrete_grid_mappings_req_args:
+                cls()
+
+        # Shouldn't be able to instantiate any abstract classes, since
+        # abstract methods grid_mapping_name and proj_id must be defined
+        # further down in the inheritance chain to enable concrete classes.
+        for cls in cf._all_abstract_grid_mappings:
+            with self.assertRaises(TypeError):
+                cls()
+
+    @unittest.skipUnless(pyproj_imported, "Requires pyproj package.")
     def test_grid_mapping__repr__str__(self):
-        """Test all means of GridMapping inspection.."""
+        """Test all means of GridMapping inspection."""
         for cls in cf._all_concrete_grid_mappings:
             if cls.__name__ not in all_concrete_grid_mappings_req_args:
                 g = cls()
@@ -108,6 +122,29 @@ class GridMappingsTest(unittest.TestCase):
             repr(g)
             str(g)
 
+        g1 = cf.Mercator()
+        self.assertEqual(repr(g1), "<CF CylindricalGridMapping: Mercator>")
+        self.assertEqual(
+            str(g1), "<CF CylindricalGridMapping: Mercator +proj=merc>"
+        )
+
+        g2 = cf.Orthographic()
+        self.assertEqual(repr(g2), "<CF AzimuthalGridMapping: Orthographic>")
+        self.assertEqual(
+            str(g2), "<CF AzimuthalGridMapping: Orthographic +proj=ortho>"
+        )
+
+        g3 = cf.Sinusoidal()
+        self.assertEqual(repr(g3), "<CF GridMapping: Sinusoidal>")
+        self.assertEqual(str(g3), "<CF GridMapping: Sinusoidal +proj=sinu>")
+
+        g4 = cf.Stereographic()
+        self.assertEqual(repr(g4), "<CF AzimuthalGridMapping: Stereographic>")
+        self.assertEqual(
+            str(g4), "<CF AzimuthalGridMapping: Stereographic +proj=stere>"
+        )
+
+    @unittest.skipUnless(pyproj_imported, "Requires pyproj package.")
     def test_grid_mapping__get_cf_grid_mapping_from_name(self):
         """Test the '_get_cf_grid_mapping_from_name' function."""
         for gm_name, cf_gm_class in {
@@ -201,7 +238,7 @@ class GridMappingsTest(unittest.TestCase):
             cf.Data([1, 2, 3]),  # not singular (size 1)
             cf.Data(45),  # no units
             cf.Data(45, "m"),  # non-angular units
-            cf.Data(2, "elephants")  # bad/non-CF units
+            cf.Data(2, "elephants"),  # bad/non-CF units
         ]:
             with self.assertRaises(ValueError):
                 cf.convert_cf_angular_data_to_proj(bad_input)
@@ -230,7 +267,6 @@ class GridMappingsTest(unittest.TestCase):
             # be re-generated since degrees_X gets converted back to the
             # default degrees, so skip those in these test cases.
             if not p.endswith("R"):
-                a = cf.convert_proj_angular_data_to_cf(p, context="lat")
                 p3 = cf.convert_cf_angular_data_to_proj(
                     cf.convert_proj_angular_data_to_cf(p, context="lat")
                 )

--- a/cf/test/test_gridmappings.py
+++ b/cf/test/test_gridmappings.py
@@ -119,41 +119,66 @@ class GridMappingsTest(unittest.TestCase):
                 cf._get_cf_grid_mapping_from_name(gm_name), cf_gm_class
             )
 
-    def test_grid_mapping__convert_units_proj_to_cf(self):
-        """TODO."""
+    def test_grid_mapping_convert_proj_angular_data_to_cf(self):
+        """Test the 'convert_proj_angular_data_to_cf' function."""
         for input_with_correct_output in [
-                # Check float value and no suffix
-                (("45.0", None), cf.Data(45.0, units="degrees")),
-                (("45.0", "lat"), cf.Data(45.0, units="degrees_north")),
-                (("45.0", "lon"), cf.Data(45.0, units="degrees_east")),
-                # Check integer and no suffix
-                (("100", None), cf.Data(100, units="degrees")),
-                (("100", "lat"), cf.Data(100, units="degrees_north")),
-                (("100", "lon"), cf.Data(100, units="degrees_east")),
-                # Check "R" suffix
-                ((f"{0.5 * np.pi}R", None), cf.Data(0.5 * np.pi, units="radians")),
-                ((f"{0.5 * np.pi}R", "lat"), cf.Data(90.0, units="degrees_north")),
-                ((f"{0.5 * np.pi}R", "lon"), cf.Data(90.0, units="degrees_east")),
-                # Check >360 degrees (over a full revolution) and  "r" suffix
-                ((f"{3.0 * np.pi}r", None), cf.Data(3.0 * np.pi, units="radians")),
-                ((f"{3.0 * np.pi}r", "lat"), cf.Data(540.0, units="degrees_north")),
-                ((f"{3.0 * np.pi}r", "lon"), cf.Data(540.0, units="degrees_east")),
-                # Check integer value and "d" suffix
-                (("10d", None), cf.Data(10, units="degrees")),
-                (("10d", "lat"), cf.Data(10, units="degrees_north")),
-                (("10d", "lon"), cf.Data(10, units="degrees_east")),
-                # Check >180 float and "D" suffix
-                (("200.123D", None), cf.Data(200.123, units="degrees")),
-                (("200.123D", "lat"), cf.Data(200.123, units="degrees_north")),
-                (("200.123D", "lon"), cf.Data(200.123, units="degrees_east")),
-                # Check negative numeric value and "°" suffix
-                (("-70.5°", None), cf.Data(-70.5, units="degrees")),
-                (("-70.5°", "lat"), cf.Data(-70.5, units="degrees_north")),
-                (("-70.5°", "lon"), cf.Data(-70.5, units="degrees_east")),
-                ]:
+            # Check float value and no suffix
+            (("45.0", None), cf.Data(45.0, units="degrees")),
+            (("45.0", "lat"), cf.Data(45.0, units="degrees_north")),
+            (("45.0", "lon"), cf.Data(45.0, units="degrees_east")),
+            # Check integer and no suffix
+            (("100", None), cf.Data(100, units="degrees")),
+            (("100", "lat"), cf.Data(100, units="degrees_north")),
+            (("100", "lon"), cf.Data(100, units="degrees_east")),
+            # Check >360 degrees (over a full revolution) and  "r" suffix
+            ((f"{3.0 * np.pi}r", None), cf.Data(3.0 * np.pi, units="radians")),
+            (
+                (f"{3.0 * np.pi}r", "lat"),
+                cf.Data(540.0, units="degrees_north"),
+            ),
+            ((f"{3.0 * np.pi}r", "lon"), cf.Data(540.0, units="degrees_east")),
+            # Check "R" suffix
+            ((f"{0.5 * np.pi}R", None), cf.Data(0.5 * np.pi, units="radians")),
+            ((f"{0.5 * np.pi}R", "lat"), cf.Data(90.0, units="degrees_north")),
+            ((f"{0.5 * np.pi}R", "lon"), cf.Data(90.0, units="degrees_east")),
+            # Check integer value and "d" suffix
+            (("10d", None), cf.Data(10, units="degrees")),
+            (("10d", "lat"), cf.Data(10, units="degrees_north")),
+            (("10d", "lon"), cf.Data(10, units="degrees_east")),
+            # Check >180 float and "D" suffix
+            (("200.123D", None), cf.Data(200.123, units="degrees")),
+            (("200.123D", "lat"), cf.Data(200.123, units="degrees_north")),
+            (("200.123D", "lon"), cf.Data(200.123, units="degrees_east")),
+            # Check negative numeric value and "°" suffix
+            (("-70.5°", None), cf.Data(-70.5, units="degrees")),
+            (("-70.5°", "lat"), cf.Data(-70.5, units="degrees_north")),
+            (("-70.5°", "lon"), cf.Data(-70.5, units="degrees_east")),
+            # Check zero and lack of digits after point edge cases
+            (("0", None), cf.Data(0, units="degrees")),
+            (("0.0", "lat"), cf.Data(0.0, units="degrees_north")),
+            (("-0.", "lon"), cf.Data(0.0, units="degrees_east")),
+        ]:
             _input, correct_output = input_with_correct_output
             d = cf.convert_proj_angular_data_to_cf(*_input)
             self.assertTrue(d.equals(correct_output, verbose=2))
+
+    def test_grid_mapping_convert_cf_angular_data_to_proj(self):
+        """Test the 'convert_cf_angular_data_to_proj' function."""
+        for input_with_correct_output in [
+            # Check float and basic lat/lon-context free degree unit
+            (cf.Data(45.0, units="degrees"), "45.0"),
+            # Check integer and various units possible for lat/lon
+            (cf.Data(45, units="degrees_north"), "45"),
+            (cf.Data(45, units="degrees_N"), "45"),
+            (cf.Data(45, units="degreeN"), "45"),
+            (cf.Data(45, units="degrees_east"), "45"),
+            (cf.Data(45, units="degrees_E"), "45"),
+            (cf.Data(45, units="degreeE"), "45"),
+        ]:
+            _input, correct_output = input_with_correct_output
+            d = cf.convert_cf_angular_data_to_proj(_input)
+            self.assertEqual(d, correct_output)
+
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())

--- a/cf/test/test_gridmappings.py
+++ b/cf/test/test_gridmappings.py
@@ -60,7 +60,7 @@ class GridMappingsTest(unittest.TestCase):
             parameters={
                 "grid_mapping_name": "albers_conical_equal_area",
                 "standard_parallel": [10, 10],
-                "longitude_of_projection_origin":45.0,
+                "longitude_of_projection_origin": 45.0,
                 "false_easting": -1000,
                 "false_northing": 500,
             }
@@ -106,12 +106,18 @@ class GridMappingsTest(unittest.TestCase):
             repr(g)
             str(g)
 
-    def test_grid_mapping_find_gm_class(self):
+    def test_grid_mapping__get_cf_grid_mapping_from_name(self):
         """TODO."""
-        for f in self.f_with_gm:
-            gms = f.domain.get_grid_mappings()
-            print(gms)
-            # TODO test that matches with GM class
+        for gm_name, cf_gm_class in {
+            "vertical_perspective": cf.VerticalPerspective,
+            "oblique_mercator": cf.ObliqueMercator,
+            "albers_conical_equal_area": cf.AlbersEqualArea,
+            "lambert_conformal_conic": cf.LambertConformalConic,
+            "some_unsupported_name": None,
+        }.items():
+            self.assertEqual(
+                cf._get_cf_grid_mapping_from_name(gm_name), cf_gm_class
+            )
 
 
 if __name__ == "__main__":

--- a/cf/test/test_gridmappings.py
+++ b/cf/test/test_gridmappings.py
@@ -58,9 +58,19 @@ all_concrete_grid_mappings_req_args = {
 
 
 class GridMappingsTest(unittest.TestCase):
-    f = cf.example_field(1)
+    """TODO."""
 
-    @unittest.skipUnless(pyproj_imported, "Requires pyproj package.")
+    # Of the example fields, only 1, 6 and 7 have any coordinate references
+    # with a coordinate conversion, hence use these to test, plus 0 as an
+    # example case of a field without a coordinate reference at all.
+    f = cf.example_fields()
+    f0 = f[0]  # No coordinate reference
+    f1 = f[1]  # 2, with grid mappings of [None, 'rotated_latitude_longitude']
+    f6 = f[6]  # 1, with grid mapping of ['latitude_longitude']
+    f7 = f[7]  # 1, with grid mapping of ['rotated_latitude_longitude']
+    f_with_gm = (f1, f6, f7)
+
+    # @unittest.skipUnless(pyproj_imported, "Requires pyproj package.")
     def test_grid_mapping__repr__str__(self):
         """TODO."""
         for cls in all_concrete_grid_mappings:
@@ -73,6 +83,16 @@ class GridMappingsTest(unittest.TestCase):
                 g = cls(*example_minimal_args)
             repr(g)
             str(g)
+
+    def test_grid_mapping_find_gm_class(self):
+        """TODO."""
+        for f in self.f_with_gm:
+            crefs = f.coordinate_references().values()
+            for cref in crefs:
+                gm = cref.coordinate_conversion.get_parameter(
+                    "grid_mapping_name", default=None
+                )
+                # TODO test that matches with GM class
 
 
 if __name__ == "__main__":

--- a/cf/test/test_gridmappings.py
+++ b/cf/test/test_gridmappings.py
@@ -179,6 +179,7 @@ class GridMappingsTest(unittest.TestCase):
             (cf.Data(45, units="degrees_east"), "45"),
             (cf.Data(45, units="degrees_E"), "45"),
             (cf.Data(45, units="degreeE"), "45"),
+            (cf.Data(45, units="degree"), "45"),
             # Check negative
             (cf.Data(-0.1, units="degrees"), "-0.1"),
             (cf.Data(-10, units="degrees"), "-10"),
@@ -188,8 +189,8 @@ class GridMappingsTest(unittest.TestCase):
             # Check radians units cases and >180
             (cf.Data(190, units="radians"), "190R"),
             (cf.Data(190.0, units="radians"), "190.0R"),
-            # Check TODO
-            # TODO
+            # Check flot with superfluous 0
+            (cf.Data(120.100, units="degrees"), "120.1"),
         ]:
             _input, correct_output = input_with_correct_output
             p = cf.convert_cf_angular_data_to_proj(_input)
@@ -200,9 +201,13 @@ class GridMappingsTest(unittest.TestCase):
             cf.Data([1, 2, 3]),  # not singular (size 1)
             cf.Data(45),  # no units
             cf.Data(45, "m"),  # non-angular units
+            cf.Data(2, "elephants")  # bad/non-CF units
         ]:
             with self.assertRaises(ValueError):
                 cf.convert_cf_angular_data_to_proj(bad_input)
+        with self.assertRaises(TypeError):
+            # Non-numeric value
+            cf.convert_cf_angular_data_to_proj(cf.Data("N", "radians"))
 
         # Note that 'convert_cf_angular_data_to_proj' and
         # 'convert_proj_angular_data_to_cf' are not strict inverse

--- a/cf/test/test_gridmappings.py
+++ b/cf/test/test_gridmappings.py
@@ -145,11 +145,11 @@ class GridMappingsTest(unittest.TestCase):
                 ]:
             _input, correct_output = input_with_correct_output
             proj_arg, context_arg = _input
-            #print("ARGS OF:", _input, correct_output, proj_arg, context_arg)
+            print("ARGS OF:", _input, correct_output, proj_arg, context_arg)
             d = cf._convert_units_proj_to_cf(proj_arg, context_arg)
-            #print("EXPECT:", correct_output)
-            #print("GET:", d)
-            #print()
+            print("EXPECT:", correct_output)
+            print("GET:", d)
+            print()
             self.assertTrue(d.equals(correct_output, verbose=2))
 
 if __name__ == "__main__":

--- a/cf/test/test_gridmappings.py
+++ b/cf/test/test_gridmappings.py
@@ -10,7 +10,7 @@ faulthandler.enable()  # to debug seg faults and timeouts
 
 pyproj_imported = False
 try:
-    import pyproj
+    import pyproj  # noqa: F401
 
     pyproj_imported = True
 except ImportError:

--- a/cf/test/test_gridmappings.py
+++ b/cf/test/test_gridmappings.py
@@ -121,6 +121,8 @@ class GridMappingsTest(unittest.TestCase):
 
     def test_grid_mapping_convert_proj_angular_data_to_cf(self):
         """Test the 'convert_proj_angular_data_to_cf' function."""
+
+        # Check representative valid inputs
         for input_with_correct_output in [
             # Check float value and no suffix
             (("45.0", None), cf.Data(45.0, units="degrees")),
@@ -164,6 +166,7 @@ class GridMappingsTest(unittest.TestCase):
 
     def test_grid_mapping_convert_cf_angular_data_to_proj(self):
         """Test the 'convert_cf_angular_data_to_proj' function."""
+        # Check representative valid inputs
         for input_with_correct_output in [
             # Check float and basic lat/lon-context free degree unit
             (cf.Data(45.0, units="degrees"), "45.0"),
@@ -174,10 +177,30 @@ class GridMappingsTest(unittest.TestCase):
             (cf.Data(45, units="degrees_east"), "45"),
             (cf.Data(45, units="degrees_E"), "45"),
             (cf.Data(45, units="degreeE"), "45"),
+            # Check negative
+            (cf.Data(-0.1, units="degrees"), "-0.1"),
+            (cf.Data(-10, units="degrees"), "-10"),
+            # Check zero case
+            (cf.Data(0, units="degrees_north"), "0"),
+            (cf.Data(0.0, units="degrees_north"), "0.0"),
+            # Check radians units cases and >180
+            (cf.Data(190, units="radians"), "190R"),
+            (cf.Data(190.0, units="radians"), "190.0R"),
+            # Check TODO
+            # TODO
         ]:
             _input, correct_output = input_with_correct_output
             p = cf.convert_cf_angular_data_to_proj(_input)
             self.assertEqual(p, correct_output)
+
+        # Check representative invalid inputs error correctly
+        for bad_input in [
+            cf.Data([1, 2, 3]),  # not singular (size 1)
+            cf.Data(45),  # no units
+            cf.Data(45, "m"),  # non-angular units
+        ]:
+            with self.assertRaises(ValueError):
+                cf.convert_cf_angular_data_to_proj(bad_input)
 
         # Note that 'convert_cf_angular_data_to_proj' and
         # 'convert_proj_angular_data_to_cf' are not strict inverse

--- a/cf/test/test_gridmappings.py
+++ b/cf/test/test_gridmappings.py
@@ -135,13 +135,13 @@ class GridMappingsTest(unittest.TestCase):
                 (("200.123D", "lat"), cf.Data(200.123, units="degrees_north")),
                 (("200.123D", "lon"), cf.Data(200.123, units="degrees_east")),
                 # Check "R" suffix
-                ((f"{0.5 * np.pi}R", None), cf.Data(90, units="degrees")),
-                ((f"{0.5 * np.pi}R", "lat"), cf.Data(90, units="degrees_north")),
-                ((f"{0.5 * np.pi}R", "lon"), cf.Data(90, units="degrees_east")),
+                ((f"{0.5 * np.pi}R", None), cf.Data(0.5 * np.pi, units="radians")),
+                ((f"{0.5 * np.pi}R", "lat"), cf.Data(90.0, units="degrees_north")),
+                ((f"{0.5 * np.pi}R", "lon"), cf.Data(90.0, units="degrees_east")),
                 # Check >360 degrees (full revolution) and  "r" suffix
-                ((f"{3.0 * np.pi}r", None), cf.Data(180, units="degrees")),
-                ((f"{3.0 * np.pi}r", "lat"), cf.Data(180, units="degrees_north")),
-                ((f"{3.0 * np.pi}r", "lon"), cf.Data(180, units="degrees_east")),
+                ((f"{3.0 * np.pi}r", None), cf.Data(3.0 * np.pi, units="radians")),
+                ((f"{3.0 * np.pi}r", "lat"), cf.Data(540.0, units="degrees_north")),
+                ((f"{3.0 * np.pi}r", "lon"), cf.Data(540.0, units="degrees_east")),
                 ]:
             _input, correct_output = input_with_correct_output
             proj_arg, context_arg = _input

--- a/cf/test/test_gridmappings.py
+++ b/cf/test/test_gridmappings.py
@@ -17,33 +17,6 @@ except ImportError:
     pass
 
 
-ALL_ABSTRACT_GRID_MAPPINGS = (
-    cf.GridMapping,
-    cf.AzimuthalGridMapping,
-    cf.ConicGridMapping,
-    cf.CylindricalGridMapping,
-    cf.LatLonGridMapping,
-    cf.PerspectiveGridMapping,
-)
-# Representing all Grid Mappings repsented by the CF Conventions (APpendix F)
-ALL_CONCRETE_GRID_MAPPINGS = (
-    cf.AlbersEqualArea,
-    cf.AzimuthalEquidistant,
-    cf.Geostationary,
-    cf.LambertAzimuthalEqualArea,
-    cf.LambertConformalConic,
-    cf.LambertCylindricalEqualArea,
-    cf.Mercator,
-    cf.ObliqueMercator,
-    cf.Orthographic,
-    cf.PolarStereographic,
-    cf.RotatedLatitudeLongitude,
-    cf.LatitudeLongitude,
-    cf.Sinusoidal,
-    cf.Stereographic,
-    cf.TransverseMercator,
-    cf.VerticalPerspective,
-)
 # These are those of the above which have required positional arguments
 all_concrete_grid_mappings_req_args = {
     "AlbersEqualArea": {"standard_parallel": 0.0},
@@ -68,11 +41,12 @@ class GridMappingsTest(unittest.TestCase):
     f1 = f[1]  # 2, with grid mappings of [None, 'rotated_latitude_longitude']
     f6 = f[6]  # 1, with grid mapping of ['latitude_longitude']
     f7 = f[7]  # 1, with grid mapping of ['rotated_latitude_longitude']
-    f_with_gm = {
-        f1: cf.RotatedLatitudeLongitude,
-        f6: cf.LatitudeLongitude,
-        f7: cf.RotatedLatitudeLongitude,
-    )
+    f_with_gm = (f1, f6, f7)
+    f_wth_gm_mapping = {
+        "f1": cf.RotatedLatitudeLongitude,
+        "f6": cf.LatitudeLongitude,
+        "f7": cf.RotatedLatitudeLongitude,
+    }
 
     # From a custom netCDF file with Oblique Mercator GM
     # TODO generate this .nc via create_test_files.py and un-commit
@@ -121,7 +95,7 @@ class GridMappingsTest(unittest.TestCase):
     # @unittest.skipUnless(pyproj_imported, "Requires pyproj package.")
     def test_grid_mapping__repr__str__(self):
         """TODO."""
-        for cls in ALL_CONCRETE_GRID_MAPPINGS:
+        for cls in cf._all_concrete_grid_mappings:
             if cls.__name__ not in all_concrete_grid_mappings_req_args:
                 g = cls()
             else:

--- a/cf/test/test_gridmappings.py
+++ b/cf/test/test_gridmappings.py
@@ -213,21 +213,26 @@ class GridMappingsTest(unittest.TestCase):
         # undone to their original form by operation of both
         # functions, namely those with this 'simplest' PROJ form,
         # do indeed get re-generated with operation of both:
-        for p in ("10", "-10", "0", "1R", "0.2R", "0.1R"):
+        for p in ("10", "-10", "10.11", "0", "1R", "0.2R", "-0.1R", "0R"):
             p2 = cf.convert_cf_angular_data_to_proj(
                 cf.convert_proj_angular_data_to_cf(p)
             )
             self.assertEqual(p, p2)
 
-            # With a lat or lon 'context'
-            p3 = cf.convert_cf_angular_data_to_proj(
-                cf.convert_proj_angular_data_to_cf(p, context="lat")
-            )
-            self.assertEqual(p, p3)
-            p4 = cf.convert_cf_angular_data_to_proj(
-                cf.convert_proj_angular_data_to_cf(p, context="lon")
-            )
-            self.assertEqual(p, p4)
+            # With a lat or lon 'context'. Only non-radians inputs will
+            # be re-generated since degrees_X gets converted back to the
+            # default degrees, so skip those in these test cases.
+            if not p.endswith("R"):
+                a = cf.convert_proj_angular_data_to_cf(p, context="lat")
+                p3 = cf.convert_cf_angular_data_to_proj(
+                    cf.convert_proj_angular_data_to_cf(p, context="lat")
+                )
+                self.assertEqual(p, p3)
+
+                p4 = cf.convert_cf_angular_data_to_proj(
+                    cf.convert_proj_angular_data_to_cf(p, context="lon")
+                )
+                self.assertEqual(p, p4)
 
 
 if __name__ == "__main__":

--- a/cf/test/test_gridmappings.py
+++ b/cf/test/test_gridmappings.py
@@ -1,0 +1,82 @@
+import datetime
+import faulthandler
+import unittest
+
+# import numpy as np
+
+faulthandler.enable()  # to debug seg faults and timeouts
+
+import cf
+
+pyproj_imported = False
+try:
+    import pyproj
+
+    pyproj_imported = True
+except ImportError:
+    pass
+
+
+all_abstract_grid_mappings = (
+    cf.GridMapping,
+    cf.AzimuthalGridMapping,
+    cf.ConicGridMapping,
+    cf.CylindricalGridMapping,
+    cf.LatLonGridMapping,
+    cf.PerspectiveGridMapping,
+)
+# Representing all Grid Mappings repsented by the CF Conventions (APpendix F)
+all_concrete_grid_mappings = (
+    cf.AlbersEqualArea,
+    cf.AzimuthalEquidistant,
+    cf.Geostationary,
+    cf.LambertAzimuthalEqualArea,
+    cf.LambertConformalConic,
+    cf.LambertCylindricalEqualArea,
+    cf.Mercator,
+    cf.ObliqueMercator,
+    cf.Orthographic,
+    cf.PolarStereographic,
+    cf.RotatedLatitudeLongitude,
+    cf.LatitudeLongitude,
+    cf.Sinusoidal,
+    cf.Stereographic,
+    cf.TransverseMercator,
+    cf.VerticalPerspective,
+)
+# These are those of the above which have required positional arguments
+all_concrete_grid_mappings_req_args = {
+    "AlbersEqualArea": {"standard_parallel": 0.0},
+    "Geostationary": {"perspective_point_height": 1000},
+    "VerticalPerspective": {"perspective_point_height": 1000},
+    "LambertConformalConic": {"standard_parallel": 0.0},
+    "RotatedLatitudeLongitude": {
+        "grid_north_pole_latitude": 0.0,
+        "grid_north_pole_longitude": 0.0,
+    },
+}
+
+
+class GridMappingsTest(unittest.TestCase):
+    f = cf.example_field(1)
+
+    @unittest.skipUnless(pyproj_imported, "Requires pyproj package.")
+    def test_grid_mapping__repr__str__(self):
+        """TODO."""
+        for cls in all_concrete_grid_mappings:
+            if cls.__name__ not in all_concrete_grid_mappings_req_args:
+                g = cls()
+            else:
+                example_minimal_args = all_concrete_grid_mappings_req_args[
+                    cls.__name__
+                ]
+                g = cls(*example_minimal_args)
+            repr(g)
+            str(g)
+
+
+if __name__ == "__main__":
+    print("Run date:", datetime.datetime.now())
+    cf.environment()
+    print()
+    unittest.main(verbosity=2)

--- a/cf/test/test_gridmappings.py
+++ b/cf/test/test_gridmappings.py
@@ -149,14 +149,16 @@ class GridMappingsTest(unittest.TestCase):
         """Test the validation of map parameters to Grid Mapping classes."""
         g1 = cf.Mercator(
             false_easting=10.0,
-            false_northing=cf.Data(-20, units="m"),
+            false_northing=cf.Data(-20, units="cm"),
             standard_parallel=(None, 50),
-            longitude_of_projection_origin=-40.0,
+            longitude_of_projection_origin=cf.Data(
+                -40.0, units="degrees_east"
+            ),
             scale_factor_at_projection_origin=3.0,
             prime_meridian_name="brussels",
         )
         self.assertEqual(g1.false_easting, cf.Data(10.0, "m"))
-        self.assertEqual(g1.false_northing, cf.Data(-20, "m"))
+        self.assertEqual(g1.false_northing, cf.Data(-0.2, "m"))
         self.assertEqual(
             g1.standard_parallel, (None, cf.Data(50, "degrees_north"))
         )

--- a/cf/test/test_gridmappings.py
+++ b/cf/test/test_gridmappings.py
@@ -152,7 +152,7 @@ class GridMappingsTest(unittest.TestCase):
                 (("-70.5°", "lon"), cf.Data(-70.5, units="degrees_east")),
                 ]:
             _input, correct_output = input_with_correct_output
-            d = cf._convert_units_proj_to_cf(*_input)
+            d = cf.convert_proj_angular_data_to_cf(*_input)
             self.assertTrue(d.equals(correct_output, verbose=2))
 
 if __name__ == "__main__":

--- a/cf/test/test_gridmappings.py
+++ b/cf/test/test_gridmappings.py
@@ -17,7 +17,7 @@ except ImportError:
     pass
 
 
-all_abstract_grid_mappings = (
+ALL_ABSTRACT_GRID_MAPPINGS = (
     cf.GridMapping,
     cf.AzimuthalGridMapping,
     cf.ConicGridMapping,
@@ -26,7 +26,7 @@ all_abstract_grid_mappings = (
     cf.PerspectiveGridMapping,
 )
 # Representing all Grid Mappings repsented by the CF Conventions (APpendix F)
-all_concrete_grid_mappings = (
+ALL_CONCRETE_GRID_MAPPINGS = (
     cf.AlbersEqualArea,
     cf.AzimuthalEquidistant,
     cf.Geostationary,
@@ -69,11 +69,21 @@ class GridMappingsTest(unittest.TestCase):
     f6 = f[6]  # 1, with grid mapping of ['latitude_longitude']
     f7 = f[7]  # 1, with grid mapping of ['rotated_latitude_longitude']
     f_with_gm = (f1, f6, f7)
+    gm_of_ex_fields = (
+        None,
+        cf.RotatedLatitudeLongitude,
+        None,
+        None,
+        None,
+        None,
+        cf.LatitudeLongitude,
+        cf.RotatedLatitudeLongitude,
+    )
 
     # @unittest.skipUnless(pyproj_imported, "Requires pyproj package.")
     def test_grid_mapping__repr__str__(self):
         """TODO."""
-        for cls in all_concrete_grid_mappings:
+        for cls in ALL_CONCRETE_GRID_MAPPINGS:
             if cls.__name__ not in all_concrete_grid_mappings_req_args:
                 g = cls()
             else:

--- a/cf/test/test_gridmappings.py
+++ b/cf/test/test_gridmappings.py
@@ -219,6 +219,16 @@ class GridMappingsTest(unittest.TestCase):
             )
             self.assertEqual(p, p2)
 
+            # With a lat or lon 'context'
+            p3 = cf.convert_cf_angular_data_to_proj(
+                cf.convert_proj_angular_data_to_cf(p, context="lat")
+            )
+            self.assertEqual(p, p3)
+            p4 = cf.convert_cf_angular_data_to_proj(
+                cf.convert_proj_angular_data_to_cf(p, context="lon")
+            )
+            self.assertEqual(p, p4)
+
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())

--- a/cf/test/test_gridmappings.py
+++ b/cf/test/test_gridmappings.py
@@ -68,16 +68,54 @@ class GridMappingsTest(unittest.TestCase):
     f1 = f[1]  # 2, with grid mappings of [None, 'rotated_latitude_longitude']
     f6 = f[6]  # 1, with grid mapping of ['latitude_longitude']
     f7 = f[7]  # 1, with grid mapping of ['rotated_latitude_longitude']
-    f_with_gm = (f1, f6, f7)
-    gm_of_ex_fields = (
-        None,
-        cf.RotatedLatitudeLongitude,
-        None,
-        None,
-        None,
-        None,
-        cf.LatitudeLongitude,
-        cf.RotatedLatitudeLongitude,
+    f_with_gm = {
+        f1: cf.RotatedLatitudeLongitude,
+        f6: cf.LatitudeLongitude,
+        f7: cf.RotatedLatitudeLongitude,
+    )
+
+    # From a custom netCDF file with Oblique Mercator GM
+    # TODO generate this .nc via create_test_files.py and un-commit
+    # forced commit of the (data-free / header-only) netCDF file.
+    f_om = cf.read("oblique_mercator.nc")
+
+    # Create some coordinate references with different GMs to test on:
+    cr_aea = cf.CoordinateReference(
+        coordinates=["coordA", "coordB", "coordC"],
+        coordinate_conversion=cf.CoordinateConversion(
+            parameters={
+                "grid_mapping_name": "albers_conical_equal_area",
+                "standard_parallel": [10, 10],
+                "longitude_of_projection_origin":45.0,
+                "false_easting": -1000,
+                "false_northing": 500,
+            }
+        ),
+    )
+    cr_aea_actual_proj_string = (
+        "+proj=aea +lat_1=10. +lat_2=10. +lon_0=45.0 +x_0=-1000. +y_0=-500."
+    )
+
+    cr_om = cf.CoordinateReference(
+        coordinates=["coordA", "coordB"],
+        coordinate_conversion=cf.CoordinateConversion(
+            parameters={
+                "grid_mapping_name": "oblique_mercator",
+                "latitude_of_projection_origin": -22.0,
+                "longitude_of_projection_origin": -59.0,
+                "false_easting": -12500.0,
+                "false_northing": -12500.0,
+                "azimuth_of_central_line": 89.999999,
+                "scale_factor_at_projection_origin": 1.0,
+                "inverse_flattening": 0.0,
+                "semi_major_axis": 6371229.0,
+            }
+        ),
+    )
+    cr_om_actual_proj_string = (
+        "+proj=omerc +lat_0=-22.00 +alpha=89.999999 +lonc=-59.00 "
+        "+x_0=-12500. +y_0=-12500. +ellps=sphere +a=6371229. +b=6371229. "
+        "+units=m +no_defs"
     )
 
     # @unittest.skipUnless(pyproj_imported, "Requires pyproj package.")


### PR DESCRIPTION
Part 1 of 2 towards #628. This first part sets up the Grid Mapping class and helper function infrastructure towards interfacing with PROJ using pyproj, so that in the second part (nearly ready, but with some issues left to resolve) we can use those to invoke PROJ `cs2cs` functionality to transform from one coordinate reference system to another, else be informed that the transformation isn't valid or possible, which allows us to get the lat-lon coordinates for a given projection with corresponding CRS parameters.

CF-supported Grid Mappings have been modelled explicitly as objects in this first step in order to, for example:
* allow us to define all supported Grid Mappings to be a paradigm for those and the CF map parameter arguments listed there;
* allow us to interface with them using our own `cf.Units` instead of having to convert to and work with PROJ formats for inputs (which are strings with a unit as a suffix e.g. "30D", "0.5R", etc.), where functions to convert to and from PROJ data and units are provided;
* to facilitate future cf-plot work and integration into the cf-python codebase.

### Diagrams of new class hierarchy

TODO