### PR TITLE
Fix bug in `cf.Field.subspace` and `cf.Field.__getitem__` for some cyclic subspaces

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -15,6 +15,9 @@ version 3.17.0
 * Fix bug that caused `cf.Field.del_file_location` to fail when
   updating its metdata constructs
   (https://github.com/NCAS-CMS/cf-python/issues/707)
+* Fix bug that caused incorrect data arrays in some cyclic subspaces
+  created by `cf.Field.subspace` and `cf.Field.__getitem__`
+  (https://github.com/NCAS-CMS/cf-python/issues/713)
 
 version 3.16.0
 --------------

--- a/cf/field.py
+++ b/cf/field.py
@@ -405,9 +405,11 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                         f"{self.constructs.domain_axis_identity(_)!r} axis"
                     )
 
-                new = new.roll(shift=shift, axis=iaxis)
+                new = new.roll(axis=iaxis, shift=shift)
         else:
             new = self.copy()
+
+        data = new.data
 
         # ------------------------------------------------------------
         # Subspace the field construct's data

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -656,6 +656,13 @@ class FieldTest(unittest.TestCase):
         with self.assertRaises(IndexError):
             f[..., [False] * f.shape[-1]]
 
+        # Test with cyclic subspace
+        f.cyclic("grid_longitude")
+        g = f[:, -3:-5:1]
+        self.assertEqual(g.shape, (10, 7))
+        self.assertTrue(np.allclose(f[:, -3:].array, g[:, :3].array))
+        self.assertTrue(f[:, :4].equals(g[:, 3:]))
+
     def test_Field__setitem__(self):
         f = self.f.copy().squeeze()
 


### PR DESCRIPTION
Fixes #713 