### PR TITLE
1-d Z Cartesian regridding fix and test

### DIFF
--- a/cf/field.py
+++ b/cf/field.py
@@ -454,8 +454,11 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
         # below.
         if org_cyclic:
             new_cyclic = new_data.cyclic()
-            [new.cyclic(i, iscyclic=False) for i in org_cyclic if i not in new_cyclic]
-                    
+            [
+                new.cyclic(i, iscyclic=False)
+                for i in org_cyclic
+                if i not in new_cyclic
+            ]
 
         # ------------------------------------------------------------
         # Subspace constructs with data

--- a/cf/regrid/regrid.py
+++ b/cf/regrid/regrid.py
@@ -988,14 +988,14 @@ def Cartesian_coords_to_domain(dst, dst_z=None, domain_class=None):
 
     if dst_z is not None:
         # Check that there are vertical coordinates, and replace
-        # 'dst_z' with its construct identifier.
+        # 'dst_z' with the identifier of its domain axis construct.
         z_key = d.coordinate(dst_z, key=True, default=None)
         if z_key is None:
             raise ValueError(
                 f"Could not find destination {dst_z!r} vertical coordinates"
             )
 
-        dst_z = z_key
+        dst_z = d.get_data_axes(z_key)[0]
 
     return d, axis_keys, dst_z
 
@@ -2112,7 +2112,6 @@ def create_esmpy_grid(grid, mask=None):
             #       masked/unmasked elements.
             grid_mask[...] = np.invert(mask).astype("int32")
 
-    #    print(esmpy_grid)
     return esmpy_grid
 
 

--- a/cf/test/test_regrid.py
+++ b/cf/test/test_regrid.py
@@ -157,6 +157,10 @@ class RegridTest(unittest.TestCase):
     dst = dst_src[0]
     src = dst_src[1]
 
+    filename_xyz = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "regrid_xyz.nc"
+    )
+
     @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_Field_regrid_2d_field(self):
         """2-d regridding with Field destination grid."""
@@ -734,6 +738,17 @@ class RegridTest(unittest.TestCase):
         for method in ("conservative_2nd", "patch"):
             with self.assertRaises(ValueError):
                 src.regridc(dst, method=method, axes=axes)
+
+    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
+    def test_Field_regridc_1d_coordinates_z(self):
+        """1-d Z Cartesian regridding with coordinates destination grid."""
+        src = cf.read(self.filename_xyz)[0]
+        dst = cf.DimensionCoordinate(
+            data=cf.Data([800, 705, 632, 510, 320.0], "hPa")
+        )
+        d = src.regridc([dst], method="linear", axes="Z", z="Z", ln_z=True)
+        z = d.dimension_coordinate("Z")
+        self.assertTrue(z.data.equals(dst.data))
 
     @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_Field_regrid_chunks(self):


### PR DESCRIPTION
Bug fix for #715

Discovered when this tutorial example code failed with `ValueError: Z coordinate 'dimensioncoordinate0' must match exactly an element of 'axes' (['domainaxis0'])`

```python
    >>> v = cf.read('vertical.nc')[0]
   >>> print(v)
   Field: eastward_wind (ncvar%ua)
   -------------------------------
   Data            : eastward_wind(time(3), air_pressure(5), grid_latitude(11), grid_longitude(10)) m s-1
   Cell methods    : time(3): mean
   Dimension coords: time(3) = [1979-05-01 12:00:00, 1979-05-02 12:00:00, 1979-05-03 12:00:00] gregorian
                   : air_pressure(5) = [850.0, ..., 50.0] hPa
                   : grid_latitude(11) = [23.32, ..., 18.92] degrees
                   : grid_longitude(10) = [-20.54, ..., -16.58] degrees
   Auxiliary coords: latitude(grid_latitude(11), grid_longitude(10)) = [[67.12, ..., 66.07]] degrees_north
                   : longitude(grid_latitude(11), grid_longitude(10)) = [[-45.98, ..., -31.73]] degrees_east
   Coord references: grid_mapping_name:rotated_latitude_longitude
   >>> new_z = cf.DimensionCoordinate(data=cf.Data([800, 705, 632, 510, 320.], 'hPa'))
   >>> new_v = v.regridc([new_z], axes='Z', method='linear', z='Z', ln_z=True)
   >>> print(new_v)
   Field: eastward_wind (ncvar%ua)
   -------------------------------
   Data            : eastward_wind(time(3), Z(5), grid_latitude(11), grid_longitude(10)) m s-1
   Cell methods    : time(3): mean
   Dimension coords: time(3) = [1979-05-01 12:00:00, 1979-05-02 12:00:00, 1979-05-03 12:00:00] gregorian
                   : Z(5) = [800.0, ..., 320.0] hPa
                   : grid_latitude(11) = [23.32, ..., 18.92] degrees
                   : grid_longitude(10) = [-20.54, ..., -16.58] degrees
   Auxiliary coords: latitude(grid_latitude(11), grid_longitude(10)) = [[67.12, ..., 66.07]] degrees_north
                   : longitude(grid_latitude(11), grid_longitude(10)) = [[-45.98, ..., -31.73]] degrees_east
   Coord references: grid_mapping_name:rotated_latitude_longitude
```