### PR TITLE
UNTESTED: do "make clean" in umlib build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,13 +70,15 @@ class build_umread(build):
         )
 
         cmd = ["make", "-C", build_dir]
+        cmd_clean = ["make", "-C", build_dir, "clean"]
 
         def compile():
             print("*" * 80)
             print("Running:", " ".join(cmd), "\n")
 
             try:
-                rc = subprocess.call(cmd)
+                # if compile returns 0, clean will also be run 
+                rc = subprocess.call(cmd) or subprocess.call(cmd_clean)
             except Exception as error:
                 print(error)
                 rc = 40
@@ -96,8 +98,8 @@ class build_umread(build):
                 print(
                     "         In particular, netCDF file processing is "
                     "unaffected."
-                )
-
+                )       
+            
             print("-" * 80)
             print("\n", "*" * 80)
             print()


### PR DESCRIPTION
Removing the `.o` files for umlib will save a little bit of disk space.
I have not tested this patch, so you may want to change the base branch for merge to something other than main so that you can test it.