### PR TITLE
Return a `FieldList` with `example_fields()`

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -1,3 +1,15 @@
+
+version NEXTRELEASE
+-------------------
+
+**2024-??-??**
+
+* Fix bug where `cf.example_fields` returned a `list`
+  of Fields rather than a `Fieldlist`
+  (https://github.com/NCAS-CMS/cf-python/issues/725)
+
+----
+
 version 3.16.2
 --------------
 

--- a/cf/examplefield.py
+++ b/cf/examplefield.py
@@ -1,6 +1,7 @@
 import cfdm
 
 from .cfimplementation import implementation
+from .fieldlist import FieldList
 
 _implementation = implementation()
 
@@ -13,7 +14,7 @@ example_field.__doc__ = cfdm.example_field.__doc__.replace("cfdm.", "cf.")
 
 
 def example_fields(*n, _func=example_field):
-    return cfdm.example_fields(*n, _func=_func)
+    return FieldList(cfdm.example_fields(*n, _func=_func))
 
 
 example_fields.__doc__ = cfdm.example_fields.__doc__.replace("cfdm.", "cf.")

--- a/cf/test/test_functions.py
+++ b/cf/test/test_functions.py
@@ -18,6 +18,7 @@ class functionTest(unittest.TestCase):
         self.test_only = ()
 
     def test_example_field(self):
+        self.assertIsInstance(cf.example_fields(), cf.FieldList)
         for f in cf.example_fields():
             f.dump(display=False)
 

--- a/cf/test/test_functions.py
+++ b/cf/test/test_functions.py
@@ -17,9 +17,12 @@ class functionTest(unittest.TestCase):
     def setUp(self):
         self.test_only = ()
 
-    def test_example_field(self):
-        self.assertIsInstance(cf.example_fields(), cf.FieldList)
-        for f in cf.example_fields():
+    def test_example_field_example_fields(self):
+        e = cf.example_fields()
+        self.assertIsInstance(e, cf.FieldList)
+
+        for f in e:
+            self.assertIsInstance(f, cf.Field)
             f.dump(display=False)
 
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Quick one to fix #725.