### PR TITLE
Testing and CI tidying including adding Python 3.12 job

### DIFF
--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -60,7 +60,7 @@ jobs:
       uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
-        miniconda-version: 'latest'
+        miniconda-version: "latest"
         activate-environment: cf-latest
         python-version: ${{ matrix.python-version }}
         channels: ncas, conda-forge
@@ -147,7 +147,7 @@ jobs:
       # passing at least for that job, avoiding useless coverage reports.
       uses: codecov/codecov-action@v3
       if: |
-        matrix.os == 'ubuntu-latest' && matrix.python-version == "3.9"
+        matrix.os == "ubuntu-latest" && matrix.python-version == "3.9"
       with:
         file: |
           ${{ github.workspace }}/main/cf/test/cf_coverage_reports/coverage.xml

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -25,7 +25,7 @@ jobs:
         # Skip older ubuntu-16.04 & macos-10.15 to save usage resource
         os: [ubuntu-latest, macos-latest]
         # Note: keep versions quoted as strings else 3.10 taken as 3.1, etc.
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     # Run on new and old(er) versions of the distros we support (Linux, Mac OS)
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -24,7 +24,8 @@ jobs:
       matrix:
         # Skip older ubuntu-16.04 & macos-10.15 to save usage resource
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.9]
+        # Note: keep versions quoted as strings else 3.10 taken as 3.1, etc.
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     # Run on new and old(er) versions of the distros we support (Linux, Mac OS)
     runs-on: ${{ matrix.os }}
@@ -146,7 +147,7 @@ jobs:
       # passing at least for that job, avoiding useless coverage reports.
       uses: codecov/codecov-action@v3
       if: |
-        matrix.os == 'ubuntu-latest' && matrix.python-version == 3.8
+        matrix.os == 'ubuntu-latest' && matrix.python-version == "3.9"
       with:
         file: |
           ${{ github.workspace }}/main/cf/test/cf_coverage_reports/coverage.xml

--- a/.github/workflows/test-source-dist.yml
+++ b/.github/workflows/test-source-dist.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.8]
+        python-version: ["3.8"]
     runs-on: ${{ matrix.os }}
 
     # The sequence of tasks that will be executed as part of this job:
@@ -52,7 +52,7 @@ jobs:
       uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
-        miniconda-version: 'latest'
+        miniconda-version: "latest"
         activate-environment: cf-latest
         python-version: ${{ matrix.python-version }}
         channels: ncas, conda-forge

--- a/cf/__init__.py
+++ b/cf/__init__.py
@@ -89,7 +89,7 @@ _requires = (
 )
 
 x = ", ".join(_requires)
-_error0 = f"cf v{ __version__} requires the modules {x}. "
+_error0 = f"cf v{__version__} requires the modules {x}. "
 
 try:
     import cfdm

--- a/cf/read_write/read.py
+++ b/cf/read_write/read.py
@@ -990,7 +990,7 @@ def read(
         if info:
             logger.info(
                 f"{org_len} input field{_plural(org_len)} aggregated into "
-                f"{n} field{ _plural(n)}"
+                f"{n} field{_plural(n)}"
             )  # pragma: no cover
 
     # ----------------------------------------------------------------

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -14,6 +14,12 @@ SCIPY_AVAILABLE = False
 try:
     from scipy.ndimage import convolve1d
 
+    # In some cases we don't need SciPy directly, since it is required by code
+    # here which uses 'convolve1d' under-the-hood. Without it installed, get:
+    #
+    # NameError: name 'convolve1d' is not defined. Did you
+    # mean: 'cf_convolve1d'?
+
     SCIPY_AVAILABLE = True
 # not 'except ImportError' as that can hide nested errors, catch anything:
 except Exception:
@@ -2330,6 +2336,9 @@ class FieldTest(unittest.TestCase):
         # TODO: add loop to check get same shape and close enough data
         # for every possible axis combo (see also test_Data_percentile).
 
+    @unittest.skipIf(
+        not SCIPY_AVAILABLE, "scipy must be installed for this test."
+    )
     def test_Field_grad_xy(self):
         f = cf.example_field(0)
 
@@ -2415,6 +2424,9 @@ class FieldTest(unittest.TestCase):
             y.dimension_coordinate("X").standard_name, "longitude"
         )
 
+    @unittest.skipIf(
+        not SCIPY_AVAILABLE, "scipy must be installed for this test."
+    )
     def test_Field_laplacian_xy(self):
         f = cf.example_field(0)
 

--- a/cf/test/test_Maths.py
+++ b/cf/test/test_Maths.py
@@ -2,12 +2,30 @@ import datetime
 import faulthandler
 import unittest
 
+
+SCIPY_AVAILABLE = False
+try:
+    # We don't need SciPy directly in this test, it is only required by code
+    # here which uses 'convolve1d' under-the-hood. Without it installed, get:
+    #
+    # NameError: name 'convolve1d' is not defined. Did you
+    # mean: 'cf_convolve1d'?
+    import scipy
+
+    SCIPY_AVAILABLE = True
+# not 'except ImportError' as that can hide nested errors, catch anything:
+except Exception:
+    pass  # test with this dependency will then be skipped by unittest
+
 faulthandler.enable()  # to debug seg faults and timeouts
 
 import cf
 
 
 class MathTest(unittest.TestCase):
+    @unittest.skipIf(
+        not SCIPY_AVAILABLE, "scipy must be installed for this test."
+    )
     def test_curl_xy(self):
         f = cf.example_field(0)
 
@@ -97,6 +115,9 @@ class MathTest(unittest.TestCase):
             c.dimension_coordinate("X").standard_name, "longitude"
         )
 
+    @unittest.skipIf(
+        not SCIPY_AVAILABLE, "scipy must be installed for this test."
+    )
     def test_div_xy(self):
         f = cf.example_field(0)
 
@@ -185,6 +206,9 @@ class MathTest(unittest.TestCase):
             d.dimension_coordinate("X").standard_name, "longitude"
         )
 
+    @unittest.skipIf(
+        not SCIPY_AVAILABLE, "scipy must be installed for this test."
+    )
     def test_differential_operators(self):
         f = cf.example_field(0)
 


### PR DESCRIPTION
Minor admin tweaks to:

* add some missing newer Python versions into the CI test workflow, including support for the new latest major version 3.12, which was released about 3 weeks ago which I tested locally to be compatible dependency-wise with cf and that all tests pass as they should with it (:heavy_check_mark:);
* add some test method skips where SciPy is required under-the-hood but not directly in the test, which produces a somewhat confusing error message as an outcome of `NameError: name 'convolve1d' is not defined. Did you mean: 'cf_convolve1d'?` because it can't find the `scipy` `convolve1d` and suggests our own wrapper;
* make two small formatting tweaks so that `test_style` i.e. `pycodestyle` passes.
