### PR TITLE
Override `del_construct` to update cyclic axes set when due

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -27,6 +27,9 @@ version 3.16.2
 * Fix bug in `cf.aggregate` that sometimes put a null transpose
   operation into the Dask graph when one was not needed
   (https://github.com/NCAS-CMS/cf-python/issues/754)
+* Fix bug whereby `Field.cyclic` is not updated after a
+  `Field.del_construct` operation
+  (https://github.com/NCAS-CMS/cf-python/issues/758)
 
 ----
 

--- a/cf/mixin/fielddomain.py
+++ b/cf/mixin/fielddomain.py
@@ -2418,7 +2418,7 @@ class FieldDomain:
         removed even if it is referenced by coordinate reference
         construct.
 
-        .. versionadded:: 3.16.2
+        .. versionadded:: NEXTVERSION
 
         .. seealso:: `get_construct`, `constructs`, `has_construct`,
                      `set_construct`
@@ -2445,7 +2445,7 @@ class FieldDomain:
 
             {{filter_kwargs: optional}}
 
-                .. versionadded:: (cfdm) 1.8.9.0
+                .. versionadded:: NEXTVERSION
 
         :Returns:
 

--- a/cf/mixin/fielddomain.py
+++ b/cf/mixin/fielddomain.py
@@ -2490,8 +2490,13 @@ class FieldDomain:
         cyclic_axes = self._cyclic.copy()
 
         deld_construct = super().del_construct(
-            *identity, default=default, **filter_kwargs
+            *identity, default=None, **filter_kwargs
         )
+        if deld_construct is None:
+            if default is None:
+                return
+                
+            return self._default(default, "Can't find unique construct to remove")
 
         # If the construct deleted was a cyclic axes, remove it from the set
         # of stored cyclic axes, to update that appropriately. Do this

--- a/cf/mixin/fielddomain.py
+++ b/cf/mixin/fielddomain.py
@@ -2509,6 +2509,8 @@ class FieldDomain:
                     f"({key}), so it was removed from the cyclic() axes set."
                 )
 
+        return deld_construct
+
     def set_coordinate_reference(
         self, coordinate_reference, key=None, parent=None, strict=True
     ):

--- a/cf/mixin/fielddomain.py
+++ b/cf/mixin/fielddomain.py
@@ -2490,7 +2490,8 @@ class FieldDomain:
         cyclic_axes = self._cyclic.copy()
 
         deld_construct = super().del_construct(
-            *identity, default=default, **filter_kwargs)
+            *identity, default=default, **filter_kwargs
+        )
 
         # If the construct deleted was a cyclic axes, remove it from the set
         # of stored cyclic axes, to update that appropriately. Do this
@@ -2499,13 +2500,13 @@ class FieldDomain:
         if key in cyclic_axes:
             # The below is to test that the construct was successfully deleted
             if isinstance(default, Exception) or (
-                    not isinstance(default, Exception)
-                    and deld_construct != default
+                not isinstance(default, Exception)
+                and deld_construct != default
             ):
                 cyclic_axes.remove(key)
                 self._cyclic = cyclic_axes
                 logger.info(
-                "Deleted a construct that corresponds to a cyclic axis "
+                    "Deleted a construct that corresponds to a cyclic axis "
                     f"({key}), so it was removed from the cyclic() axes set."
                 )
 

--- a/cf/mixin/fielddomain.py
+++ b/cf/mixin/fielddomain.py
@@ -2505,10 +2505,6 @@ class FieldDomain:
             ):
                 cyclic_axes.remove(key)
                 self._cyclic = cyclic_axes
-                logger.info(
-                    "Deleted a construct that corresponds to a cyclic axis "
-                    f"({key}), so it was removed from the cyclic() axes set."
-                )
 
         return deld_construct
 

--- a/cf/mixin/fielddomain.py
+++ b/cf/mixin/fielddomain.py
@@ -2408,6 +2408,107 @@ class FieldDomain:
         # Return the construct key
         return out
 
+    def del_construct(self, *identity, default=ValueError(), **filter_kwargs):
+        """Remove a metadata construct.
+
+        If a domain axis construct is selected for removal then it
+        can't be spanned by any data arrays of the field nor metadata
+        constructs, nor be referenced by any cell method
+        constructs. However, a domain ancillary construct may be
+        removed even if it is referenced by coordinate reference
+        construct.
+
+        .. versionadded:: 3.16.2
+
+        .. seealso:: `get_construct`, `constructs`, `has_construct`,
+                     `set_construct`
+
+        :Parameters:
+
+            identity:
+                Select the unique construct that has the identity,
+                defined by its `!identities` method, that matches the
+                given values.
+
+                Additionally, the values are matched against construct
+                identifiers, with or without the ``'key%'`` prefix.
+
+                {{value match}}
+
+                {{displayed identity}}
+
+            default: optional
+                Return the value of the *default* parameter if the
+                data axes have not been set.
+
+                {{default Exception}}
+
+            {{filter_kwargs: optional}}
+
+                .. versionadded:: (cfdm) 1.8.9.0
+
+        :Returns:
+
+                The removed metadata construct.
+
+        **Examples**
+
+        >>> f = {{package}}.example_field(0)
+        >>> print(f)
+        Field: specific_humidity (ncvar%q)
+        ----------------------------------
+        Data            : specific_humidity(latitude(5), longitude(8)) 1
+        Cell methods    : area: mean
+        Dimension coords: latitude(5) = [-75.0, ..., 75.0] degrees_north
+                        : longitude(8) = [22.5, ..., 337.5] degrees_east
+                        : time(1) = [2019-01-01 00:00:00]
+        >>> f.del_construct('time')
+        <{{repr}}DimensionCoordinate: time(1) days since 2018-12-01 >
+        >>> f.del_construct('time')
+        Traceback (most recent call last):
+            ...
+        ValueError: Can't find unique construct to remove
+        >>> f.del_construct('time', default='No time')
+        'No time'
+        >>> f.del_construct('dimensioncoordinate1')
+        <{{repr}}DimensionCoordinate: longitude(8) degrees_east>
+        >>> print(f)
+        Field: specific_humidity (ncvar%q)
+        ----------------------------------
+        Data            : specific_humidity(latitude(5), ncdim%lon(8)) 1
+        Cell methods    : area: mean
+        Dimension coords: latitude(5) = [-75.0, ..., 75.0] degrees_north
+
+        """
+        # Need to re-define to overload this method since cfdm doesn't
+        # have the concept of cyclic axes, so have to update the
+        # register of cyclic axes when we delete a construct in cf.
+
+        # Get the relevant key first because it will be lost upon deletion.
+        key = self.construct_key(*identity, default=None, **filter_kwargs)
+        # Copy since should never change value of _cyclic attribute in-place
+        cyclic_axes = self._cyclic.copy()
+
+        deld_construct = super().del_construct(
+            *identity, default=default, **filter_kwargs)
+
+        # If the construct deleted was a cyclic axes, remove it from the set
+        # of stored cyclic axes, to update that appropriately. Do this
+        # afterwards because the deletion might not be successful and don't
+        # want to update the cyclic() set unless we know the deletion occurred.
+        if key in cyclic_axes:
+            # The below is to test that the construct was successfully deleted
+            if isinstance(default, Exception) or (
+                    not isinstance(default, Exception)
+                    and deld_construct != default
+            ):
+                cyclic_axes.remove(key)
+                self._cyclic = cyclic_axes
+                logger.info(
+                "Deleted a construct that corresponds to a cyclic axis "
+                    f"({key}), so it was removed from the cyclic() axes set."
+                )
+
     def set_coordinate_reference(
         self, coordinate_reference, key=None, parent=None, strict=True
     ):

--- a/cf/test/test_Domain.py
+++ b/cf/test/test_Domain.py
@@ -393,8 +393,8 @@ class DomainTest(unittest.TestCase):
 
     def test_Domain_del_construct(self):
         """Test the `del_construct` Domain method."""
-        # Test a field without cyclic axes. These are equivalent tests to those
-        # in the cfdm test suite, to check the behaviour is the same in cf.
+        # Test a domain without cyclic axes. These are equivalent tests to
+        # those in the cfdm test suite, to check behaviour is the same in cf.
         d = self.d.copy()
 
         self.assertIsInstance(
@@ -414,7 +414,7 @@ class DomainTest(unittest.TestCase):
             d.del_construct("measure:area"), cf.CellMeasure
         )
 
-        # Test a field with cyclic axes, to ensure the cyclic() set is
+        # Test a domain with cyclic axes, to ensure the cyclic() set is
         # updated accordingly if a cyclic axes is the one removed.
         e = cf.example_field(2).domain  # this has a cyclic axes 'domainaxis2'
         # To delete a cyclic axes, must first delete this dimension coordinate

--- a/cf/test/test_Domain.py
+++ b/cf/test/test_Domain.py
@@ -391,6 +391,42 @@ class DomainTest(unittest.TestCase):
             np.allclose(latitude_specific.array - y_points_specific, 0)
         )
 
+    def test_Domain_del_construct(self):
+        """Test the `del_construct` Domain method."""
+        # Test a field without cyclic axes. These are equivalent tests to those
+        # in the cfdm test suite, to check the behaviour is the same in cf.
+        d = self.d.copy()
+
+        self.assertIsInstance(
+            d.del_construct("dimensioncoordinate1"), cf.DimensionCoordinate
+        )
+        self.assertIsInstance(
+            d.del_construct("auxiliarycoordinate1"), cf.AuxiliaryCoordinate
+        )
+        with self.assertRaises(ValueError):
+            d.del_construct("auxiliarycoordinate1")
+
+        self.assertIsNone(
+            d.del_construct("auxiliarycoordinate1", default=None)
+        )
+
+        self.assertIsInstance(
+            d.del_construct("measure:area"), cf.CellMeasure
+        )
+
+        # Test a field with cyclic axes, to ensure the cyclic() set is
+        # updated accordingly if a cyclic axes is the one removed.
+        e = cf.example_field(2).domain  # this has a cyclic axes 'domainaxis2'
+        # To delete a cyclic axes, must first delete this dimension coordinate
+        # because 'domainaxis2' spans it.
+        self.assertIsInstance(
+            e.del_construct("dimensioncoordinate2"), cf.DimensionCoordinate
+        )
+        self.assertEqual(e.cyclic(), set(("domainaxis2",)))
+        self.assertIsInstance(
+            e.del_construct("domainaxis2"), cf.DomainAxis
+        )
+        self.assertEqual(e.cyclic(), set())
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())

--- a/cf/test/test_Domain.py
+++ b/cf/test/test_Domain.py
@@ -410,9 +410,7 @@ class DomainTest(unittest.TestCase):
             d.del_construct("auxiliarycoordinate1", default=None)
         )
 
-        self.assertIsInstance(
-            d.del_construct("measure:area"), cf.CellMeasure
-        )
+        self.assertIsInstance(d.del_construct("measure:area"), cf.CellMeasure)
 
         # NOTE: this test will fail presently because of a bug which means
         # that Field.domain doesn't inherit the cyclic() axes of the
@@ -427,10 +425,9 @@ class DomainTest(unittest.TestCase):
             e.del_construct("dimensioncoordinate2"), cf.DimensionCoordinate
         )
         self.assertEqual(e.cyclic(), set(("domainaxis2",)))
-        self.assertIsInstance(
-            e.del_construct("domainaxis2"), cf.DomainAxis
-        )
+        self.assertIsInstance(e.del_construct("domainaxis2"), cf.DomainAxis)
         self.assertEqual(e.cyclic(), set())
+
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())

--- a/cf/test/test_Domain.py
+++ b/cf/test/test_Domain.py
@@ -414,6 +414,10 @@ class DomainTest(unittest.TestCase):
             d.del_construct("measure:area"), cf.CellMeasure
         )
 
+        # NOTE: this test will fail presently because of a bug which means
+        # that Field.domain doesn't inherit the cyclic() axes of the
+        # corresponding Field (see Issue #762) which will be fixed shortly.
+        #
         # Test a domain with cyclic axes, to ensure the cyclic() set is
         # updated accordingly if a cyclic axes is the one removed.
         e = cf.example_field(2).domain  # this has a cyclic axes 'domainaxis2'

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -2594,7 +2594,19 @@ class FieldTest(unittest.TestCase):
             f.del_construct("measure:area"), cf.CellMeasure
         )
 
-        # TODO test cyclic nature
+        # Test a field with cyclic axes, to ensure the cyclic() set is
+        # updated accordingly if a cyclic axes is the one removed.
+        g = cf.example_field(2)  # this has a cyclic axes 'domainaxis2'
+        # To delete a cyclic axes, must first delete this dimension coordinate
+        # because 'domainaxis2' spans it.
+        self.assertIsInstance(
+            g.del_construct("dimensioncoordinate2"), cf.DimensionCoordinate
+        )
+        self.assertEqual(g.cyclic(), set(("domainaxis2",)))
+        self.assertIsInstance(
+            g.del_construct("domainaxis2"), cf.DomainAxis
+        )
+        self.assertEqual(g.cyclic(), set())
 
     def test_Field_persist(self):
         """Test the `persist` Field method."""

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -2577,7 +2577,6 @@ class FieldTest(unittest.TestCase):
         # Test a field without cyclic axes. These are equivalent tests to those
         # in the cfdm test suite, to check the behaviour is the same in cf.
         f = self.f1.copy()
-        print(f.cyclic())
 
         self.assertIsInstance(
             f.del_construct("auxiliarycoordinate1"), cf.AuxiliaryCoordinate

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -2572,6 +2572,30 @@ class FieldTest(unittest.TestCase):
         cm2 = f.cell_method("method:maximum")
         self.assertEqual(cm2.get_axes(), ("T",))
 
+    def test_Field_del_construct(self):
+        """Test the `del_construct` Field method."""
+        # Test a field without cyclic axes. These are equivalent tests to those
+        # in the cfdm test suite, to check the behaviour is the same in cf.
+        f = self.f1.copy()
+        print(f.cyclic())
+
+        self.assertIsInstance(
+            f.del_construct("auxiliarycoordinate1"), cf.AuxiliaryCoordinate
+        )
+
+        with self.assertRaises(ValueError):
+            f.del_construct("auxiliarycoordinate1")
+
+        self.assertIsNone(
+            f.del_construct("auxiliarycoordinate1", default=None)
+        )
+
+        self.assertIsInstance(
+            f.del_construct("measure:area"), cf.CellMeasure
+        )
+
+        # TODO test cyclic nature
+
     def test_Field_persist(self):
         """Test the `persist` Field method."""
         f = cf.example_field(0)

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -2589,9 +2589,7 @@ class FieldTest(unittest.TestCase):
             f.del_construct("auxiliarycoordinate1", default=None)
         )
 
-        self.assertIsInstance(
-            f.del_construct("measure:area"), cf.CellMeasure
-        )
+        self.assertIsInstance(f.del_construct("measure:area"), cf.CellMeasure)
 
         # Test a field with cyclic axes, to ensure the cyclic() set is
         # updated accordingly if a cyclic axes is the one removed.
@@ -2602,9 +2600,7 @@ class FieldTest(unittest.TestCase):
             g.del_construct("dimensioncoordinate2"), cf.DimensionCoordinate
         )
         self.assertEqual(g.cyclic(), set(("domainaxis2",)))
-        self.assertIsInstance(
-            g.del_construct("domainaxis2"), cf.DomainAxis
-        )
+        self.assertIsInstance(g.del_construct("domainaxis2"), cf.DomainAxis)
         self.assertEqual(g.cyclic(), set())
 
     def test_Field_persist(self):


### PR DESCRIPTION
Fix #758 and #756 (the former being the underlying issue and the latter a specific bug as a downstream effect) by overriding the `del_construct` inherited from cfdm to account for and update the store of `cyclic` axes. Previously we used the inherited method as-is so cyclic axes weren't updated and could get out of sync, notably contain axes which no longer existed due to deletion.

Note:
* The test `test_Domain_del_construct` added here will currently fail halfway-through due to #762, as noted in the test. I am fixing that next.
* I will add a note of two to the code in anticipation of some comments in review, for discussion.
