### PR TITLE
Fix misleading error message when it is not possible to create area weights requested from `cf.Field.collapse`

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -1,3 +1,14 @@
+version NEXT
+------------
+
+**2024-??-??**
+
+* Fix misleading error message when it is not possible to create area
+  weights requested from `cf.Field.collapse`
+  (https://github.com/NCAS-CMS/cf-python/issues/731)
+
+----
+
 version 3.16.1
 --------------
 
@@ -28,6 +39,8 @@ version 3.16.1
   created by `cf.Field.subspace` and `cf.Field.__getitem__`
   (https://github.com/NCAS-CMS/cf-python/issues/713)
 * Changed dependency: ``1.11.1.0<=cfdm<1.11.2.0``
+
+----
 
 version 3.16.0
 --------------

--- a/cf/field.py
+++ b/cf/field.py
@@ -3836,18 +3836,17 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                         # Found area weights from X and Y dimension
                         # coordinates
                         area_weights = True
-                    else:
-                        Weights.polygon_area(
-                            self,
-                            None,
-                            comp,
-                            weights_axes,
-                            measure=measure,
-                            radius=radius,
-                            great_circle=great_circle,
-                            methods=methods,
-                            auto=False,
-                        )
+                    elif Weights.polygon_area(
+                        self,
+                        None,
+                        comp,
+                        weights_axes,
+                        measure=measure,
+                        radius=radius,
+                        great_circle=great_circle,
+                        methods=methods,
+                        auto=True,
+                    ):
                         # Found area weights from UGRID/geometry cells
                         area_weights = True
 


### PR DESCRIPTION
Fixes #731 