### PR TITLE
Fix bug in `cf.aggregate` that sometimes put a null transpose operation into the Dask grpah when one was not needed

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -24,6 +24,9 @@ version NEXT
 * Fix bug in `cf.read` when reading UM files that caused LBPROC value
   131072 (Mean over an ensemble of parallel runs) to be ignored
   (https://github.com/NCAS-CMS/cf-python/issues/737)
+* Fix bug in `cf.aggregate` that sometimes put a null transpose
+  operation into the Dask grpah when one was not needed
+  (https://github.com/NCAS-CMS/cf-python/issues/754)
 
 ----
 

--- a/cf/aggregate.py
+++ b/cf/aggregate.py
@@ -4817,7 +4817,7 @@ def _aggregate_2_fields(
 
         # Ensure that the axis orders are the same in both fields
         transpose_axes1 = [dim0_name_map[axis0] for axis0 in data_axes0]
-        if transpose_axes1 != data_axes1:
+        if transpose_axes1 != list(data_axes1):
             parent1.transpose(transpose_axes1, inplace=True)
 
         construct_type = parent0.construct_type


### PR DESCRIPTION
Fixes #754 