### PR TITLE
Allow data instantiation from a `xarray.DataArray` object 

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -3,6 +3,8 @@ version 3.17.0
 
 **2024-??-??**
 
+* Allow `cf.Data` to be initialised with `xarray.DataAarray`
+  (https://github.com/NCAS-CMS/cf-python/issues/706)
 * Fix bug that caused `cf.Field.del_file_location` to fail when
   updating its metdata constructs
   (https://github.com/NCAS-CMS/cf-python/issues/707)

--- a/cf/data/creation.py
+++ b/cf/data/creation.py
@@ -15,8 +15,9 @@ def to_dask(array, chunks, **from_array_options):
 
         array: array_like
             The array to be converted to a `dask` array. Examples of
-            valid types include `numpy` arrays, `dask` arrays, `Array`
-            subclasses, `list`, `tuple`, scalars.
+            valid types include anything with a `to_dask_array`
+            method, `numpy` arrays, `dask` arrays, `xarray` arrays,
+            `cf.Array` subclasses, `list`, `tuple`, scalars.
 
         chunks: `int`, `tuple`, `dict` or `str`, optional
             Specify the chunking of the returned dask array.  Any
@@ -67,6 +68,11 @@ def to_dask(array, chunks, **from_array_options):
             return array.to_dask_array(chunks=chunks)
         except TypeError:
             return array.to_dask_array()
+
+    if type(array).__module__.split(".")[0] == "xarray":
+        data = getattr(array, "data", None)
+        if data is not None:
+            return da.asanyarray(data)
 
     if not isinstance(
         array, (np.ndarray, list, tuple, memoryview) + np.ScalarType

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -189,11 +189,14 @@ class Data(DataClassDeprecationsMixin, CFANetCDF, Container, cfdm.Data):
         :Parameters:
 
             array: optional
-                The array of values. May be any scalar or array-like
-                object, including another `Data` instance.
+                The array of values. May be a scalar or array-like
+                object, including another `Data` instance, anything
+                with a `!to_dask_array` method, `numpy` array, `dask`
+                array, `xarray` array, `cf.Array` subclass, `list`,
+                `tuple`, scalar.
 
                 *Parameter example:*
-                  ``array=[34.6]``
+                  ``array=34.6``
 
                 *Parameter example:*
                   ``array=[[1, 2], [3, 4]]``


### PR DESCRIPTION
Fixes #706 

Uses the same technique as Dask.