### PR TITLE
Update links to point to new home of cf-plot documentation

### DIFF
--- a/cf/__init__.py
+++ b/cf/__init__.py
@@ -65,7 +65,7 @@ can:
 
 Powerful, flexible, and very simple to produce visualisations of field
 constructs uses the `cfplot` package
-(http://ajheaps.github.io/cf-plot), that is automatically installed
+(https://ncas-cms.github.io/cf-plot/build/), that is automatically installed
 along with with `cf`.
 
 See the :ref:`cf-python home page <cf-python-home>` for documentation,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -153,7 +153,7 @@ intersphinx_mapping = {
     "cftime": ("https://unidata.github.io/cftime", None),
     "cfunits": ("https://ncas-cms.github.io/cfunits", None),
     "cfdm": ("https://ncas-cms.github.io/cfdm", None),
-    "cfplot": ("https://ajheaps.github.io/cf-plot", None),
+    "cfplot": ("https://ncas-cms.github.io/cf-plot/build/", None),
     "dask": ("https://docs.dask.org/en/latest", None),
     "matplotlib": ("https://matplotlib.org/stable/", None),
 }

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -102,7 +102,7 @@ details.
 
 To install cf with all of its :ref:`required <Required>` and
 :ref:`optional <Optional>` dependencies, and the `cf-plot
-visualisation package <http://ajheaps.github.io/cf-plot>`_, run:
+visualisation package <https://ncas-cms.github.io/cf-plot/build/>`_, run:
 
 .. code-block:: console
    :caption: *Install with conda.*

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -116,10 +116,12 @@ manipulation and can:
 
 Powerful, flexible, and user-friendly visualisations of field
 constructs are available with the `cf-plot` package that is installed
-separately to `cf` (see http://ajheaps.github.io/cf-plot for details).
+separately to `cf` (see the
+`cf-plot documentation
+<https://ncas-cms.github.io/cf-plot/build/>`_ for details).
 
 See the `cf-plot gallery
-<http://ajheaps.github.io/cf-plot/gallery.html>`_ for the wide range
+<https://ncas-cms.github.io/cf-plot/build/gallery.html>`_ for the wide range
 of plotting possibilities with example code.
 
 .. figure:: images/cfplot_example.png

--- a/docs/source/recipes/plot_05_recipe.py
+++ b/docs/source/recipes/plot_05_recipe.py
@@ -44,7 +44,7 @@ pre = f3[0]
 print(pre)
 
 # %%
-# 4. Plot the wind vectors on top of precipitation data for June 1995 by creating a subspace with a date-time object and using `cfplot.con <http://ajheaps.github.io/cf-plot/con.html>`_. Here `cfplot.gopen <http://ajheaps.github.io/cf-plot/gopen.html>`_ is used to define the parts of the plot area, which is closed by `cfplot.gclose <http://ajheaps.github.io/cf-plot/gclose.html>`_; `cfplot.cscale <http://ajheaps.github.io/cf-plot/cscale.html>`_ is used to choose one of the colour maps amongst many available; `cfplot.levs <http://ajheaps.github.io/cf-plot/levs.html>`_ is used to set the contour levels for precipitation data; and `cfplot.vect <http://ajheaps.github.io/cf-plot/vect.html>`_ is used to plot the wind vectors for June 1995:
+# 4. Plot the wind vectors on top of precipitation data for June 1995 by creating a subspace with a date-time object and using `cfplot.con <https://ncas-cms.github.io/cf-plot/build/con.html>`_. Here `cfplot.gopen <https://ncas-cms.github.io/cf-plot/build/gopen.html>`_ is used to define the parts of the plot area, which is closed by `cfplot.gclose <https://ncas-cms.github.io/cf-plot/build/gclose.html>`_; `cfplot.cscale <https://ncas-cms.github.io/cf-plot/build/cscale.html>`_ is used to choose one of the colour maps amongst many available; `cfplot.levs <https://ncas-cms.github.io/cf-plot/build/levs.html>`_ is used to set the contour levels for precipitation data; and `cfplot.vect <https://ncas-cms.github.io/cf-plot/build/vect.html>`_ is used to plot the wind vectors for June 1995:
 june_95 = cf.year(1995) & cf.month(6)
 cfp.gopen()
 cfp.cscale("precip4_11lev")

--- a/docs/source/recipes/plot_06_recipe.py
+++ b/docs/source/recipes/plot_06_recipe.py
@@ -35,12 +35,12 @@ test = cf.dt(2051, 4, 14, 1, 30, 0, 0)
 print(test)
 
 # %%
-# 6. Plot the wind gust by creating a subspace for the specified variable ``test`` using `cfplot.con <http://ajheaps.github.io/cf-plot/con.html>`_. Here `cfplot.mapset <http://ajheaps.github.io/cf-plot/mapset.html>`_ is used to set the mapping parameters like setting the map resolution to 50m:
+# 6. Plot the wind gust by creating a subspace for the specified variable ``test`` using `cfplot.con <https://ncas-cms.github.io/cf-plot/build/con.html>`_. Here `cfplot.mapset <https://ncas-cms.github.io/cf-plot/build/mapset.html>`_ is used to set the mapping parameters like setting the map resolution to 50m:
 cfp.mapset(resolution="50m")
 cfp.con(gust.subspace(T=test), lines=False)
 
 # %%
-# 7. To see the rotated pole data on the native grid, the above steps are repeated and projection is set to rotated in `cfplot.mapset <http://ajheaps.github.io/cf-plot/mapset.html>`_:
+# 7. To see the rotated pole data on the native grid, the above steps are repeated and projection is set to rotated in `cfplot.mapset <https://ncas-cms.github.io/cf-plot/build/mapset.html>`_:
 cfp.mapset(resolution="50m", proj="rotated")
 cfp.con(gust.subspace(T=test), lines=False)
 

--- a/docs/source/recipes/plot_07_recipe.py
+++ b/docs/source/recipes/plot_07_recipe.py
@@ -38,7 +38,7 @@ print(ensemble)
 print(ensemble.constructs)
 
 # %%
-# 6. Loop over the realizations in the ensemble using the *range* function and the *domain_axis* to determine the size of the realization dimension. For each realization, extract a subspace of the ensemble using the *subspace* method and the ``'id%realization'`` keyword argument along a specific latitude and longitude and plot the realizations from the 4D field using `cfplot.lineplot <http://ajheaps.github.io/cf-plot/lineplot.html>`_.
+# 6. Loop over the realizations in the ensemble using the *range* function and the *domain_axis* to determine the size of the realization dimension. For each realization, extract a subspace of the ensemble using the *subspace* method and the ``'id%realization'`` keyword argument along a specific latitude and longitude and plot the realizations from the 4D field using `cfplot.lineplot <https://ncas-cms.github.io/cf-plot/build/lineplot.html>`_.
 # A moving average of the ensemble along the time axis, with a window size of 90 (i.e. an approximately 3-month moving average) is calculated using the *moving_window* method. The ``mode='nearest'`` parameter is used to specify how to pad the data outside of the time range. The *squeeze* method removes any dimensions of size 1 from the field to produce a 2D field:
 
 cfp.gopen()

--- a/docs/source/recipes/plot_08_recipe.py
+++ b/docs/source/recipes/plot_08_recipe.py
@@ -87,15 +87,15 @@ for start, end, prefix in time_periods:
     )
 
 # %%
-# 7. Create two plots - one for the 1850-2020 time period and another for the 1980-2020 time period using `cfplot.con <http://ajheaps.github.io/cf-plot/con.html>`_.
+# 7. Create two plots - one for the 1850-2020 time period and another for the 1980-2020 time period using `cfplot.con <https://ncas-cms.github.io/cf-plot/build/con.html>`_.
 # The results are multiplied by 10 so that each plot displays the temperature trend in K/decade with stippling to indicate areas where the trend is statistically significant (p-value < 0.05).
-# Here `cfplot.gopen <http://ajheaps.github.io/cf-plot/gopen.html>`_ is used to define the parts of the plot area with two rows and one column, and setting the bottom margin to 0.2.
-# It is closed by `cfplot.gclose <http://ajheaps.github.io/cf-plot/gclose.html>`_;
-# `cfplot.gpos <http://ajheaps.github.io/cf-plot/gpos.html>`_ is used to set the plotting position of both the plots;
-# `cfplot.mapset <http://ajheaps.github.io/cf-plot/mapset.html>`_ is used to set the map projection to Robinson;
-# `cfplot.cscale <http://ajheaps.github.io/cf-plot/cscale.html>`_ is used to choose one of the colour maps amongst many available;
-# `cfplot.levs <http://ajheaps.github.io/cf-plot/levs.html>`_ is used to set the contour levels;
-# and `cfplot.stipple <http://ajheaps.github.io/cf-plot/stipple.html>`_ is used to add stippling to show statistically significant areas:
+# Here `cfplot.gopen <https://ncas-cms.github.io/cf-plot/build/gopen.html>`_ is used to define the parts of the plot area with two rows and one column, and setting the bottom margin to 0.2.
+# It is closed by `cfplot.gclose <https://ncas-cms.github.io/cf-plot/build/gclose.html>`_;
+# `cfplot.gpos <https://ncas-cms.github.io/cf-plot/build/gpos.html>`_ is used to set the plotting position of both the plots;
+# `cfplot.mapset <https://ncas-cms.github.io/cf-plot/build/mapset.html>`_ is used to set the map projection to Robinson;
+# `cfplot.cscale <https://ncas-cms.github.io/cf-plot/build/cscale.html>`_ is used to choose one of the colour maps amongst many available;
+# `cfplot.levs <https://ncas-cms.github.io/cf-plot/build/levs.html>`_ is used to set the contour levels;
+# and `cfplot.stipple <https://ncas-cms.github.io/cf-plot/build/stipple.html>`_ is used to add stippling to show statistically significant areas:
 
 cfp.gopen(rows=2, columns=1, bottom=0.2)
 

--- a/docs/source/recipes/plot_10_recipe.py
+++ b/docs/source/recipes/plot_10_recipe.py
@@ -40,7 +40,7 @@ jan_2023 = cf.year(2023) & cf.month(1)
 # %%
 # 5. The relative vorticity is calculated using `cf.curl_xy
 # <https://ncas-cms.github.io/cf-python/function/cf.curl_xy.html>`_ and
-# plotted using `cfplot.con <http://ajheaps.github.io/cf-plot/con.html>`_.
+# plotted using `cfplot.con <https://ncas-cms.github.io/cf-plot/build/con.html>`_.
 # The ``with cf.relaxed_identities(True)`` context manager statement prevents
 # the curl opereration broadcasting across the two ``expver`` dimensions because
 # it can't be certain that they are the same as they lack the standardised

--- a/docs/source/recipes/plot_12_recipe.py
+++ b/docs/source/recipes/plot_12_recipe.py
@@ -77,8 +77,8 @@ high = aod.where(mask, cf.masked)
 # - `plt.suptitle <https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.suptitle.html>`_
 #   is used to add a title for the whole figure;
 # - the subplots for plotting are selected using
-#   `cfplot.gpos <https://ajheaps.github.io/cf-plot/gpos.html>`_ after which
-#   `cfplot.mapset <https://ajheaps.github.io/cf-plot/mapset.html>`_ is used to
+#   `cfplot.gpos <https://ncas-cms.github.io/cf-plot/build/gpos.html>`_ after which
+#   `cfplot.mapset <https://ncas-cms.github.io/cf-plot/build/mapset.html>`_ is used to
 #   set the map limits and resolution for the subplots;
 # - and as cf-plot stores the plot in a plot object with the name
 #   ``cfp.plotvars.plot``, country borders are added using normal

--- a/docs/source/recipes/plot_12_recipe.py
+++ b/docs/source/recipes/plot_12_recipe.py
@@ -43,7 +43,7 @@ lat = aod.coordinate("Y")
 
 # %%
 # 6. Plot the AOD for all the retrievals using
-# `cfplot.con <http://ajheaps.github.io/cf-plot/con.html>`_. Here the argument
+# `cfplot.con <https://ncas-cms.github.io/cf-plot/build/con.html>`_. Here the argument
 # ``'ptype'`` specifies the type of plot to use (latituide-longitude here) and
 # the argument ``'lines=False'`` does not draw contour lines:
 cfp.con(f=aod.array, x=lon.array, y=lat.array, ptype=1, lines=False)
@@ -68,12 +68,12 @@ high = aod.where(mask, cf.masked)
 
 # %%
 # 9. Now plot both the AOD from `high-quality` retrieval and all other retrievals
-# using `cfplot.con <http://ajheaps.github.io/cf-plot/con.html>`_. Here:
+# using `cfplot.con <https://ncas-cms.github.io/cf-plot/build/con.html>`_. Here:
 #
-# - `cfplot.gopen <http://ajheaps.github.io/cf-plot/gopen.html>`_ is used to
+# - `cfplot.gopen <https://ncas-cms.github.io/cf-plot/build/gopen.html>`_ is used to
 #   define the parts of the plot area, specifying that the figure should have
 #   1 row and 2 columns, which is closed by
-#   `cfplot.gclose <http://ajheaps.github.io/cf-plot/gclose.html>`_;
+#   `cfplot.gclose <https://ncas-cms.github.io/cf-plot/build/gclose.html>`_;
 # - `plt.suptitle <https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.suptitle.html>`_
 #   is used to add a title for the whole figure;
 # - the subplots for plotting are selected using

--- a/docs/source/recipes/plot_13_recipe.py
+++ b/docs/source/recipes/plot_13_recipe.py
@@ -38,16 +38,16 @@ region = sst.subspace(X=cf.wi(360 - 170, 360 - 120), Y=cf.wi(-5, 5))
 # %%
 # 5. Plot the various Niño regions using cf-plot. Here:
 #
-# - `cfplot.gopen <http://ajheaps.github.io/cf-plot/gopen.html>`_ is used to
+# - `cfplot.gopen <https://ncas-cms.github.io/cf-plot/build/gopen.html>`_ is used to
 #   define the parts of the plot area, which is closed by
-#   `cfplot.gclose <http://ajheaps.github.io/cf-plot/gclose.html>`_;
+#   `cfplot.gclose <https://ncas-cms.github.io/cf-plot/build/gclose.html>`_;
 # - `cfplot.mapset <https://ajheaps.github.io/cf-plot/mapset.html>`_ is used to
 #   set the map limits and projection;
-# - `cfplot.setvars <http://ajheaps.github.io/cf-plot/setvars.html>`_ is used to
+# - `cfplot.setvars <https://ncas-cms.github.io/cf-plot/build/setvars.html>`_ is used to
 #   set various attributes of the plot, like setting the land colour to grey;
-# - `cfplot.cscale <http://ajheaps.github.io/cf-plot/cscale.html>`_ is used to
+# - `cfplot.cscale <https://ncas-cms.github.io/cf-plot/build/cscale.html>`_ is used to
 #   choose one of the colour maps amongst many available;
-# - `cfplot.con <http://ajheaps.github.io/cf-plot/con.html>`_ plots contour data
+# - `cfplot.con <https://ncas-cms.github.io/cf-plot/build/con.html>`_ plots contour data
 #   from the ``region`` subspace at a specific time with no contour lines and a
 #   title;
 # - next, four Niño regions and labels are defined using
@@ -206,13 +206,13 @@ nino34_rolling = nino34_anomaly.moving_window(
 # El Niño and La Niña events. Now plot SST anomalies in the Niño 3.4 region over
 # time using cf-plot. Here:
 #
-# - `cfplot.gset <http://ajheaps.github.io/cf-plot/gset.html>`_ sets the limits
+# - `cfplot.gset <https://ncas-cms.github.io/cf-plot/build/gset.html>`_ sets the limits
 #   of the x-axis (years from 1940 to 2022) and y-axis (anomalies from -3
 #   degrees C to 3 degrees C) for the plot;
-# - `cfplot.gopen <http://ajheaps.github.io/cf-plot/gopen.html>`_ is used to
+# - `cfplot.gopen <https://ncas-cms.github.io/cf-plot/build/gopen.html>`_ is used to
 #   define the parts of the plot area, which is closed by
-#   `cfplot.gclose <http://ajheaps.github.io/cf-plot/gclose.html>`_;
-# - `cfplot.lineplot <http://ajheaps.github.io/cf-plot/lineplot.html>`_ plots
+#   `cfplot.gclose <https://ncas-cms.github.io/cf-plot/build/gclose.html>`_;
+# - `cfplot.lineplot <https://ncas-cms.github.io/cf-plot/build/lineplot.html>`_ plots
 #   the rolling Niño 3.4 index over time;
 # - a zero line and also horizontal dashed lines are drawn for El Niño and
 #   La Niña thresholds using

--- a/docs/source/recipes/plot_13_recipe.py
+++ b/docs/source/recipes/plot_13_recipe.py
@@ -41,7 +41,7 @@ region = sst.subspace(X=cf.wi(360 - 170, 360 - 120), Y=cf.wi(-5, 5))
 # - `cfplot.gopen <https://ncas-cms.github.io/cf-plot/build/gopen.html>`_ is used to
 #   define the parts of the plot area, which is closed by
 #   `cfplot.gclose <https://ncas-cms.github.io/cf-plot/build/gclose.html>`_;
-# - `cfplot.mapset <https://ajheaps.github.io/cf-plot/mapset.html>`_ is used to
+# - `cfplot.mapset <https://ncas-cms.github.io/cf-plot/build/mapset.html>`_ is used to
 #   set the map limits and projection;
 # - `cfplot.setvars <https://ncas-cms.github.io/cf-plot/build/setvars.html>`_ is used to
 #   set various attributes of the plot, like setting the land colour to grey;

--- a/docs/source/recipes/plot_14_recipe.py
+++ b/docs/source/recipes/plot_14_recipe.py
@@ -33,22 +33,22 @@ gph_july = gph.subspace(T=cf.month(7) & cf.year(2018)).squeeze()
 # %%
 # 5. Plot contour lines of this geopotential height for July 2018. Here:
 #
-# - `cfplot.gopen <http://ajheaps.github.io/cf-plot/gopen.html>`_ is used to
+# - `cfplot.gopen <https://ncas-cms.github.io/cf-plot/build/gopen.html>`_ is used to
 #   define the parts of the plot area, which is closed by
-#   `cfplot.gclose <http://ajheaps.github.io/cf-plot/gclose.html>`_;
+#   `cfplot.gclose <https://ncas-cms.github.io/cf-plot/build/gclose.html>`_;
 # - `cfplot.mapset <https://ajheaps.github.io/cf-plot/mapset.html>`_ is used to
 #   set the map projection to North Polar Stereographic;
-# - `cfplot.setvars <http://ajheaps.github.io/cf-plot/setvars.html>`_ is used to
+# - `cfplot.setvars <https://ncas-cms.github.io/cf-plot/build/setvars.html>`_ is used to
 #   set various attributes of the plot, like setting the thickness of the lines
 #   that represent continents;
-# - `cfplot.con <http://ajheaps.github.io/cf-plot/con.html>`_ plots the contour
+# - `cfplot.con <https://ncas-cms.github.io/cf-plot/build/con.html>`_ plots the contour
 #   lines representing the 200 hpa geopotential height values without filling
 #   between the contour lines (``fill=False``) and no colour bar
 #   (``colorbar=False``);
 # - `cfplot.levs <https://ajheaps.github.io/cf-plot/levs.html>`_ is used to
 #   specify two contour levels, 12000 and 12300 m, corresponding to the
 #   approximate polar-front jet and subtropical jet respectively;
-# - `cfplot.con <http://ajheaps.github.io/cf-plot/con.html>`_ is again used to
+# - `cfplot.con <https://ncas-cms.github.io/cf-plot/build/con.html>`_ is again used to
 #   plot the contour lines for polar-front jet and subtropical jet with a
 #   thicker line width;
 # - `cfp.plotvars.mymap.stock_img() <https://scitools.org.uk/cartopy/docs/v0.15/matplotlib/geoaxes.html#cartopy.mpl.geoaxes.GeoAxes.stock_img>`_
@@ -119,20 +119,20 @@ t2m_july_anomaly_2018 = (
 # provide an insight into the atmospheric conditions, the temperature anomalies
 # and the geopotential height contours are plotted using cf-plot. Here:
 #
-# - `cfplot.gopen <http://ajheaps.github.io/cf-plot/gopen.html>`_ is used to
+# - `cfplot.gopen <https://ncas-cms.github.io/cf-plot/build/gopen.html>`_ is used to
 #   define the parts of the plot area, which is closed by
-#   `cfplot.gclose <http://ajheaps.github.io/cf-plot/gclose.html>`_;
+#   `cfplot.gclose <https://ncas-cms.github.io/cf-plot/build/gclose.html>`_;
 # - `cfplot.mapset <https://ajheaps.github.io/cf-plot/mapset.html>`_ is used to
 #   set the map projection to Robinson;
-# - `cfplot.setvars <http://ajheaps.github.io/cf-plot/setvars.html>`_ is used to
+# - `cfplot.setvars <https://ncas-cms.github.io/cf-plot/build/setvars.html>`_ is used to
 #   set various attributes of the plot, like setting the thickness of the lines
 #   that represent continents and master title properties;
 # - `cfplot.levs <https://ajheaps.github.io/cf-plot/levs.html>`_ is used to
 #   specify the contour levels for temperature anomalies, starting from -2 to 2
 #   with an interval of 0.5;
-# - `cfplot.cscale <http://ajheaps.github.io/cf-plot/cscale.html>`_ is used to
+# - `cfplot.cscale <https://ncas-cms.github.io/cf-plot/build/cscale.html>`_ is used to
 #   choose one of the colour maps amongst many available;
-# - `cfplot.con <http://ajheaps.github.io/cf-plot/con.html>`_ plots contour fill
+# - `cfplot.con <https://ncas-cms.github.io/cf-plot/build/con.html>`_ plots contour fill
 #   of temperature anomalies without contour lines (``lines=False``);
 # - `cfplot.levs() <https://ajheaps.github.io/cf-plot/levs.html>`_ is used to
 #   reset contour levels to default after which the steps to plot the contour

--- a/docs/source/recipes/plot_14_recipe.py
+++ b/docs/source/recipes/plot_14_recipe.py
@@ -36,7 +36,7 @@ gph_july = gph.subspace(T=cf.month(7) & cf.year(2018)).squeeze()
 # - `cfplot.gopen <https://ncas-cms.github.io/cf-plot/build/gopen.html>`_ is used to
 #   define the parts of the plot area, which is closed by
 #   `cfplot.gclose <https://ncas-cms.github.io/cf-plot/build/gclose.html>`_;
-# - `cfplot.mapset <https://ajheaps.github.io/cf-plot/mapset.html>`_ is used to
+# - `cfplot.mapset <https://ncas-cms.github.io/cf-plot/build/mapset.html>`_ is used to
 #   set the map projection to North Polar Stereographic;
 # - `cfplot.setvars <https://ncas-cms.github.io/cf-plot/build/setvars.html>`_ is used to
 #   set various attributes of the plot, like setting the thickness of the lines
@@ -45,7 +45,7 @@ gph_july = gph.subspace(T=cf.month(7) & cf.year(2018)).squeeze()
 #   lines representing the 200 hpa geopotential height values without filling
 #   between the contour lines (``fill=False``) and no colour bar
 #   (``colorbar=False``);
-# - `cfplot.levs <https://ajheaps.github.io/cf-plot/levs.html>`_ is used to
+# - `cfplot.levs <https://ncas-cms.github.io/cf-plot/build/levs.html>`_ is used to
 #   specify two contour levels, 12000 and 12300 m, corresponding to the
 #   approximate polar-front jet and subtropical jet respectively;
 # - `cfplot.con <https://ncas-cms.github.io/cf-plot/build/con.html>`_ is again used to
@@ -122,19 +122,19 @@ t2m_july_anomaly_2018 = (
 # - `cfplot.gopen <https://ncas-cms.github.io/cf-plot/build/gopen.html>`_ is used to
 #   define the parts of the plot area, which is closed by
 #   `cfplot.gclose <https://ncas-cms.github.io/cf-plot/build/gclose.html>`_;
-# - `cfplot.mapset <https://ajheaps.github.io/cf-plot/mapset.html>`_ is used to
+# - `cfplot.mapset <https://ncas-cms.github.io/cf-plot/build/mapset.html>`_ is used to
 #   set the map projection to Robinson;
 # - `cfplot.setvars <https://ncas-cms.github.io/cf-plot/build/setvars.html>`_ is used to
 #   set various attributes of the plot, like setting the thickness of the lines
 #   that represent continents and master title properties;
-# - `cfplot.levs <https://ajheaps.github.io/cf-plot/levs.html>`_ is used to
+# - `cfplot.levs <https://ncas-cms.github.io/cf-plot/build/levs.html>`_ is used to
 #   specify the contour levels for temperature anomalies, starting from -2 to 2
 #   with an interval of 0.5;
 # - `cfplot.cscale <https://ncas-cms.github.io/cf-plot/build/cscale.html>`_ is used to
 #   choose one of the colour maps amongst many available;
 # - `cfplot.con <https://ncas-cms.github.io/cf-plot/build/con.html>`_ plots contour fill
 #   of temperature anomalies without contour lines (``lines=False``);
-# - `cfplot.levs() <https://ajheaps.github.io/cf-plot/levs.html>`_ is used to
+# - `cfplot.levs() <https://ncas-cms.github.io/cf-plot/build/levs.html>`_ is used to
 #   reset contour levels to default after which the steps to plot the contour
 #   lines representing the 200 hpa geopotential height values, the approximate
 #   polar-front jet and subtropical jet from Step 5 are repeated:

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -532,16 +532,16 @@ files <External-variables-with-cfa>`.
 
 Powerful, flexible, and user-friendly visualisations of field
 constructs are available with the `cf-plot` package (that needs to be
-installed separately to cf, see http://ajheaps.github.io/cf-plot for
-details).
+installed separately to cf, see `cf-plot documentation
+<https://ncas-cms.github.io/cf-plot/build/>`_ for details).
 
 .. figure:: images/cfplot_example.png
 
    *Example output of cf-plot displaying a cf field construct.*
 
-See the `cfplot gallery
-<http://ajheaps.github.io/cf-plot/gallery.html>`_ for the wide range
-of plotting possibilities, with example code. These include, but are
+See the `cf-plot gallery
+<https://ncas-cms.github.io/cf-plot/build/gallery.html>`_ for the wide
+range of plotting possibilities, with example code. These include, but are
 not limited to:
 
 * Cylindrical, polar stereographic and other plane projections

--- a/setup.py
+++ b/setup.py
@@ -157,11 +157,11 @@ Visualization
 
 Powerful, flexible, and very simple to produce visualizations of field
 constructs are available with the
-[cfplot](http://ajheaps.github.io/cf-plot) package, that needs to be
+[cfplot](https://ncas-cms.github.io/cf-plot/build/) package, that needs to be
 installed seprately to the ``cf`` package.
 
 See the `cfplot gallery
-<http://ajheaps.github.io/cf-plot/gallery.html>`_ for the full range
+<https://ncas-cms.github.io/cf-plot/build/gallery.html>`_ for the full range
 of plotting possibilities with example code.
 
 Functionality

--- a/setup.py
+++ b/setup.py
@@ -157,8 +157,8 @@ Visualization
 
 Powerful, flexible, and very simple to produce visualizations of field
 constructs are available with the
-[cfplot](https://ncas-cms.github.io/cf-plot/build/) package, that needs to be
-installed seprately to the ``cf`` package.
+`cf-plot <https://ncas-cms.github.io/cf-plot/build/>`_ package, that
+needs to be installed seprately to the ``cf`` package.
 
 See the `cfplot gallery
 <https://ncas-cms.github.io/cf-plot/build/gallery.html>`_ for the full range


### PR DESCRIPTION
As I realised when guiding our summer student this week, the cf-python documentation still links to the old cf-plot documentation under the 'ajheaps' userspace, except for the README. I had updated the README some months ago but neglected to do a full sweep of the codebase to update all references to the old cf-plot docs, so here is that mass update.

@davidhassell, feel free to just sanity check as a review since this is very self-contained, specific and non-controversial. Thanks.