### PR TITLE
Fix bug that caused `cf.Field.del_file_location` to fail when updating its metdata constructs

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -1,3 +1,12 @@
+version 3.17.0
+--------------
+
+**2024-??-??**
+
+* Fix bug that caused `cf.Field.del_file_location` to fail when
+  updating its metdata constructs
+  (http://github.com/NCAS-CMS/cf-python/issues/707)
+
 version 3.16.0
 --------------
 

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -5,7 +5,7 @@ version 3.17.0
 
 * Fix bug that caused `cf.Field.del_file_location` to fail when
   updating its metdata constructs
-  (http://github.com/NCAS-CMS/cf-python/issues/707)
+  (https://github.com/NCAS-CMS/cf-python/issues/707)
 
 version 3.16.0
 --------------

--- a/cf/field.py
+++ b/cf/field.py
@@ -2543,7 +2543,7 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
 
         if constructs:
             for c in self.constructs.filter_by_data(todict=True).values():
-                c.del_file_location(location, inplace=True)
+                c.del_file_location(location)
 
         return location
 

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -2629,6 +2629,28 @@ class FieldTest(unittest.TestCase):
         self.assertTrue(g.aux("X").data.range() < 30)
         self.assertTrue(g.aux("Y").data.range() < 50)
 
+    def test_Field_file_location(self):
+        f = cf.example_field(0)
+
+        self.assertEqual(f.add_file_location("/data/model/"), "/data/model")
+
+        cf.write(f, tmpfile)
+        f = cf.read(tmpfile)[0]
+        g = f.copy()
+        location = os.path.dirname(os.path.abspath(tmpfile))
+
+        self.assertEqual(f.file_locations(), set((location,)))
+        self.assertEqual(f.add_file_location("/data/model/"), "/data/model")
+        self.assertEqual(f.file_locations(), set((location, "/data/model")))
+
+        # Check that we haven't changed 'g'
+        self.assertEqual(g.file_locations(), set((location,)))
+
+        self.assertEqual(f.del_file_location("/data/model/"), "/data/model")
+        self.assertEqual(f.file_locations(), set((location,)))
+        f.del_file_location("/invalid")
+        self.assertEqual(f.file_locations(), set((location,)))
+
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())

--- a/docs/source/class/cf.Data.rst
+++ b/docs/source/class/cf.Data.rst
@@ -663,22 +663,22 @@ CFA
    :toctree: ../method/
    :template: method.rst
 	  
+   ~cf.Data.file_locations
+   ~cf.Data.del_file_location
    ~cf.Data.add_file_location
    ~cf.Data.cfa_clear_file_substitutions
-   ~cf.Data.cfa_del_aggregated_data
-   ~cf.Data.cfa_del_file_substitution
    ~cf.Data.cfa_file_substitutions
+   ~cf.Data.cfa_update_file_substitutions
+   ~cf.Data.cfa_del_file_substitution
+   ~cf.Data.cfa_has_file_substitutions
+   ~cf.Data.cfa_del_aggregated_data
    ~cf.Data.cfa_get_aggregated_data
+   ~cf.Data.cfa_has_aggregated_data
+   ~cf.Data.cfa_set_aggregated_data
    ~cf.Data.cfa_get_term
    ~cf.Data.cfa_get_write
-   ~cf.Data.cfa_has_aggregated_data
-   ~cf.Data.cfa_has_file_substitutions
-   ~cf.Data.cfa_set_aggregated_data
    ~cf.Data.cfa_set_term
    ~cf.Data.cfa_set_write
-   ~cf.Data.cfa_update_file_substitutions
-   ~cf.Data.del_file_location
-   ~cf.Data.file_locations
 
 Element-wise arithmetic, bit and comparison operations
 ------------------------------------------------------

--- a/docs/source/class/cf.Field.rst
+++ b/docs/source/class/cf.Field.rst
@@ -442,13 +442,13 @@ CFA
    :toctree: ../method/
    :template: method.rst
 	      
+   ~cf.Field.file_locations
    ~cf.Field.add_file_location
+   ~cf.Field.del_file_location
    ~cf.Field.cfa_clear_file_substitutions
    ~cf.Field.cfa_del_file_substitution
    ~cf.Field.cfa_file_substitutions
    ~cf.Field.cfa_update_file_substitutions
-   ~cf.Field.del_file_location
-   ~cf.Field.file_locations
 
 Geometries
 ^^^^^^^^^^


### PR DESCRIPTION
Fixes #707

Also improves method order in API docs.