### PR TITLE
fixing a mistake in tutorial.rst

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -621,7 +621,7 @@ retrieved with the `~Field.properties` method:
 .. code-block:: python
    :caption: *Retrieve all of the descriptive properties*
 
-   >>> q, t = cf.read('file.nc')
+   >>> q, t = cf.read('file.nc')[1]
    >>> t.properties()
    {'Conventions': 'CF-1.11',
     'project': 'research',


### PR DESCRIPTION
'FieldList' object has no attribute 'properties' so I changed t = cf.read('file.nc') to t = cf.read('file.nc')[1]