### PR TITLE
Open and half-open intervals for `wi` queries

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -24,6 +24,8 @@ version NEXT
 * Fix bug in `cf.read` when reading UM files that caused LBPROC value
   131072 (Mean over an ensemble of parallel runs) to be ignored
   (https://github.com/NCAS-CMS/cf-python/issues/737)
+* New keyword parameters to `cf.wi`: ``open_lower`` and ``open_upper``
+  (https://github.com/NCAS-CMS/cf-python/issues/740)
 
 ----
 

--- a/cf/query.py
+++ b/cf/query.py
@@ -251,15 +251,21 @@ class Query:
 
                 .. versionadded:: 3.15.2
 
-            open_lower: number, optional
+            open_lower: `bool`, optional
                 Only applicable to the ``'wi'`` operator.
-                TODO
+                If True, open the interval at the lower
+                bound so that value0 is excluded from the
+                range. By default the interval is closed
+                so that value0 is included.
 
                 .. versionadded:: NEXTVERSION
 
-            open_upper: number, optional
+            open_upper: `bool`, optional
                 Only applicable to the ``'wi'`` operator.
-                TODO
+                If True, open the interval at the upper
+                bound so that value1 is excluded from the
+                range. By default the interval is closed
+                so that value1 is included.
 
                 .. versionadded:: NEXTVERSION
 
@@ -636,14 +642,22 @@ class Query:
 
     @property
     def open_lower(self):
-        """TODO
+        """True if the interval is open at the (excludes the) lower bound.
+
+        .. versionadded:: NEXTVERSION
+
+        .. seealso:: `open_upper`
 
         """
         return getattr(self, "_open_lower", False)
 
     @property
     def open_upper(self):
-        """TODO
+        """True if the interval is open at the (excludes the) upper bound.
+
+        .. versionadded:: NEXTVERSION
+
+        .. seealso:: `open_lower`
 
         """
         return getattr(self, "_open_upper", False)
@@ -1760,21 +1774,23 @@ def wi(
     >>> q.evaluate(7)
     True
 
+    The interval can be made open on either side or both. Note that,
+    as per mathematical interval notation, square brackets indicate
+    closed endpoints and parentheses open endpoints in the representation:
+
     >>> q = cf.wi(5, 7, open_upper=True)
     >>> q
-    TODO SLB
+    <CF Query: (wi [5, 7))>
     >>> q.evaluate(7)
     False
     >>> q = cf.wi(5, 7, open_lower=True)
     >>> q
-    TODO SLB
+    <CF Query: (wi (5, 7])>
     >>> q.evaluate(5)
     False
     >>> q = cf.wi(5, 7, open_lower=True, open_upper=True)
     >>> q
-    TODO SLB
-    >>> q.evaluate(6)
-    True
+    <CF Query: (wi (5, 7))>
     >>> q.evaluate(5)
     False
     >>> q.evaluate(7)

--- a/cf/query.py
+++ b/cf/query.py
@@ -495,6 +495,7 @@ class Query:
         if self.open_lower:
             repr_value = "(" + repr_value[1:]
 
+
         if self.open_upper:
             repr_value = repr_value[:-1] + ")"
 

--- a/cf/query.py
+++ b/cf/query.py
@@ -713,8 +713,7 @@ class Query:
         return value
 
     def addattr(self, attr):
-        """Return a `Query` object with a new left hand side operand
-        attribute to be used during evaluation.
+        """Redefine the query to be on an object's attribute.
 
         If another attribute has previously been specified, then the new
         attribute is considered to be an attribute of the existing

--- a/cf/query.py
+++ b/cf/query.py
@@ -1629,8 +1629,16 @@ def isclose(value, units=None, attr=None, rtol=None, atol=None):
     )
 
 
-def wi(value0, value1, units=None, attr=None):
+def wi(
+        value0, value1, open_lower=False, open_upper=False,
+        units=None, attr=None
+):
     """A `Query` object for a "within a range" condition.
+
+    The condition is a closed interval by default, inclusive of
+    both the endpoints, but can be made open or half-open to exclude
+    the endpoints on either end with use of the `open_lower` and
+    `open_upper` parameters.
 
     .. seealso:: `cf.contains`, `cf.eq`, `cf.ge`, `cf.gt`, `cf.ne`,
                  `cf.le`, `cf.lt`, `cf.set`, `cf.wo`, `cf.isclose`
@@ -1642,6 +1650,18 @@ def wi(value0, value1, units=None, attr=None):
 
         value1:
              The upper bound of the range.
+
+        open_lower: `bool`, optional
+             If True, open the interval at the lower
+             bound so that value0 is excluded from the
+             range. By default the interval is closed
+             so that value0 is included.
+
+        open_upper: `bool`, optional
+             If True, open the interval at the upper
+             bound so that value1 is excluded from the
+             range. By default the interval is closed
+             so that value1 is included.
 
         units: `str` or `Units`, optional
             The units of *value*. By default, the same units as the
@@ -1670,6 +1690,14 @@ def wi(value0, value1, units=None, attr=None):
     >>> q.evaluate(6)
     True
     >>> q.evaluate(4)
+    False
+    >>> q.evaluate(5)
+    True
+    >>> q.evaluate(5, open_lower=True)
+    False
+    >>> q.evaluate(7)
+    True
+    >>> q.evaluate(7, open_upper=True)
     False
 
     """

--- a/cf/query.py
+++ b/cf/query.py
@@ -345,6 +345,7 @@ class Query:
         operator = self._operator
         if operator == "isclose":
             value += (self.rtol, self.atol)
+
         if operator == "wi":
             value += (self.open_lower, self.open_upper)
 

--- a/cf/query.py
+++ b/cf/query.py
@@ -482,8 +482,8 @@ class Query:
         # For "wi" queries only, open intervals are supported. For "wi" _value
         # is a list of two values, with representation from string list form
         # of '[a, b]' which corresponds to the standard mathematical notation
-        # for a closed interval, the default. For a (half-)open interval need
-        # square bracket(s) -> parenthesis(/es), so unpack to adjust the repr.
+        # for a closed interval, the default. But an open endpoint is indicated
+        # by a parenthesis, so adjust repr. to convert square bracket(s).
         repr_value = str(self._value)
         if self.open_lower:
             repr_value = "(" + repr_value[1:]
@@ -1694,8 +1694,8 @@ def isclose(value, units=None, attr=None, rtol=None, atol=None):
 
 
 def wi(
-        value0, value1, open_lower=False, open_upper=False,
-        units=None, attr=None
+        value0, value1, units=None, attr=None, open_lower=False,
+        open_upper=False,
 ):
     """A `Query` object for a "within a range" condition.
 

--- a/cf/query.py
+++ b/cf/query.py
@@ -339,6 +339,8 @@ class Query:
         operator = self._operator
         if operator == "isclose":
             value += (self.rtol, self.atol)
+        if operator == "wi":
+            value += (self.open_lower, self.open_upper)
 
         return (self.__class__, operator, self._attr) + value
 

--- a/cf/query.py
+++ b/cf/query.py
@@ -476,7 +476,6 @@ class Query:
                 repr_value = repr_value[:-1] + ")"
 
         if not compound:
-            print(self._value, type(self._value))
             out = f"{attr}({operator} {repr_value}"
             rtol = self.rtol
             if rtol is not None:

--- a/cf/query.py
+++ b/cf/query.py
@@ -1741,12 +1741,16 @@ def wi(
              bound so that value0 is excluded from the
              range. By default the interval is closed
              so that value0 is included.
+             
+             .. versionadded:: NEXTVERSION
 
         open_upper: `bool`, optional
              If True, open the interval at the upper
              bound so that value1 is excluded from the
              range. By default the interval is closed
              so that value1 is included.
+             
+             .. versionadded:: NEXTVERSION
 
         units: `str` or `Units`, optional
             The units of *value*. By default, the same units as the

--- a/cf/query.py
+++ b/cf/query.py
@@ -1713,11 +1713,27 @@ def wi(
     False
     >>> q.evaluate(5)
     True
-    >>> q.evaluate(5, open_lower=True)
-    False
     >>> q.evaluate(7)
     True
-    >>> q.evaluate(7, open_upper=True)
+
+    >>> q = cf.wi(5, 7, open_upper=True)
+    >>> q
+    TODO SLB
+    >>> q.evaluate(7)
+    False
+    >>> q = cf.wi(5, 7, open_lower=True)
+    >>> q
+    TODO SLB
+    >>> q.evaluate(5)
+    False
+    >>> q = cf.wi(5, 7, open_lower=True, open_upper=True)
+    >>> q
+    TODO SLB
+    >>> q.evaluate(6)
+    True
+    >>> q.evaluate(5)
+    False
+    >>> q.evaluate(7)
     False
 
     """

--- a/cf/query.py
+++ b/cf/query.py
@@ -711,7 +711,7 @@ class Query:
 
     def addattr(self, attr):
         """Return a `Query` object with a new left hand side operand
-        attribute to be used during evaluation. TODO.
+        attribute to be used during evaluation.
 
         If another attribute has previously been specified, then the new
         attribute is considered to be an attribute of the existing
@@ -1708,8 +1708,12 @@ def isclose(value, units=None, attr=None, rtol=None, atol=None):
 
 
 def wi(
-        value0, value1, units=None, attr=None, open_lower=False,
-        open_upper=False,
+    value0,
+    value1,
+    units=None,
+    attr=None,
+    open_lower=False,
+    open_upper=False,
 ):
     """A `Query` object for a "within a range" condition.
 
@@ -1798,8 +1802,12 @@ def wi(
 
     """
     return Query(
-        "wi", [value0, value1], units=units, attr=attr,
-        open_lower=open_lower, open_upper=open_upper,
+        "wi",
+        [value0, value1],
+        units=units,
+        attr=attr,
+        open_lower=open_lower,
+        open_upper=open_upper,
     )
 
 
@@ -2592,10 +2600,6 @@ def seasons(n=4, start=12):
 
     .. seealso:: `cf.year`, `cf.month`, `cf.day`, `cf.hour`, `cf.minute`,
                  `cf.second`, `cf.djf`, `cf.mam`, `cf.jja`, `cf.son`
-
-    TODO
-
-    .. seealso:: `cf.mam`, `cf.jja`, `cf.son`, `cf.djf`
 
     :Parameters:
 

--- a/cf/query.py
+++ b/cf/query.py
@@ -855,6 +855,8 @@ class Query:
             "_operator",
             "_rtol",
             "_atol",
+            "_open_lower",
+            "_open_upper",
         ):
             x = getattr(self, attr, None)
             y = getattr(other, attr, None)

--- a/cf/query.py
+++ b/cf/query.py
@@ -916,13 +916,15 @@ class Query:
 
             open_lower, open_upper = self._open_bounds
             if open_lower:
-                lower_bound = (x > value[0])
+                lower_bound = x > value[0]
             else:
-                lower_bound = (x >= value[0])
+                lower_bound = x >= value[0]
+
             if open_upper:
-                upper_bound = (x < value[1])
+                upper_bound = x < value[1]
             else:
-                upper_bound = (x <= value[1])
+                upper_bound = x <= value[1]
+
             return lower_bound & upper_bound
 
         if operator == "eq":

--- a/cf/query.py
+++ b/cf/query.py
@@ -494,6 +494,7 @@ class Query:
         repr_value = str(self._value)
         if self.open_lower:
             repr_value = "(" + repr_value[1:]
+
         if self.open_upper:
             repr_value = repr_value[:-1] + ")"
 

--- a/cf/query.py
+++ b/cf/query.py
@@ -461,8 +461,23 @@ class Query:
         attr = ".".join(self._attr)
         operator = self._operator
         compound = self._compound
+
+        # For "wi" queries only, open intervals are supported. For "wi" _value
+        # is a list of two values, with representation from string list form
+        # of '[a, b]' which corresponds to the standard mathematical notation
+        # for a closed interval, the default. For a (half-)open interval need
+        # square bracket(s) -> parenthesis(/es), so unpack to adjust the repr.
+        repr_value = str(self._value)
+        if True in self._open_bounds:  # that is, at least one side is open
+            open_lower, open_upper = self._open_bounds
+            if open_lower:
+                repr_value = "(" + repr_value[1:]
+            if open_upper:
+                repr_value = repr_value[:-1] + ")"
+
         if not compound:
-            out = f"{attr}({operator} {self._value!s}"
+            print(self._value, type(self._value))
+            out = f"{attr}({operator} {repr_value}"
             rtol = self.rtol
             if rtol is not None:
                 out += f" rtol={rtol}"

--- a/cf/test/test_Query.py
+++ b/cf/test/test_Query.py
@@ -510,7 +510,7 @@ class QueryTest(unittest.TestCase):
         e1 = c0 | d1     # interval: [2, 4] | (6, 8]
         e2 = c1 | d2    # interval: (2, 4] | [6, 8)
         e3 = d3 | c3    # interval: (6, 8) | (2, 4)
-        ex = [e, e1, e2, e3]
+        all_e = [e, e1, e2, e3]
 
         for cx in all_c:
             self.assertTrue(cx.evaluate(3))

--- a/cf/test/test_Query.py
+++ b/cf/test/test_Query.py
@@ -494,12 +494,28 @@ class QueryTest(unittest.TestCase):
             self.assertNotEqual(cf.set([3, 8, 11]), x)
 
         c = cf.wi(2, 4)
+        c0 = cf.wi(2, 4, open_lower=False)  # equivalent to c, to check default
+        c1 = cf.wi(2, 4, open_lower=True)
+        c2 = cf.wi(2, 4, open_upper=True)
+        c3 = cf.wi(2, 4, open_lower=True, open_upper=True)
+        all_c = [c, c0, c1, c2, c3]
+
         d = cf.wi(6, 8)
+        d0 = cf.wi(2, 4, open_lower=False)  # equivalent to d, to check default
+        d1 = cf.wi(2, 4, open_lower=True)
+        d2 = cf.wi(2, 4, open_upper=True)
+        d3 = cf.wi(2, 4, open_lower=True, open_upper=True)
+        all_d = [d, d0, d1, d2, d3]
 
-        e = d | c
+        e = d | c       # interval: [2, 4] | [6, 8]
+        e1 = c | d1     # interval: [2, 4] | (6, 8]
+        e2 = c1 | d2    # interval: (2, 4] | [6, 8)
+        e3 = c3 | d3    # interval: (2, 4) | (6, 8)
+        e4 = d | c2     # interval: [6, 8] | [2, 4)
 
-        self.assertTrue(c.evaluate(3))
-        self.assertFalse(c.evaluate(5))
+        for cx in all_c:
+            self.assertTrue(cx.evaluate(3))
+            self.assertFalse(cx.evaluate(5))
 
         self.assertTrue(e.evaluate(3))
         self.assertTrue(e.evaluate(7))

--- a/cf/test/test_Query.py
+++ b/cf/test/test_Query.py
@@ -68,6 +68,9 @@ class QueryTest(unittest.TestCase):
         self.assertTrue(u.equals(u.copy(), verbose=2))
         self.assertFalse(u.equals(t, verbose=0))
 
+        self.assertTrue(q.equals(q.copy()))
+        self.assertTrue(
+            q.equals(cf.wi(2, 5, open_lower=False, open_upper=False)))
         self.assertFalse(q.equals(v))
         self.assertFalse(q.equals(w))
         self.assertFalse(q.equals(x))

--- a/cf/test/test_Query.py
+++ b/cf/test/test_Query.py
@@ -705,8 +705,8 @@ class QueryTest(unittest.TestCase):
             cf.wo(2, 5, attr="day") | cf.set(cf.Data([1, 2], "km")),
             cf.eq(8) | cf.lt(9) & cf.ge(10),
             cf.isclose(1, "days", rtol=10, atol=99),
-            cf.wi(-5, 5, "days", open_lower=True),
-            cf.wi(-5, 5, "days", open_lower=True, open_upper=True),
+            cf.wi(-5, 5, open_lower=True),
+            cf.wi(-5, 5, open_lower=True, open_upper=True),
         ):
             self.assertEqual(tokenize(q), tokenize(q.copy()))
 
@@ -717,24 +717,37 @@ class QueryTest(unittest.TestCase):
         self.assertNotEqual(
             tokenize(cf.isclose(9)), tokenize(cf.isclose(9, rtol=10))
         )
+
         self.assertNotEqual(
-            tokenize(
-                cf.wi(-5, 5, "days", open_lower=True),
-                cf.wi(-5, 5, "days")
-            )
+            tokenize(cf.wi(-5, 5, open_lower=True)),
+            tokenize(cf.wi(-5, 5))
         )
         self.assertNotEqual(
-            tokenize(
-                cf.wi(-5, 5, "days", open_upper=True),
-                cf.wi(-5, 5, "days")
-            )
+            tokenize(cf.wi(-5, 5, open_upper=True)),
+            tokenize(cf.wi(-5, 5))
         )
         self.assertNotEqual(
-            tokenize(
-                cf.wi(-5, 5, "days", open_lower=True, open_upper=True),
-                cf.wi(-5, 5, "days", open_upper=True)
-            )
+            tokenize(cf.wi(-5, 5, open_upper=True)),
+            tokenize(cf.wi(-5, 5, open_lower=True))
         )
+        self.assertNotEqual(
+            tokenize(cf.wi(-5, 5, open_lower=True, open_upper=True)),
+            tokenize(cf.wi(-5, 5))
+        )
+        self.assertNotEqual(
+            tokenize(cf.wi(-5, 5, open_lower=True, open_upper=True)),
+            tokenize(cf.wi(-5, 5, open_lower=True))
+        )
+        self.assertNotEqual(
+            tokenize(cf.wi(-5, 5, open_lower=True, open_upper=True)),
+            tokenize(cf.wi(-5, 5, open_upper=True))
+        )
+        # Check defaults
+        self.assertEqual(
+            tokenize(cf.wi(-5, 5, open_lower=False, open_upper=False)),
+            tokenize(cf.wi(-5, 5))
+        )
+
 
     def test_Query_Units(self):
         self.assertEqual(cf.eq(9).Units, cf.Units())

--- a/cf/test/test_Query.py
+++ b/cf/test/test_Query.py
@@ -507,17 +507,16 @@ class QueryTest(unittest.TestCase):
         d3 = cf.wi(2, 4, open_lower=True, open_upper=True)
 
         e = d | c       # interval: [2, 4] | [6, 8]
-        e1 = c | d1     # interval: [2, 4] | (6, 8]
+        e1 = c0 | d1     # interval: [2, 4] | (6, 8]
         e2 = c1 | d2    # interval: (2, 4] | [6, 8)
-        e3 = c3 | d3    # interval: (2, 4) | (6, 8)
-        e4 = d | c2     # interval: [6, 8] | [2, 4)
-        ex = [e, e1, e2, e3, e4]
+        e3 = d3 | c3    # interval: (6, 8) | (2, 4)
+        ex = [e, e1, e2, e3]
 
         for cx in all_c:
             self.assertTrue(cx.evaluate(3))
             self.assertFalse(cx.evaluate(5))
 
-        # Test the 2 open_* keywords for direct (non-compound) queries
+        # Test the two open_* keywords for direct (non-compound) queries
         self.assertEqual(c.evaluate(2), c0.evaluate(2))
         self.assertTrue(c0.evaluate(2))
         self.assertFalse(c1.evaluate(2))
@@ -533,6 +532,27 @@ class QueryTest(unittest.TestCase):
             self.assertTrue(e.evaluate(3))
             self.assertTrue(e.evaluate(7))
             self.assertFalse(e.evaluate(5))
+
+        # Test the two open_* keywords for compound queries.
+        # Must be careful to capture correct openness/closure of any inner
+        # bounds introduced through compound queries, e.g. for 'e' there
+        # are internal endpoints at 4 and 6 to behave like in 'c' and 'd'.
+        self.assertTrue(e.evaluate(2))
+        self.assertTrue(e1.evaluate(2))
+        self.assertFalse(e2.evaluate(2))
+        self.assertFalse(e3.evaluate(2))
+        self.assertTrue(e.evaluate(4))
+        self.assertTrue(e1.evaluate(4))
+        self.assertTrue(e2.evaluate(4))
+        self.assertFalse(e3.evaluate(4))
+        self.assertTrue(e.evaluate(6))
+        self.assertFalse(e1.evaluate(6))
+        self.assertTrue(e2.evaluate(6))
+        self.assertFalse(e3.evaluate(6))
+        self.assertTrue(e.evaluate(8))
+        self.assertTrue(e1.evaluate(8))
+        self.assertFalse(e2.evaluate(8))
+        self.assertFalse(e3.evaluate(8))
 
         self.assertEqual(3, c)
         self.assertNotEqual(5, c)

--- a/cf/test/test_Query.py
+++ b/cf/test/test_Query.py
@@ -505,21 +505,34 @@ class QueryTest(unittest.TestCase):
         d1 = cf.wi(2, 4, open_lower=True)
         d2 = cf.wi(2, 4, open_upper=True)
         d3 = cf.wi(2, 4, open_lower=True, open_upper=True)
-        all_d = [d, d0, d1, d2, d3]
 
         e = d | c       # interval: [2, 4] | [6, 8]
         e1 = c | d1     # interval: [2, 4] | (6, 8]
         e2 = c1 | d2    # interval: (2, 4] | [6, 8)
         e3 = c3 | d3    # interval: (2, 4) | (6, 8)
         e4 = d | c2     # interval: [6, 8] | [2, 4)
+        ex = [e, e1, e2, e3, e4]
 
         for cx in all_c:
             self.assertTrue(cx.evaluate(3))
             self.assertFalse(cx.evaluate(5))
 
-        self.assertTrue(e.evaluate(3))
-        self.assertTrue(e.evaluate(7))
-        self.assertFalse(e.evaluate(5))
+        # Test the 2 open_* keywords for direct (non-compound) queries
+        self.assertEqual(c.evaluate(2), c0.evaluate(2))
+        self.assertTrue(c0.evaluate(2))
+        self.assertFalse(c1.evaluate(2))
+        self.assertTrue(c2.evaluate(2))
+        self.assertFalse(c3.evaluate(2))
+        self.assertEqual(c.evaluate(4), c0.evaluate(4))
+        self.assertTrue(c0.evaluate(4))
+        self.assertTrue(c1.evaluate(4))
+        self.assertFalse(c2.evaluate(4))
+        self.assertFalse(c3.evaluate(4))
+
+        for ex in all_e:
+            self.assertTrue(e.evaluate(3))
+            self.assertTrue(e.evaluate(7))
+            self.assertFalse(e.evaluate(5))
 
         self.assertEqual(3, c)
         self.assertNotEqual(5, c)

--- a/cf/test/test_Query.py
+++ b/cf/test/test_Query.py
@@ -36,16 +36,26 @@ class QueryTest(unittest.TestCase):
         s = q | r
         t = cf.Query("gt", 12, attr="bounds")
         u = s & t
+        v = cf.wi(2, 5, open_lower=True)
+        w = cf.wi(2, 5, open_upper=True)
+        x = cf.wi(2, 5, open_lower=True, open_upper=True)
 
         repr(q)
-        repr(s)
+        ###repr(s)
         repr(t)
-        repr(u)
+        ###repr(u)
         str(q)
-        str(s)
+        ###str(s)
         str(t)
-        str(u)
-        u.dump(display=False)
+        ### str(u)
+        ###u.dump(display=False)
+
+        # For "wi", check repr. provides correct notation for open/closed-ness
+        # of the interval captured.
+        self.assertEqual(repr(q), "<CF Query: (wi [2, 5])>")
+        self.assertEqual(repr(v), "<CF Query: (wi (2, 5])>")
+        self.assertEqual(repr(w), "<CF Query: (wi [2, 5))>")
+        self.assertEqual(repr(x), "<CF Query: (wi (2, 5))>")
 
         u.attr
         u.operator

--- a/cf/test/test_Query.py
+++ b/cf/test/test_Query.py
@@ -68,6 +68,12 @@ class QueryTest(unittest.TestCase):
         self.assertTrue(u.equals(u.copy(), verbose=2))
         self.assertFalse(u.equals(t, verbose=0))
 
+        self.assertFalse(q.equals(v))
+        self.assertFalse(q.equals(w))
+        self.assertFalse(q.equals(x))
+        self.assertFalse(v.equals(w))
+        self.assertFalse(v.equals(x))
+
         copy.deepcopy(u)
 
         c = self.f.dimension_coordinate("X")

--- a/cf/test/test_Query.py
+++ b/cf/test/test_Query.py
@@ -41,14 +41,14 @@ class QueryTest(unittest.TestCase):
         x = cf.wi(2, 5, open_lower=True, open_upper=True)
 
         repr(q)
-        ###repr(s)
+        repr(s)
         repr(t)
-        ###repr(u)
+        repr(u)
         str(q)
-        ###str(s)
+        str(s)
         str(t)
-        ### str(u)
-        ###u.dump(display=False)
+        str(u)
+        u.dump(display=False)
 
         # For "wi", check repr. provides correct notation for open/closed-ness
         # of the interval captured.

--- a/cf/test/test_Query.py
+++ b/cf/test/test_Query.py
@@ -705,6 +705,8 @@ class QueryTest(unittest.TestCase):
             cf.wo(2, 5, attr="day") | cf.set(cf.Data([1, 2], "km")),
             cf.eq(8) | cf.lt(9) & cf.ge(10),
             cf.isclose(1, "days", rtol=10, atol=99),
+            cf.wi(-5, 5, "days", open_lower=True),
+            cf.wi(-5, 5, "days", open_lower=True, open_upper=True),
         ):
             self.assertEqual(tokenize(q), tokenize(q.copy()))
 
@@ -714,6 +716,24 @@ class QueryTest(unittest.TestCase):
         )
         self.assertNotEqual(
             tokenize(cf.isclose(9)), tokenize(cf.isclose(9, rtol=10))
+        )
+        self.assertNotEqual(
+            tokenize(
+                cf.wi(-5, 5, "days", open_lower=True),
+                cf.wi(-5, 5, "days")
+            )
+        )
+        self.assertNotEqual(
+            tokenize(
+                cf.wi(-5, 5, "days", open_upper=True),
+                cf.wi(-5, 5, "days")
+            )
+        )
+        self.assertNotEqual(
+            tokenize(
+                cf.wi(-5, 5, "days", open_lower=True, open_upper=True),
+                cf.wi(-5, 5, "days", open_upper=True)
+            )
         )
 
     def test_Query_Units(self):

--- a/cf/test/test_Query.py
+++ b/cf/test/test_Query.py
@@ -70,7 +70,8 @@ class QueryTest(unittest.TestCase):
 
         self.assertTrue(q.equals(q.copy()))
         self.assertTrue(
-            q.equals(cf.wi(2, 5, open_lower=False, open_upper=False)))
+            q.equals(cf.wi(2, 5, open_lower=False, open_upper=False))
+        )
         self.assertFalse(q.equals(v))
         self.assertFalse(q.equals(w))
         self.assertFalse(q.equals(x))
@@ -525,10 +526,10 @@ class QueryTest(unittest.TestCase):
         d2 = cf.wi(6, 8, open_upper=True)
         d3 = cf.wi(6, 8, open_lower=True, open_upper=True)
 
-        e = d | c       # interval: [2, 4] | [6, 8]
-        e1 = c0 | d1    # interval: [2, 4] | (6, 8]
-        e2 = c1 | d2    # interval: (2, 4] | [6, 8)
-        e3 = d3 | c3    # interval: (6, 8) | (2, 4)
+        e = d | c  # interval: [2, 4] | [6, 8]
+        e1 = c0 | d1  # interval: [2, 4] | (6, 8]
+        e2 = c1 | d2  # interval: (2, 4] | [6, 8)
+        e3 = d3 | c3  # interval: (6, 8) | (2, 4)
         all_e = [e, e1, e2, e3]
 
         for cx in all_c:
@@ -728,35 +729,32 @@ class QueryTest(unittest.TestCase):
         )
 
         self.assertNotEqual(
+            tokenize(cf.wi(-5, 5, open_lower=True)), tokenize(cf.wi(-5, 5))
+        )
+        self.assertNotEqual(
+            tokenize(cf.wi(-5, 5, open_upper=True)), tokenize(cf.wi(-5, 5))
+        )
+        self.assertNotEqual(
+            tokenize(cf.wi(-5, 5, open_upper=True)),
             tokenize(cf.wi(-5, 5, open_lower=True)),
-            tokenize(cf.wi(-5, 5))
         )
         self.assertNotEqual(
+            tokenize(cf.wi(-5, 5, open_lower=True, open_upper=True)),
+            tokenize(cf.wi(-5, 5)),
+        )
+        self.assertNotEqual(
+            tokenize(cf.wi(-5, 5, open_lower=True, open_upper=True)),
+            tokenize(cf.wi(-5, 5, open_lower=True)),
+        )
+        self.assertNotEqual(
+            tokenize(cf.wi(-5, 5, open_lower=True, open_upper=True)),
             tokenize(cf.wi(-5, 5, open_upper=True)),
-            tokenize(cf.wi(-5, 5))
-        )
-        self.assertNotEqual(
-            tokenize(cf.wi(-5, 5, open_upper=True)),
-            tokenize(cf.wi(-5, 5, open_lower=True))
-        )
-        self.assertNotEqual(
-            tokenize(cf.wi(-5, 5, open_lower=True, open_upper=True)),
-            tokenize(cf.wi(-5, 5))
-        )
-        self.assertNotEqual(
-            tokenize(cf.wi(-5, 5, open_lower=True, open_upper=True)),
-            tokenize(cf.wi(-5, 5, open_lower=True))
-        )
-        self.assertNotEqual(
-            tokenize(cf.wi(-5, 5, open_lower=True, open_upper=True)),
-            tokenize(cf.wi(-5, 5, open_upper=True))
         )
         # Check defaults
         self.assertEqual(
             tokenize(cf.wi(-5, 5, open_lower=False, open_upper=False)),
-            tokenize(cf.wi(-5, 5))
+            tokenize(cf.wi(-5, 5)),
         )
-
 
     def test_Query_Units(self):
         self.assertEqual(cf.eq(9).Units, cf.Units())

--- a/cf/test/test_Query.py
+++ b/cf/test/test_Query.py
@@ -501,13 +501,13 @@ class QueryTest(unittest.TestCase):
         all_c = [c, c0, c1, c2, c3]
 
         d = cf.wi(6, 8)
-        d0 = cf.wi(2, 4, open_lower=False)  # equivalent to d, to check default
-        d1 = cf.wi(2, 4, open_lower=True)
-        d2 = cf.wi(2, 4, open_upper=True)
-        d3 = cf.wi(2, 4, open_lower=True, open_upper=True)
+        d0 = cf.wi(6, 8, open_lower=False)  # equivalent to d, to check default
+        d1 = cf.wi(6, 8, open_lower=True)
+        d2 = cf.wi(6, 8, open_upper=True)
+        d3 = cf.wi(6, 8, open_lower=True, open_upper=True)
 
         e = d | c       # interval: [2, 4] | [6, 8]
-        e1 = c0 | d1     # interval: [2, 4] | (6, 8]
+        e1 = c0 | d1    # interval: [2, 4] | (6, 8]
         e2 = c1 | d2    # interval: (2, 4] | [6, 8)
         e3 = d3 | c3    # interval: (6, 8) | (2, 4)
         all_e = [e, e1, e2, e3]


### PR DESCRIPTION
Close  #740, where we have come to realise that it might not be a good idea to support the feature for `wo` queries since there is the potential for a lot of confusion, namely I started to document and implement the following behaviour:

> open_lower: `bool`, optional
>              If True, open the interval at the lower
>              bound so that value0 is excluded from the
>              range and therefore included in the set of
>              values outside of the range captured by "wo".
>              By default the interval is closed so that
>              value0 is included in the range and not
>              captured by "wo".

and @davidhassell and I decided it might be too confusing when applied to "outside a range" as opposed to "inside a range", where it is quite intuitive. So I will update the Issue description accordingly.
