### PR TITLE
Fix bug when calculating UGRID cell areas when non-spatial coordinates span the discrete axis

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -3,6 +3,9 @@ version 3.17.0
 
 **2024-??-??**
 
+* Fix occasional bug when calculating UGRID cell areas when
+  non-spatial coordinates span the discrete axis
+  (https://github.com/NCAS-CMS/cf-python/issues/721)
 * Added the ``cell_measures`` and ``coordinates`` keyword arguments to
   `cf.Field.weights`
   (https://github.com/NCAS-CMS/cf-python/issues/709)

--- a/cf/weights.py
+++ b/cf/weights.py
@@ -1652,7 +1652,7 @@ class Weights(Container, cfdm.Container):
         )
 
         for key, aux in auxiliary_coordinates_1d.items():
-            if aux.ctype not in "XYZ":
+            if str(aux.ctype) not in "XYZ":
                 continue
 
             aux_axis = f.get_data_axes(key)[0]

--- a/cf/weights.py
+++ b/cf/weights.py
@@ -1652,8 +1652,8 @@ class Weights(Container, cfdm.Container):
         )
 
         for key, aux in auxiliary_coordinates_1d.items():
-            #            if aux.ctype not in "XYZ":
-            #                continue
+            if aux.ctype not in "XYZ":
+                continue
 
             aux_axis = f.get_data_axes(key)[0]
 

--- a/cf/weights.py
+++ b/cf/weights.py
@@ -1652,6 +1652,9 @@ class Weights(Container, cfdm.Container):
         )
 
         for key, aux in auxiliary_coordinates_1d.items():
+            #            if aux.ctype not in "XYZ":
+            #                continue
+
             aux_axis = f.get_data_axes(key)[0]
 
             ugrid = f.domain_topology(default=None, filter_by_axis=(aux_axis,))
@@ -1665,8 +1668,8 @@ class Weights(Container, cfdm.Container):
             ):
                 continue
 
-            # Still here? Then this auxiliary coordinate has either UGRID
-            # or geometry cells.
+            # Still here? Then this X, Y, or Z auxiliary coordinate is
+            # for either UGRID or geometry cells.
             if aux.X:
                 aux_X = aux.copy()
                 x_axis = aux_axis
@@ -1701,7 +1704,7 @@ class Weights(Container, cfdm.Container):
 
             raise ValueError(
                 "Can't create weights: X and Y cells span different domain "
-                "axes"
+                f"axes: {x_axis} != {y_axis}"
             )
 
         axis = x_axis


### PR DESCRIPTION
Fixes #721 

No unit test - due to the lightly random nature, it's a bit tricky to write one. But the fix is pretty simple and it works for the use case described in the issue :)