### PR TITLE
Override `cfdm.Field.get_domain` to store axes cyclicity

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -35,6 +35,9 @@ version 3.16.2
 * Fix bug whereby `Field.cyclic` is not updated after a
   `Field.del_construct` operation
   (https://github.com/NCAS-CMS/cf-python/issues/758)
+* Fix bug that meant `cyclic()` always returned an empty
+  set for domains produced by `cf.Field.domain`
+  (https://github.com/NCAS-CMS/cf-python/issues/762)
 
 ----
 

--- a/cf/field.py
+++ b/cf/field.py
@@ -2691,6 +2691,30 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
             for c in self.constructs.filter_by_data(todict=True).values():
                 c.cfa_update_file_substitutions(substitutions)
 
+    def get_domain(self):
+        """Return the domain.
+
+        .. versionadded:: NEXTVERSION
+
+        .. seealso:: `domain`
+
+        :Returns:
+
+            `Domain`
+                 The domain.
+
+        **Examples**
+
+        >>> d = f.get_domain()
+
+        """
+        domain = super().get_domain()
+
+        # Set axis cyclicity for the domain
+        domain._cyclic = self._cyclic
+
+        return domain
+
     def radius(self, default=None):
         """Return the radius of a latitude-longitude plane defined in
         spherical polar coordinates.

--- a/cf/field.py
+++ b/cf/field.py
@@ -10479,9 +10479,9 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                     new_bounds[0 : length - lower_offset, 1:] = old_bounds[
                         lower_offset:length, 1:
                     ]
-                    new_bounds[
-                        length - lower_offset : length, 1:
-                    ] = old_bounds[length - 1, 1:]
+                    new_bounds[length - lower_offset : length, 1:] = (
+                        old_bounds[length - 1, 1:]
+                    )
 
                 coord.set_bounds(self._Bounds(data=new_bounds))
 

--- a/cf/mixin/fielddomain.py
+++ b/cf/mixin/fielddomain.py
@@ -1909,7 +1909,7 @@ class FieldDomain:
     def cyclic(
         self, *identity, iscyclic=True, period=None, config={}, **filter_kwargs
     ):
-        """Set the cyclicity of an axis.
+        """Get or set the cyclicity of an axis.
 
         .. versionadded:: 1.0
 

--- a/cf/mixin/propertiesdata.py
+++ b/cf/mixin/propertiesdata.py
@@ -2934,7 +2934,7 @@ class PropertiesData(Properties):
         return data.count_masked()
 
     def cyclic(self, axes=None, iscyclic=True):
-        """Set the cyclicity of an axis.
+        """Get or set the cyclicity of an axis.
 
         .. seealso:: `iscyclic`
 

--- a/cf/mixin/propertiesdatabounds.py
+++ b/cf/mixin/propertiesdatabounds.py
@@ -1607,7 +1607,7 @@ class PropertiesDataBounds(PropertiesData):
         )
 
     def cyclic(self, axes=None, iscyclic=True):
-        """Set the cyclicity of axes of the data array.
+        """Get or set the cyclicity of axes of the data array.
 
         .. seealso:: `iscyclic`
 

--- a/cf/test/test_Domain.py
+++ b/cf/test/test_Domain.py
@@ -439,24 +439,23 @@ class DomainTest(unittest.TestCase):
         # Getting
         self.assertEqual(d1.cyclic(), f1.cyclic())
         self.assertEqual(d1.cyclic(), set())
-        self.assertFalse(d1.iscyclic('X'))
-        self.assertFalse(d1.iscyclic('Y'))
-        self.assertFalse(d1.iscyclic('Z'))
-        self.assertFalse(d1.iscyclic('T'))
+        self.assertFalse(d1.iscyclic("X"))
+        self.assertFalse(d1.iscyclic("Y"))
+        self.assertFalse(d1.iscyclic("Z"))
+        self.assertFalse(d1.iscyclic("T"))
         self.assertEqual(d2.cyclic(), f2.cyclic())
         self.assertEqual(d2.cyclic(), set(("domainaxis2",)))
-        self.assertTrue(d2.iscyclic('X'))
-        self.assertFalse(d2.iscyclic('Y'))
-        self.assertFalse(d2.iscyclic('Z'))
-        self.assertFalse(d2.iscyclic('T'))
+        self.assertTrue(d2.iscyclic("X"))
+        self.assertFalse(d2.iscyclic("Y"))
+        self.assertFalse(d2.iscyclic("Z"))
+        self.assertFalse(d2.iscyclic("T"))
 
         # Setting
-        self.assertEqual(
-            d2.cyclic('X', iscyclic=False), set(("domainaxis2",)))
+        self.assertEqual(d2.cyclic("X", iscyclic=False), set(("domainaxis2",)))
         self.assertEqual(d2.cyclic(), set())
-        self.assertEqual(d2.cyclic('X', period=360), set())
+        self.assertEqual(d2.cyclic("X", period=360), set())
         self.assertEqual(d2.cyclic(), set(("domainaxis2",)))
-        self.assertTrue(d2.iscyclic('X'))
+        self.assertTrue(d2.iscyclic("X"))
 
 
 if __name__ == "__main__":

--- a/cf/test/test_Domain.py
+++ b/cf/test/test_Domain.py
@@ -428,6 +428,36 @@ class DomainTest(unittest.TestCase):
         self.assertIsInstance(e.del_construct("domainaxis2"), cf.DomainAxis)
         self.assertEqual(e.cyclic(), set())
 
+    def test_Domain_cyclic_iscyclic(self):
+        """Test the `cyclic` and `iscyclic` Domain methods."""
+        # A field and its domain should have the same cyclic() output.
+        f1 = cf.example_field(1)  # no cyclic axes
+        d1 = f1.domain
+        f2 = cf.example_field(2)  # one cyclic axis, 'domainaxis2' ('X')
+        d2 = f2.domain
+
+        # Getting
+        self.assertEqual(d1.cyclic(), f1.cyclic())
+        self.assertEqual(d1.cyclic(), set())
+        self.assertFalse(d1.iscyclic('X'))
+        self.assertFalse(d1.iscyclic('Y'))
+        self.assertFalse(d1.iscyclic('Z'))
+        self.assertFalse(d1.iscyclic('T'))
+        self.assertEqual(d2.cyclic(), f2.cyclic())
+        self.assertEqual(d2.cyclic(), set(("domainaxis2",)))
+        self.assertTrue(d2.iscyclic('X'))
+        self.assertFalse(d2.iscyclic('Y'))
+        self.assertFalse(d2.iscyclic('Z'))
+        self.assertFalse(d2.iscyclic('T'))
+
+        # Setting
+        self.assertEqual(
+            d2.cyclic('X', iscyclic=False), set(("domainaxis2",)))
+        self.assertEqual(d2.cyclic(), set())
+        self.assertEqual(d2.cyclic('X', period=360), set())
+        self.assertEqual(d2.cyclic(), set(("domainaxis2",)))
+        self.assertTrue(d2.iscyclic('X'))
+
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -2866,23 +2866,22 @@ class FieldTest(unittest.TestCase):
 
         # Getting
         self.assertEqual(f1.cyclic(), set())
-        self.assertFalse(f1.iscyclic('X'))
-        self.assertFalse(f1.iscyclic('Y'))
-        self.assertFalse(f1.iscyclic('Z'))
-        self.assertFalse(f1.iscyclic('T'))
+        self.assertFalse(f1.iscyclic("X"))
+        self.assertFalse(f1.iscyclic("Y"))
+        self.assertFalse(f1.iscyclic("Z"))
+        self.assertFalse(f1.iscyclic("T"))
         self.assertEqual(f2.cyclic(), set(("domainaxis2",)))
-        self.assertTrue(f2.iscyclic('X'))
-        self.assertFalse(f2.iscyclic('Y'))
-        self.assertFalse(f2.iscyclic('Z'))
-        self.assertFalse(f2.iscyclic('T'))
+        self.assertTrue(f2.iscyclic("X"))
+        self.assertFalse(f2.iscyclic("Y"))
+        self.assertFalse(f2.iscyclic("Z"))
+        self.assertFalse(f2.iscyclic("T"))
 
         # Setting
-        self.assertEqual(
-            f2.cyclic('X', iscyclic=False), set(("domainaxis2",)))
+        self.assertEqual(f2.cyclic("X", iscyclic=False), set(("domainaxis2",)))
         self.assertEqual(f2.cyclic(), set())
-        self.assertEqual(f2.cyclic('X', period=360), set())
+        self.assertEqual(f2.cyclic("X", period=360), set())
         self.assertEqual(f2.cyclic(), set(("domainaxis2",)))
-        self.assertTrue(f2.iscyclic('X'))
+        self.assertTrue(f2.iscyclic("X"))
 
 
 if __name__ == "__main__":

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -2859,6 +2859,31 @@ class FieldTest(unittest.TestCase):
         self.assertEqual(g.shape, (6, 11))
         self.assertTrue(g[5, :].mask.all())
 
+    def test_Field_cyclic_iscyclic(self):
+        """Test the `cyclic` and `iscyclic` Field methods."""
+        f1 = cf.example_field(1)  # no cyclic axes
+        f2 = cf.example_field(2)  # one cyclic axis, 'domainaxis2' ('X')
+
+        # Getting
+        self.assertEqual(f1.cyclic(), set())
+        self.assertFalse(f1.iscyclic('X'))
+        self.assertFalse(f1.iscyclic('Y'))
+        self.assertFalse(f1.iscyclic('Z'))
+        self.assertFalse(f1.iscyclic('T'))
+        self.assertEqual(f2.cyclic(), set(("domainaxis2",)))
+        self.assertTrue(f2.iscyclic('X'))
+        self.assertFalse(f2.iscyclic('Y'))
+        self.assertFalse(f2.iscyclic('Z'))
+        self.assertFalse(f2.iscyclic('T'))
+
+        # Setting
+        self.assertEqual(
+            f2.cyclic('X', iscyclic=False), set(("domainaxis2",)))
+        self.assertEqual(f2.cyclic(), set())
+        self.assertEqual(f2.cyclic('X', period=360), set())
+        self.assertEqual(f2.cyclic(), set(("domainaxis2",)))
+        self.assertTrue(f2.iscyclic('X'))
+
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())


### PR DESCRIPTION
Fix #762. The reason for the underlying issue was that the `Field.domain` attribute called `get_domain` which was inherited from `cfdm`, which doesn't have the concept of cyclic axes. So quite similar in terms of cause to #763 (maybe we should check there aren't further cases of cyclic axes not being accounted for, in case other bugs might exist?).