### PR TITLE
Field combination

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -3,11 +3,18 @@ version NEXTVERSION
 
 **2024-??-??**
 
+* New method: `cf.Field.is_discrete_axis`
+  (https://github.com/NCAS-CMS/cf-python/issues/784)
 * Include the UM version as a field property when reading UM files
   (https://github.com/NCAS-CMS/cf-python/issues/777)
-* Fix bug where `cf.example_fields` returned a `list`
-  of Fields rather than a `Fieldlist`
+* Include the UM version as a field property when reading UM files
+  (https://github.com/NCAS-CMS/cf-python/issues/777)
+* Fix bug where `cf.example_fields` returned a `list` of Fields rather
+  than a `Fieldlist`
   (https://github.com/NCAS-CMS/cf-python/issues/725)
+* Fix bug where combining UGRID fields erroneously creates an extra
+  axis and broadcasts over it
+  (https://github.com/NCAS-CMS/cf-python/issues/784)
 * Fix bug where `cf.normalize_slice` doesn't correctly
   handle certain cyclic slices
   (https://github.com/NCAS-CMS/cf-python/issues/774)

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -7,8 +7,6 @@ version NEXTVERSION
   (https://github.com/NCAS-CMS/cf-python/issues/784)
 * Include the UM version as a field property when reading UM files
   (https://github.com/NCAS-CMS/cf-python/issues/777)
-* Include the UM version as a field property when reading UM files
-  (https://github.com/NCAS-CMS/cf-python/issues/777)
 * Fix bug where `cf.example_fields` returned a `list` of Fields rather
   than a `Fieldlist`
   (https://github.com/NCAS-CMS/cf-python/issues/725)

--- a/cf/cellmethod.py
+++ b/cf/cellmethod.py
@@ -486,8 +486,7 @@ class CellMethod(cfdm.CellMethod):
     @_deprecated_kwarg_check("i", version="3.0.0", removed_at="4.0.0")
     @_inplace_enabled(default=False)
     def change_axes(self, axis_map, inplace=False, i=False):
-        """Change the axes of the cell method according to a given
-        mapping.
+        """Replace the axes of the cell method.
 
         :Parameters:
 

--- a/cf/field.py
+++ b/cf/field.py
@@ -203,7 +203,7 @@ class _Axis_characterisation:
 
     """
 
-    # The size of the axis, a positive integer.
+    # The size of the axis, an integer.
     size: int = -1
     # The domain axis identifier. E.g. 'domainaxis0'
     axis: str = ""

--- a/cf/field.py
+++ b/cf/field.py
@@ -1,5 +1,4 @@
 import logging
-from collections import namedtuple
 from dataclasses import dataclass
 from functools import reduce
 from operator import mul as operator_mul

--- a/cf/field.py
+++ b/cf/field.py
@@ -1024,6 +1024,10 @@ class Field(mixin.FieldDomain, mixin.PropertiesData, cfdm.Field):
                             x[identity] = key
 
                     if x:
+                        # Get the sorted identities (sorted so that
+                        # they're comparable between fields) and their
+                        # corresponding keys.
+                        #
                         # E.g. {2:3, 4:6, 1:7} -> (1, 2, 4), (7, 3, 6)
                         identity, keys = tuple(zip(*sorted(x.items())))
                         coords = tuple(

--- a/cf/mixin/fielddomain.py
+++ b/cf/mixin/fielddomain.py
@@ -2364,7 +2364,7 @@ class FieldDomain:
 
         .. versionaddedd:: NEXTVERSION
 
-        .. seealso:: `domain_axis`
+        .. seealso:: `domain_axis`, `coordinates`
 
         :Parameters:
 

--- a/cf/mixin/fielddomain.py
+++ b/cf/mixin/fielddomain.py
@@ -2354,7 +2354,7 @@ class FieldDomain:
         correspond to a continuous physical quantity, but only the
         following types of discrete axis are identified here:
 
-        * The feature instance axis of a discreate sampling geometry
+        * The feature instance axis of a discrete sampling geometry
           (DSG) domain.
 
         * An axis spanned by the domain topology construct of an

--- a/cf/mixin/fielddomain.py
+++ b/cf/mixin/fielddomain.py
@@ -2347,6 +2347,98 @@ class FieldDomain:
 
         return axis in self.cyclic()
 
+    def is_discrete_axis(self, *identity, **filter_kwargs):
+        """Return True if the given axis is discrete.
+
+        In general, a discrete axis is any axis that does not
+        correspond to a continuous physical quantity, but only the
+        following types of discrete axis are identified here:
+
+        * The feature instance axis of a discreate sampling geometry
+          (DSG) domain.
+
+        * An axis spanned by the domain topology construct of an
+          unstructured grid.
+
+        * The axis with geometry cells.
+
+        .. versionaddedd:: NEXTVERSION
+
+        .. seealso:: `domain_axis`
+
+        :Parameters:
+
+            identity: `tuple`, optional
+                Select domain axis constructs that have an identity,
+                defined by their `!identities` methods, that matches
+                any of the given values.
+
+                Additionally, the values are matched against construct
+                identifiers, with or without the ``'key%'`` prefix.
+
+                Additionally, if for a given ``value``,
+                ``f.coordinates(value, filter_by_naxes=(1,))`` returns
+                1-d coordinate constructs that all span the same
+                domain axis construct then that domain axis construct
+                is selected. See `coordinates` for details.
+
+                Additionally, if there is a `Field` data array and a
+                value matches the integer position of an array
+                dimension, then the corresponding domain axis
+                construct is selected.
+
+                If no values are provided then all domain axis
+                constructs are selected.
+
+                {{value match}}
+
+                {{displayed identity}}
+
+            {{filter_kwargs: optional}}
+
+        **Examples**
+
+        >>> f = cf.example_{{class_lower}}(8)
+        >>> f.is_discrete_axis('X')
+        True
+        >>> f.is_discrete_axis('T')
+        False
+
+        """
+        # Get the axis key
+        axis = self.domain_axis(*identity, key=True, **filter_kwargs)
+
+        # DSG
+        if self.has_property("featureType") and not self.dimension_coordinate(
+            filter_by_axis=(axis,), default=False
+        ):
+            ctypes = ("X", "Y", "T")
+            n = 0
+            for aux in self.auxiliary_coordinates(
+                filter_by_axis=(axis,), axis_mode="and", todict=True
+            ).values():
+                if aux.ctype in ctypes:
+                    n += 1
+
+            if n == len(ctypes):
+                return True
+
+        # UGRID
+        if self.domain_topologies(
+            filter_by_axis=(axis,), axis_mode="exact", todict=True
+        ):
+            return True
+
+        # Geometries
+        for aux in self.auxiliary_coordinates(
+            filter_by_axis=(axis,), axis_mode="exact", todict=True
+        ).values():
+            if aux.get_geometry(None):
+                return True
+
+        # Still here? Then the axis is not discrete.
+        return False
+
     def match_by_rank(self, *ranks):
         """Whether or not the number of domain axis constructs satisfies
         conditions.

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -749,6 +749,11 @@ class FieldTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             f + ("a string",)
 
+        # Addition with a UGRID discrete axis
+        f = cf.example_field(8)
+        g = f + f
+        self.assertEqual(g.shape, f.shape)
+
     def test_Field__mul__(self):
         f = self.f.copy().squeeze()
 
@@ -2882,6 +2887,28 @@ class FieldTest(unittest.TestCase):
         self.assertEqual(f2.cyclic("X", period=360), set())
         self.assertEqual(f2.cyclic(), set(("domainaxis2",)))
         self.assertTrue(f2.iscyclic("X"))
+
+    def test_Field_is_discrete_axis(self):
+        """Test the `is_discrete_axis` Field method."""
+        # No discrete axes
+        f = cf.example_field(1)
+        for axis in f.domain_axes(todict=True):
+            self.assertFalse(f.is_discrete_axis(axis))
+
+        # UGRID
+        f = cf.example_field(8)
+        self.assertTrue(f.is_discrete_axis("X"))
+        self.assertFalse(f.is_discrete_axis("T"))
+
+        # DSG
+        f = cf.example_field(4)
+        self.assertTrue(f.is_discrete_axis("cf_role=timeseries_id"))
+        self.assertFalse(f.is_discrete_axis("ncdim%timeseries"))
+
+        # Geometries
+        f = cf.example_field(6)
+        self.assertTrue(f.is_discrete_axis("cf_role=timeseries_id"))
+        self.assertFalse(f.is_discrete_axis("time"))
 
 
 if __name__ == "__main__":

--- a/cf/test/test_functions.py
+++ b/cf/test/test_functions.py
@@ -389,24 +389,24 @@ class functionTest(unittest.TestCase):
             cf.normalize_slice(slice(2, 5, -2), 8, cyclic=True),
             slice(2, -3, -2),
         )
-        
+
         self.assertEqual(
             cf.normalize_slice(slice(-8, 0, 1), 8, cyclic=True),
-            slice(-8, 0, 1)
-            )
+            slice(-8, 0, 1),
+        )
         self.assertEqual(
             cf.normalize_slice(slice(0, 7, -1), 8, cyclic=True),
-            slice(0, -1, -1)
-            )        
+            slice(0, -1, -1),
+        )
         self.assertEqual(
             cf.normalize_slice(slice(-1, -8, 1), 8, cyclic=True),
-            slice(-1, 0, 1)
-            )
+            slice(-1, 0, 1),
+        )
         self.assertEqual(
             cf.normalize_slice(slice(-8, -1, -1), 8, cyclic=True),
-            slice(0, -1, -1)
-            )        
-        
+            slice(0, -1, -1),
+        )
+
         with self.assertRaises(IndexError):
             cf.normalize_slice([1, 2], 8)
 

--- a/docs/source/class/cf.Domain.rst
+++ b/docs/source/class/cf.Domain.rst
@@ -207,6 +207,7 @@ Domain axes
    ~cf.Domain.direction
    ~cf.Domain.directions
    ~cf.Domain.iscyclic
+   ~cf.Domain.is_discrete_axis
 
 Subspacing
 ----------

--- a/docs/source/class/cf.Field.rst
+++ b/docs/source/class/cf.Field.rst
@@ -518,6 +518,7 @@ Domain axes
    ~cf.Field.direction
    ~cf.Field.directions
    ~cf.Field.iscyclic
+   ~cf.Field.is_discrete_axis
    ~cf.Field.isperiodic
    ~cf.Field.item_axes
    ~cf.Field.items_axes


### PR DESCRIPTION
Fixes #784

### Notes

- The changes to `test_functions.py` are left-over linting from a previous PR.

- The changes to `cf.FIeld._binary_operation` look scarier than they are :). We've essentailly just moved from 2 cases (axis defined by dim coord, or axis defined by aux coord) to 3 cases (axis defined by dim coord, or axis defined by aux coord, or discrete axis), and the rest is largely just a bit code reorganisation around that (this is old and horrible code!)

- This doesn't do what we might hope for in the DSG discrete axis case, but that's not a fault of this code. In this case, it's doing the right thing with the discrete axes, but is the _non_-discrete axes that unexpected  broadcasting, because these axes have no identifying coordinates - that a sperate issue to be dealt with elsewhere.

