### PR TITLE
Correct finding coordrefs in `cf.aggregate`

### DIFF
--- a/cf/aggregate.py
+++ b/cf/aggregate.py
@@ -511,7 +511,7 @@ class _Meta:
                         "cf_role": None,
                         "hasdata": dim_coord.has_data(),
                         "hasbounds": hasbounds,
-                        "coordrefs": self.find_coordrefs(axis),
+                        "coordrefs": self.find_coordrefs(dim_coord_key),
                         "cellsize": cellsize,
                         "spacing": spacing,
                     }


### PR DESCRIPTION
A bit tricky to test, as I can't see a case where the bug isn't benign: If two fields have different coordinate references, then they won't  get aggregated anyway, regardless of whether or not any coordinate references are attached to dimension coordinates (which is the "bug")