### PR TITLE
Add new recipe (16) by summer student: projection subplots

### DIFF
--- a/docs/source/recipes/plot_16_recipe.py
+++ b/docs/source/recipes/plot_16_recipe.py
@@ -2,9 +2,8 @@
 Plotting contour subplots with different projections
 ====================================================
 
-In this recipe, we will plot different projections for the same
-data to illustrate visually the ones available in order to more
-visually decide which is suitable.
+In this recipe, we will plot the same data using different projections
+as subplots to illustrate visually some available possibilities.
 
 """
 
@@ -17,8 +16,7 @@ import cf
 
 # %%
 # 2. Read the field in:
-PATH = "~/git-repos/cf-plot/cfplot/test/cfplot_data"
-f = cf.read(f"{PATH}/ggap.nc")[0]
+f = cf.read("~/recipes/ggap.nc")[0]
 
 # %%
 # 3. Create the file with subplots. If changing the number of subplots,

--- a/docs/source/recipes/plot_16_recipe.py
+++ b/docs/source/recipes/plot_16_recipe.py
@@ -19,7 +19,8 @@ import cf
 # 2. Read the field in:
 # Here I've used sample data ggap.nc (and later pressure=850),
 # but you could use tas_A1.nc (with time=15)
-f = cf.read("~/cfplot_data/ggap.nc")[0]
+PATH = "~/git-repos/cf-plot/cfplot/test/cfplot_data"
+f = cf.read(f"{PATH}/ggap.nc")[0]
 
 # %%
 # 3. Create the file with subplots:
@@ -36,7 +37,9 @@ cfp.gopen(rows=2, columns=3, bottom=0.2, file="projections.png")
 # However you could also use other such as "rotated", "ortho" or
 # "merc", "ukcp", "osgb", or "EuroPP"
 # https://ncas-cms.github.io/cf-plot/build/user_guide.html#appendixc
-projtypes = ["cyl", "npstere", "spstere", "moll", "lcc", "robin"]
+# TODO SB update second 'cyl' to 'lcc', replaced for now due to possible bug,
+# see: https://github.com/NCAS-CMS/cf-plot/issues/75
+projtypes = ["cyl", "npstere", "spstere", "moll", "cyl", "robin"]
 
 # %%
 # 5. We then use a for loop to cycle through all the different projection

--- a/docs/source/recipes/plot_16_recipe.py
+++ b/docs/source/recipes/plot_16_recipe.py
@@ -1,6 +1,7 @@
 """
 Plotting Contour Subplots with different Projections
-============================================
+====================================================
+
 In this recipe, we will plot different projections for the same data to illustrate
 visually the ones available in order to more visually decide which is suitable.
 """
@@ -9,51 +10,61 @@ visually the ones available in order to more visually decide which is suitable.
 # 1. Import cf-python and cf-plot:
 
 import cfplot as cfp
-
 import cf
 
-#%%
+# %%
 # 2. Read the field in:
-# Here I've used sample data ggap.nc (and later pressure=850), 
+# Here I've used sample data ggap.nc (and later pressure=850),
 # but you could use tas_A1.nc (with time=15)
 
-f=cf.read("~/cfplot_data/ggap.nc")[0] 
+f = cf.read("~/cfplot_data/ggap.nc")[0]
 
-#%%
+# %%
 # 3. Create the file with subplots:
-# If you are changing the number of subplots ensure the number of rows * number 
+# If you are changing the number of subplots ensure the number of rows * number
 # of columns = the number of subplots/projections
 # Here we are doing 6 projections so 2x3 is fine
 
 cfp.gopen(rows=2, columns=3, bottom=0.2, file="projections.png")
 
-#%%
+# %%
 # 4. List the projection types being used:
-# Here we are using Cylindrical/Default, North Pole Stereographic, 
+# Here we are using Cylindrical/Default, North Pole Stereographic,
 # South Pole Stereographic, Mollweide, Cropped Lambert Conformal and Robinson
-# However you could also use other such as "rotated", "ortho" or 
+# However you could also use other such as "rotated", "ortho" or
 # "merc", "ukcp", "osgb", or "EuroPP"
 # https://ncas-cms.github.io/cf-plot/build/user_guide.html#appendixc
 
-projtypes = ["cyl", "npstere", "spstere", "moll", "lcc", "robin"] 
+projtypes = ["cyl", "npstere", "spstere", "moll", "lcc", "robin"]
 
-#%%
+# %%
 # 5. We then use a for loop to cycle through all the different projection types:
-# Only gpos has 1 added because it can only take 1 as its first value, otherwise there are 
+# Only gpos has 1 added because it can only take 1 as its first value, otherwise there are
 # errors. There are if statements for some projections (lcc, OSGB and EuroPP) as they have
 # specific requirements for their contour.
 # However, OSGB and EuroPP will require very different data anyway.
 
 for i, proj in enumerate(projtypes):
-    cfp.gpos(i+1) 
+    cfp.gpos(i + 1)
     if projtypes[i] == "lcc":
-        cfp.mapset(proj='lcc', lonmin=-50, lonmax=50, latmin=20, latmax=85)
-    if (projtypes[i]== "OSGB") or (projtypes[i] =="EuroPP"):
-        cfp.mapset(proj=projtypes[i], resolution='50m')
+        cfp.mapset(proj="lcc", lonmin=-50, lonmax=50, latmin=20, latmax=85)
+    if (projtypes[i] == "OSGB") or (projtypes[i] == "EuroPP"):
+        cfp.mapset(proj=projtypes[i], resolution="50m")
     else:
         cfp.mapset(proj=projtypes[i])
-    if i ==len(projtypes)-1:
-         cfp.con(f.subspace(pressure=850), lines=False, title = projtypes[i], colorbar_position=[0.1, 0.1, 0.8, 0.02], colorbar_orientation='horizontal') #to see the marking lines need to be True, but this can be hard to read so if not needed use False
+    if i == len(projtypes) - 1:
+        cfp.con(
+            f.subspace(pressure=850),
+            lines=False,
+            title=projtypes[i],
+            colorbar_position=[0.1, 0.1, 0.8, 0.02],
+            colorbar_orientation="horizontal",
+        )  # to see the marking lines need to be True, but this can be hard to read so if not needed use False
     else:
-        cfp.con(f.subspace(pressure=850), lines = False, title = projtypes[i], colorbar = False)
+        cfp.con(
+            f.subspace(pressure=850),
+            lines=False,
+            title=projtypes[i],
+            colorbar=False,
+        )
 cfp.gclose()

--- a/docs/source/recipes/plot_16_recipe.py
+++ b/docs/source/recipes/plot_16_recipe.py
@@ -1,49 +1,52 @@
 """
-Plotting Contour Subplots with different Projections
+Plotting contour subplots with different projections
 ====================================================
 
-In this recipe, we will plot different projections for the same data to illustrate
-visually the ones available in order to more visually decide which is suitable.
+In this recipe, we will plot different projections for the same
+data to illustrate visually the ones available in order to more
+visually decide which is suitable.
+
 """
 
 # %%
 # 1. Import cf-python and cf-plot:
 
 import cfplot as cfp
+
 import cf
 
 # %%
 # 2. Read the field in:
 # Here I've used sample data ggap.nc (and later pressure=850),
 # but you could use tas_A1.nc (with time=15)
-
 f = cf.read("~/cfplot_data/ggap.nc")[0]
 
 # %%
 # 3. Create the file with subplots:
-# If you are changing the number of subplots ensure the number of rows * number
-# of columns = the number of subplots/projections
+# If you are changing the number of subplots ensure the number of
+# rows * number of columns = the number of subplots/projections
 # Here we are doing 6 projections so 2x3 is fine
-
 cfp.gopen(rows=2, columns=3, bottom=0.2, file="projections.png")
 
 # %%
 # 4. List the projection types being used:
 # Here we are using Cylindrical/Default, North Pole Stereographic,
-# South Pole Stereographic, Mollweide, Cropped Lambert Conformal and Robinson
+# South Pole Stereographic, Mollweide, Cropped Lambert Conformal
+# and Robinson.
 # However you could also use other such as "rotated", "ortho" or
 # "merc", "ukcp", "osgb", or "EuroPP"
 # https://ncas-cms.github.io/cf-plot/build/user_guide.html#appendixc
-
 projtypes = ["cyl", "npstere", "spstere", "moll", "lcc", "robin"]
 
 # %%
-# 5. We then use a for loop to cycle through all the different projection types:
-# Only gpos has 1 added because it can only take 1 as its first value, otherwise there are
-# errors. There are if statements for some projections (lcc, OSGB and EuroPP) as they have
+# 5. We then use a for loop to cycle through all the different projection
+# types:
+# Only gpos has 1 added because it can only take 1 as its first value,
+# otherwise there are
+# errors. There are if statements for some projections (lcc, OSGB and
+# EuroPP) as they have
 # specific requirements for their contour.
 # However, OSGB and EuroPP will require very different data anyway.
-
 for i, proj in enumerate(projtypes):
     cfp.gpos(i + 1)
     if projtypes[i] == "lcc":
@@ -59,7 +62,9 @@ for i, proj in enumerate(projtypes):
             title=projtypes[i],
             colorbar_position=[0.1, 0.1, 0.8, 0.02],
             colorbar_orientation="horizontal",
-        )  # to see the marking lines need to be True, but this can be hard to read so if not needed use False
+        )
+        # to see the marking lines need to be True, but this can be
+        # hard to read so if not needed use False
     else:
         cfp.con(
             f.subspace(pressure=850),

--- a/docs/source/recipes/plot_16_recipe.py
+++ b/docs/source/recipes/plot_16_recipe.py
@@ -17,47 +17,32 @@ import cf
 
 # %%
 # 2. Read the field in:
-# Here I've used sample data ggap.nc (and later pressure=850),
-# but you could use tas_A1.nc (with time=15)
 PATH = "~/git-repos/cf-plot/cfplot/test/cfplot_data"
 f = cf.read(f"{PATH}/ggap.nc")[0]
 
 # %%
-# 3. Create the file with subplots:
-# If you are changing the number of subplots ensure the number of
-# rows * number of columns = the number of subplots/projections
-# Here we are doing 6 projections so 2x3 is fine
+# 3. Create the file with subplots. If changing the number of subplots,
+# ensure the number of rows * number of columns = the number of projections.
+# Here we are doing 6 projections so 2 x 3 is fine:
 cfp.gopen(rows=2, columns=3, bottom=0.2, file="projections.png")
 
 # %%
-# 4. List the projection types being used:
-# Here we are using Cylindrical/Default, North Pole Stereographic,
-# South Pole Stereographic, Mollweide, Cropped Lambert Conformal
-# and Robinson.
-# However you could also use other such as "rotated", "ortho" or
-# "merc", "ukcp", "osgb", or "EuroPP"
-# https://ncas-cms.github.io/cf-plot/build/user_guide.html#appendixc
-# TODO SB update second 'cyl' to 'lcc', replaced for now due to possible bug,
-# see: https://github.com/NCAS-CMS/cf-plot/issues/75
-projtypes = ["cyl", "npstere", "spstere", "moll", "cyl", "robin"]
+# 4. List the projection types to use. Here we are using
+# Cylindrical/Default, North Pole Stereographic, South Pole Stereographic,
+# Mollweide, Mercator and Robinson. However there are several other choices
+# possible, see:
+# https://ncas-cms.github.io/cf-plot/build/user_guide.html#appendixc. Our
+# chosen list is:
+projtypes = ["cyl", "npstere", "spstere", "moll", "merc", "robin"]
 
 # %%
-# 5. We then use a for loop to cycle through all the different projection
-# types:
-# Only gpos has 1 added because it can only take 1 as its first value,
-# otherwise there are
-# errors. There are if statements for some projections (lcc, OSGB and
-# EuroPP) as they have
-# specific requirements for their contour.
-# However, OSGB and EuroPP will require very different data anyway.
+# 5. Loop through the list of projection types and plot each as a sub-plot:
 for i, proj in enumerate(projtypes):
+    # gpos has 1 added to the index because it takes 1 as its first value
     cfp.gpos(i + 1)
-    if proj == "lcc":
-        cfp.mapset(proj="lcc", lonmin=-50, lonmax=50, latmin=20, latmax=85)
-    if proj in ("OSGB", "EuroPP"):
-        cfp.mapset(proj=proj, resolution="50m")
-    else:
-        cfp.mapset(proj=proj)
+    cfp.mapset(proj=proj)
+
+    # For the final plot only, add a colour bar to cover all the sub-plots
     if i == len(projtypes) - 1:
         cfp.con(
             f.subspace(pressure=850),
@@ -66,8 +51,6 @@ for i, proj in enumerate(projtypes):
             colorbar_position=[0.1, 0.1, 0.8, 0.02],
             colorbar_orientation="horizontal",
         )
-        # to see the marking lines need to be True, but this can be
-        # hard to read so if not needed use False
     else:
         cfp.con(
             f.subspace(pressure=850),

--- a/docs/source/recipes/plot_16_recipe.py
+++ b/docs/source/recipes/plot_16_recipe.py
@@ -1,0 +1,59 @@
+"""
+Plotting Contour Subplots with different Projections
+============================================
+In this recipe, we will plot different projections for the same data to illustrate
+visually the ones available in order to more visually decide which is suitable.
+"""
+
+# %%
+# 1. Import cf-python and cf-plot:
+
+import cfplot as cfp
+
+import cf
+
+#%%
+# 2. Read the field in:
+# Here I've used sample data ggap.nc (and later pressure=850), 
+# but you could use tas_A1.nc (with time=15)
+
+f=cf.read("~/cfplot_data/ggap.nc")[0] 
+
+#%%
+# 3. Create the file with subplots:
+# If you are changing the number of subplots ensure the number of rows * number 
+# of columns = the number of subplots/projections
+# Here we are doing 6 projections so 2x3 is fine
+
+cfp.gopen(rows=2, columns=3, bottom=0.2, file="projections.png")
+
+#%%
+# 4. List the projection types being used:
+# Here we are using Cylindrical/Default, North Pole Stereographic, 
+# South Pole Stereographic, Mollweide, Cropped Lambert Conformal and Robinson
+# However you could also use other such as "rotated", "ortho" or 
+# "merc", "ukcp", "osgb", or "EuroPP"
+# https://ncas-cms.github.io/cf-plot/build/user_guide.html#appendixc
+
+projtypes = ["cyl", "npstere", "spstere", "moll", "lcc", "robin"] 
+
+#%%
+# 5. We then use a for loop to cycle through all the different projection types:
+# Only gpos has 1 added because it can only take 1 as its first value, otherwise there are 
+# errors. There are if statements for some projections (lcc, OSGB and EuroPP) as they have
+# specific requirements for their contour.
+# However, OSGB and EuroPP will require very different data anyway.
+
+for i, proj in enumerate(projtypes):
+    cfp.gpos(i+1) 
+    if projtypes[i] == "lcc":
+        cfp.mapset(proj='lcc', lonmin=-50, lonmax=50, latmin=20, latmax=85)
+    if (projtypes[i]== "OSGB") or (projtypes[i] =="EuroPP"):
+        cfp.mapset(proj=projtypes[i], resolution='50m')
+    else:
+        cfp.mapset(proj=projtypes[i])
+    if i ==len(projtypes)-1:
+         cfp.con(f.subspace(pressure=850), lines=False, title = projtypes[i], colorbar_position=[0.1, 0.1, 0.8, 0.02], colorbar_orientation='horizontal') #to see the marking lines need to be True, but this can be hard to read so if not needed use False
+    else:
+        cfp.con(f.subspace(pressure=850), lines = False, title = projtypes[i], colorbar = False)
+cfp.gclose()

--- a/docs/source/recipes/plot_16_recipe.py
+++ b/docs/source/recipes/plot_16_recipe.py
@@ -52,17 +52,17 @@ projtypes = ["cyl", "npstere", "spstere", "moll", "cyl", "robin"]
 # However, OSGB and EuroPP will require very different data anyway.
 for i, proj in enumerate(projtypes):
     cfp.gpos(i + 1)
-    if projtypes[i] == "lcc":
+    if proj == "lcc":
         cfp.mapset(proj="lcc", lonmin=-50, lonmax=50, latmin=20, latmax=85)
-    if (projtypes[i] == "OSGB") or (projtypes[i] == "EuroPP"):
-        cfp.mapset(proj=projtypes[i], resolution="50m")
+    if proj in ("OSGB", "EuroPP"):
+        cfp.mapset(proj=proj, resolution="50m")
     else:
-        cfp.mapset(proj=projtypes[i])
+        cfp.mapset(proj=proj)
     if i == len(projtypes) - 1:
         cfp.con(
             f.subspace(pressure=850),
             lines=False,
-            title=projtypes[i],
+            title=proj,
             colorbar_position=[0.1, 0.1, 0.8, 0.02],
             colorbar_orientation="horizontal",
         )
@@ -72,7 +72,7 @@ for i, proj in enumerate(projtypes):
         cfp.con(
             f.subspace(pressure=850),
             lines=False,
-            title=projtypes[i],
+            title=proj,
             colorbar=False,
         )
 cfp.gclose()

--- a/docs/source/recipes/recipe_list.txt
+++ b/docs/source/recipes/recipe_list.txt
@@ -29,4 +29,4 @@ plot_14_recipe.html#sphx-glr-recipes-plot-14-recipe-py
 plot_15_recipe.html#sphx-glr-recipes-plot-15-recipe-py
 <div class="sphx-glr-thumbcontainer histogram subspace" tooltip="Histogram, Subspace, Subplot">
 plot_16_recipe.html#sphx-glr-recipes-plot-16-recipe-py
-<div class="sphx-glr-thumbcontainer histogram subspace" tooltip="Contourmap, Subspace, Subplot">
+<div class="sphx-glr-thumbcontainer contourmap subspace subplot" tooltip="Contourmap, Subspace, Subplot">

--- a/docs/source/recipes/recipe_list.txt
+++ b/docs/source/recipes/recipe_list.txt
@@ -28,3 +28,5 @@ plot_14_recipe.html#sphx-glr-recipes-plot-14-recipe-py
 <div class="sphx-glr-thumbcontainer subspace collapse contourmap" tooltip="Subspace, Collapse, Contourmap">
 plot_15_recipe.html#sphx-glr-recipes-plot-15-recipe-py
 <div class="sphx-glr-thumbcontainer histogram subspace" tooltip="Histogram, Subspace">
+plot_16_recipe.html#sphx-glr-recipes-plot-16-recipe-py
+<div class="sphx-glr-thumbcontainer histogram subspace" tooltip="Contourmap, Subspace">

--- a/docs/source/recipes/recipe_list.txt
+++ b/docs/source/recipes/recipe_list.txt
@@ -13,7 +13,7 @@ plot_06_recipe.html#sphx-glr-recipes-plot-06-recipe-py
 plot_07_recipe.html#sphx-glr-recipes-plot-07-recipe-py
 <div class="sphx-glr-thumbcontainer aggregate lineplot subspace" tooltip="Aggregate, Lineplot, Subspace">
 plot_08_recipe.html#sphx-glr-recipes-plot-08-recipe-py
-<div class="sphx-glr-thumbcontainer collapse contourmap" tooltip="Collapse, Contourmap">
+<div class="sphx-glr-thumbcontainer collapse contourmap" tooltip="Collapse, Contourmap, Subplot">
 plot_09_recipe.html#sphx-glr-recipes-plot-09-recipe-py
 <div class="sphx-glr-thumbcontainer histogram" tooltip="Histogram">
 plot_10_recipe.html#sphx-glr-recipes-plot-10-recipe-py
@@ -27,6 +27,6 @@ plot_13_recipe.html#sphx-glr-recipes-plot-13-recipe-py
 plot_14_recipe.html#sphx-glr-recipes-plot-14-recipe-py
 <div class="sphx-glr-thumbcontainer subspace collapse contourmap" tooltip="Subspace, Collapse, Contourmap">
 plot_15_recipe.html#sphx-glr-recipes-plot-15-recipe-py
-<div class="sphx-glr-thumbcontainer histogram subspace" tooltip="Histogram, Subspace">
+<div class="sphx-glr-thumbcontainer histogram subspace" tooltip="Histogram, Subspace, Subplot">
 plot_16_recipe.html#sphx-glr-recipes-plot-16-recipe-py
-<div class="sphx-glr-thumbcontainer histogram subspace" tooltip="Contourmap, Subspace">
+<div class="sphx-glr-thumbcontainer histogram subspace" tooltip="Contourmap, Subspace, Subplot">


### PR DESCRIPTION
This is the first of three recipes created this summer by our first summer student of two, Natalia. It has been prepared in the form consistent with the existing recipes.

I have only added the Python script - @bewithankit, I see four different files per recipe, is this one sufficient or do I need to generate the other three (`plot_N_recipe_codeobj.pickle`, `plot_N_recipe.ipynb` and `plot_N_recipe.rst`) from this for this PR, or can this be done at release time (or is the creation automatic from release r other procedures)? I will be adding the other five student-made recipes in the next few (working) days - all are in the same format as the canonical Python script.

Given the nature of recipes, the script itself should be self-contained and self-explanatory. But for context, I will add that, given the summer placement was only two weeks including time for making a poster, there wasn't time to do a full feedback round, so I have included some commits to Natalia's final script to apply linting including line wrapping; simplification of some logic and comment wording; and notably to replace one projection, 'lcc', with another, 'merc', because there is a bug with the former (see NCAS-CMS/cf-plot#75) which breaks the script, so to avoid that bug.


### Expected output

![projections](https://github.com/user-attachments/assets/39db01b4-1f61-4667-8f7a-3b27368a617e)

Note there is a cf-plot bug (yet another one, eek, NCAS-CMS/cf-plot#77) preventing us from disabling the axes for all plots, which would make everything consistent given some of the projections don't have default in-built axes labelling.