### PR TITLE
Fix bug where `cf.Field.subspace` doesn't always correctly handle   global cyclic subspaces

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -46,6 +46,9 @@ version NEXTVERSION
 * Fix bug where `cf.normalize_slice` doesn't correctly
   handle certain cyclic slices
   (https://github.com/NCAS-CMS/cf-python/issues/774)
+* Fix bug where `cf.Field.subspace` doesn't also correctly
+  handle some global cyclic subspaces
+  (https://github.com/NCAS-CMS/cf-python/issues/828)
 
 ----
 

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -34,7 +34,7 @@ version NEXTVERSION
   handle certain cyclic slices
   (https://github.com/NCAS-CMS/cf-python/issues/774)
 * Fix bug where `cf.Field.subspace` doesn't always correctly handle
-  global cyclic subspaces
+  global or near-global cyclic subspaces
   (https://github.com/NCAS-CMS/cf-python/issues/828)
 * New dependency: ``h5netcdf>=1.3.0``
 * New dependency: ``h5py>=3.10.0``

--- a/cf/cfimplementation.py
+++ b/cf/cfimplementation.py
@@ -26,7 +26,6 @@ from . import (
     TiePointIndex,
 )
 from .data import Data
-
 from .data.array import (
     BoundsFromNodesArray,
     CellConnectivityArray,

--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -43,7 +43,6 @@ from ..mixin2 import CFANetCDF, Container
 from ..units import Units
 from .collapse import Collapse
 from .creation import generate_axis_identifiers, to_dask
-
 from .dask_utils import (
     _da_ma_allclose,
     cf_asanyarray,

--- a/cf/dimensioncoordinate.py
+++ b/cf/dimensioncoordinate.py
@@ -248,7 +248,84 @@ class DimensionCoordinate(
 
     @_inplace_enabled(default=False)
     def anchor(self, value, parameters=None, inplace=False):
-        """TODO"""
+        """Anchor the coordinate values.
+
+
+
+        axis to the *value*.Roll cyclic coordinates so that a value lies in the first cell (REALLY?)
+        coordinate cell.
+
+        A unique axis is selected with the *axes* and *kwargs*
+        parameters.
+
+        .. versionadded:: NEXTVERSION
+
+TODO provide a bounds treament: bounds=False|True
+
+        .. seealso:: `period`, `roll`
+
+        :Parameters:
+
+            axis:
+                The cyclic axis to be anchored.
+
+                domain axis selection TODO.
+
+            value:
+
+                Anchor the coordinate values for the selected cyclic
+                axis to the *value*. May be any numeric scalar object
+                that can be converted to a `Data` object (which
+                includes `numpy` and `Data` objects). If *value* has
+                units then they must be compatible with those of the
+                coordinates, otherwise it is assumed to have the same
+                units as the coordinates. The coordinate values are
+                transformed so that *value* is "equal to or just
+                before" the new first coordinate value. More
+                specifically:
+
+                  * Increasing coordinates with positive period, P,
+                    are transformed so that *value* lies in the
+                    half-open range (L-P, F], where F and L are the
+                    transformed first and last coordinate values,
+                    respectively.
+
+            ..
+
+                  * Decreasing coordinates with positive period, P,
+                    are transformed so that *value* lies in the
+                    half-open range (L+P, F], where F and L are the
+                    transformed first and last coordinate values,
+                    respectively.
+
+                *Parameter example:*
+                  If the original coordinates are ``0, 5, ..., 355``
+                  (evenly spaced) and the period is ``360`` then
+                  ``value=0`` implies transformed coordinates of ``0,
+                  5, ..., 355``; ``value=-12`` implies transformed
+                  coordinates of ``-10, -5, ..., 345``; ``value=380``
+                  implies transformed coordinates of ``380, 385, ...,
+                  715``.
+
+                *Parameter example:*
+                  If the original coordinates are ``355, 350, ..., 0``
+                  (evenly spaced) and the period is ``360`` then
+                  ``value=355`` implies transformed coordinates of
+                  ``355, 350, ..., 0``; ``value=0`` implies
+                  transformed coordinates of ``0, -5, ..., -355``;
+                  ``value=392`` implies transformed coordinates of
+                  ``390, 385, ..., 30``.
+
+            parameters: `dict`, optional
+                TODO Return a dictionary of parameters which describe the
+                anchoring process. The construct is not changed, even
+                if *inplace* is True.
+
+            {{inplace: `bool`, optional}}
+
+        :Returns:
+
+        """
         
         d = _inplace_enabled_define_and_cleanup(self)
 

--- a/cf/dimensioncoordinate.py
+++ b/cf/dimensioncoordinate.py
@@ -304,7 +304,7 @@ class DimensionCoordinate(
                   5, ..., 355``; ``value=-12`` implies transformed
                   coordinates of ``-10, -5, ..., 345``; ``value=380``
                   implies transformed coordinates of ``380, 385, ...,
-                  715``.
+                  735``.
 
                 *Parameter example:*
                   If the original coordinates are ``355, 350, ..., 0``
@@ -313,7 +313,7 @@ class DimensionCoordinate(
                   ``355, 350, ..., 0``; ``value=0`` implies
                   transformed coordinates of ``0, -5, ..., -355``;
                   ``value=392`` implies transformed coordinates of
-                  ``390, 385, ..., 30``.
+                  ``390, 385, ..., 35``.
 
             cell: `bool`, optional
                 If True, then the coordinate values are transformed so

--- a/cf/dimensioncoordinate.py
+++ b/cf/dimensioncoordinate.py
@@ -327,13 +327,17 @@ class DimensionCoordinate(
                 (decreasing) coordinates.
 
             parameters: `dict`, optional
-                TODO Return a dictionary of parameters which describe the
-                anchoring process. The construct is not changed, even
-                if *inplace* is True.
+                If a `dict` is provided then it will be updated
+                in-place with parameters which describe thethe
+                anchoring process.
 
             {{inplace: `bool`, optional}}
 
         :Returns:
+
+            `{{class}}` or `None`
+                The anchored dimension coordinates, or `None` if the
+                operation was in-place.
 
         """
         d = _inplace_enabled_define_and_cleanup(self)

--- a/cf/dimensioncoordinate.py
+++ b/cf/dimensioncoordinate.py
@@ -260,7 +260,7 @@ class DimensionCoordinate(
 
         If the *cell* parameter is True, then the coordinate values
         are transformed so that the first cell either contains
-        *value*; or is the closet to cell to *value* from above
+        *value*; or is the closest to cell to *value* from above
         (below) for increasing (decreasing) coordinates.
 
         .. versionadded:: NEXTVERSION
@@ -279,9 +279,9 @@ class DimensionCoordinate(
                 units as the coordinates.
 
                 The coordinate values are transformed so the first
-                corodinate is the closet to *value* from above (for
-                increasing coordinates), or the closet to *value* from
-                above (for idereasing coordinates)
+                corodinate is the closest to *value* from above (for
+                increasing coordinates), or the closest to *value* from
+                above (for decreasing coordinates)
 
                   * Increasing coordinates with positive period, P,
                     are transformed so that *value* lies in the
@@ -318,11 +318,11 @@ class DimensionCoordinate(
             cell: `bool`, optional
                 If True, then the coordinate values are transformed so
                 that the first cell either contains *value*, or is the
-                closet to cell to *value* from above (below) for
+                closest to cell to *value* from above (below) for
                 increasing (decreasing) coordinates.
 
                 If False (the default) then the coordinate values are
-                transformed so that the first coordinate is the closet
+                transformed so that the first coordinate is the closest
                 to *value* from above (below) for increasing
                 (decreasing) coordinates.
 

--- a/cf/dimensioncoordinate.py
+++ b/cf/dimensioncoordinate.py
@@ -262,20 +262,14 @@ class DimensionCoordinate(
         are transformed so that the first cell either contains
         *value*; or is the closet to cell to *value* from above
         (below) for increasing (decreasing) coordinates.
-    
+
         .. versionadded:: NEXTVERSION
 
         .. seealso:: `period`, `roll`
 
         :Parameters:
-    
-            axis:
-                The cyclic axis to be anchored.
-    
-                domain axis selection TODO.
-    
+
             value: scalar array_like
-    
                 Anchor the coordinate values for the selected cyclic
                 axis to the *value*. May be any numeric scalar object
                 that can be converted to a `Data` object (which
@@ -283,26 +277,26 @@ class DimensionCoordinate(
                 units then they must be compatible with those of the
                 coordinates, otherwise it is assumed to have the same
                 units as the coordinates.
-        
+
                 The coordinate values are transformed so the first
                 corodinate is the closet to *value* from above (for
                 increasing coordinates), or the closet to *value* from
                 above (for idereasing coordinates)
-    
+
                   * Increasing coordinates with positive period, P,
                     are transformed so that *value* lies in the
                     half-open range (L-P, F], where F and L are the
                     transformed first and last coordinate values,
                     respectively.
-    
+
             ..
-    
+
                   * Decreasing coordinates with positive period, P,
                     are transformed so that *value* lies in the
                     half-open range (L+P, F], where F and L are the
                     transformed first and last coordinate values,
                     respectively.
-    
+
                 *Parameter example:*
                   If the original coordinates are ``0, 5, ..., 355``
                   (evenly spaced) and the period is ``360`` then
@@ -311,7 +305,7 @@ class DimensionCoordinate(
                   coordinates of ``-10, -5, ..., 345``; ``value=380``
                   implies transformed coordinates of ``380, 385, ...,
                   715``.
-    
+
                 *Parameter example:*
                   If the original coordinates are ``355, 350, ..., 0``
                   (evenly spaced) and the period is ``360`` then
@@ -320,17 +314,25 @@ class DimensionCoordinate(
                   transformed coordinates of ``0, -5, ..., -355``;
                   ``value=392`` implies transformed coordinates of
                   ``390, 385, ..., 30``.
-    
+
             cell: `bool`, optional
-                TODO
+                If True, then the coordinate values are transformed so
+                that the first cell either contains *value*, or is the
+                closet to cell to *value* from above (below) for
+                increasing (decreasing) coordinates.
+
+                If False (the default) then the coordinate values are
+                transformed so that the first coordinate is the closet
+                to *value* from above (below) for increasing
+                (decreasing) coordinates.
 
             parameters: `dict`, optional
                 TODO Return a dictionary of parameters which describe the
                 anchoring process. The construct is not changed, even
                 if *inplace* is True.
-    
+
             {{inplace: `bool`, optional}}
-    
+
         :Returns:
 
         """
@@ -353,8 +355,8 @@ class DimensionCoordinate(
         else:
             d.persist(inplace=True)
             c = d.get_data(_fill_value=False)
-      
-        if d.increasing: 
+
+        if d.increasing:
             # Adjust value so it's in the range [c[0], c[0]+period)
             n = ((c[0] - value) / period).ceil()
             value1 = value + n * period
@@ -364,7 +366,7 @@ class DimensionCoordinate(
                 d0 = d[0].upper_bounds
             else:
                 d0 = d.get_data(_fill_value=False)[0]
-    
+
             n = ((value - d0) / period).ceil()
         else:
             # Adjust value so it's in the range (c[0]-period, c[0]]

--- a/cf/dimensioncoordinate.py
+++ b/cf/dimensioncoordinate.py
@@ -255,7 +255,7 @@ class DimensionCoordinate(
         """Anchor the coordinate values.
 
         By default, the coordinate values are transformed so that the
-        first coordinate is the closet to *value* from above (below)
+        first coordinate is the closest to *value* from above (below)
         for increasing (decreasing) coordinates.
 
         If the *cell* parameter is True, then the coordinate values

--- a/cf/mixin/fielddomain.py
+++ b/cf/mixin/fielddomain.py
@@ -472,7 +472,9 @@ class FieldDomain:
                             stop = start - n.size
                         else:
                             start = size - parameters["shift"]
-                            stop = start
+                            stop = start + size
+                            if stop > size:
+                                stop -= size
 
                     index = slice(start, stop, 1)
 

--- a/cf/mixin/fielddomain.py
+++ b/cf/mixin/fielddomain.py
@@ -440,7 +440,7 @@ class FieldDomain:
                     if debug:
                         logger.debug("  1-d CASE 2:")  # pragma: no cover
 
-                    size = item.size                        
+                    size = item.size
                     if item.increasing:
                         anchor = value.value[0]
                     else:
@@ -449,14 +449,14 @@ class FieldDomain:
                     item = item.persist()
                     parameters = {}
                     item = item.anchor(anchor, parameters=parameters)
-                    n = np.roll(np.arange(size), parameters['shift'], 0)
+                    n = np.roll(np.arange(size), parameters["shift"], 0)
                     if value.operator == "wi":
                         n = n[item == value]
                         if not n.size:
                             raise ValueError(
                                 f"No indices found from: {identity}={value!r}"
                             )
-                        
+
                         start = n[0]
                         stop = n[-1] + 1
                     else:
@@ -471,7 +471,7 @@ class FieldDomain:
                             start = n[-1] + 1
                             stop = start - n.size
                         else:
-                            start = size - parameters['shift']
+                            start = size - parameters["shift"]
                             stop = start
 
                     index = slice(start, stop, 1)
@@ -1276,96 +1276,36 @@ class FieldDomain:
                 self, "anchor", kwargs
             )  # pragma: no cover
 
-        da_key, axis = self.domain_axis(axis, item=True)
+        axis = self.domain_axis(axis, key=True)
 
         if dry_run:
             f = self
         else:
             f = _inplace_enabled_define_and_cleanup(self)
 
-        dim = f.dimension_coordinate(filter_by_axis=(da_key,), default=None)
+        dim = f.dimension_coordinate(filter_by_axis=(axis,), default=None)
         if dim is None:
             raise ValueError(
                 "Can't shift non-cyclic "
-                f"{f.constructs.domain_axis_identity(da_key)!r} axis"
+                f"{f.constructs.domain_axis_identity(axis)!r} axis"
             )
 
-#        period = dim.period()
-#        if period is None:
- #           raise ValueError(f"Cyclic {dim.identity()!r} axis has no period")
-
-        value = f._Data.asdata(value)
-        if not value.Units:
-            value = value.override_units(dim.Units)
-        elif not value.Units.equivalent(dim.Units):
-            raise ValueError(
-                f"Anchor value has incompatible units: {value.Units!r}"
-            )
-
-        axis_size = axis.get_size()
-
-        if axis_size <= 1:
-            # Don't need to roll a size one axis
-            if dry_run:
-                return {"axis": da_key, "roll": 0, "nperiod": 0}
-
-            return f
-
-        parameters = {}
+        parameters = {"axis": axis}
         dim = dim.anchor(value, parameters=parameters)
 
-        f.roll(da_key, parameters['shift'], inplace=True)
-
         if dry_run:
-            out = {"axis": da_key}
-            out.update(parameters)
-            return out
+            return parameters
 
-        if parameters['nperiod']:
-            dim = f.dimension_coordinate(filter_by_axis=(da_key,))
+        f.roll(axis, parameters["shift"], inplace=True)
+
+        if parameters["nperiod"]:
+            # Get the rolled dimension coordinate and adjust the
+            # values by the non-zero integer multiple of 'period'
+            dim = f.dimension_coordinate(filter_by_axis=(axis,))
             with bounds_combination_mode("OR"):
-                dim += parameters['nperiod']
+                dim += parameters["nperiod"]
 
         return f
-
-#        c = dim.get_data(_fill_value=False)
-#
-#        if dim.increasing:
-#            # Adjust value so it's in the range [c[0], c[0]+period)
-#            n = ((c[0] - value) / period).ceil()
-#            value1 = value + n * period
-#
-#            shift = axis_size - np.argmax((c - value1 >= 0).array)
-#            if not dry_run:
-#                f.roll(da_key, shift, inplace=True)
-#
-#            # Re-get dim
-#            dim = f.dimension_coordinate(filter_by_axis=(da_key,))
-#            # TODO CHECK n for dry run or not
-#            n = ((value - dim.data[0]) / period).ceil()
-#        else:
-#            # Adjust value so it's in the range (c[0]-period, c[0]]
-#            n = ((c[0] - value) / period).floor()
-#            value1 = value + n * period
-#
-#            shift = axis_size - np.argmax((value1 - c >= 0).array)
-#
-#            if not dry_run:
-#                f.roll(da_key, shift, inplace=True)
-#
-#            # Re-get dim
-#            dim = f.dimension_coordinate(filter_by_axis=(da_key,))
-#            # TODO CHECK n for dry run or not
-#            n = ((value - dim.data[0]) / period).floor()
-#
-#        if dry_run:
-#            return {"axis": da_key, "roll": shift, "nperiod": n * period}
-#
-#        if n:
-#            with bounds_combination_mode("OR"):
-#                dim += n * period
-#
-#        return f
 
     @_manage_log_level_via_verbosity
     def autocyclic(self, key=None, coord=None, verbose=None, config={}):

--- a/cf/mixin/fielddomain.py
+++ b/cf/mixin/fielddomain.py
@@ -475,9 +475,15 @@ class FieldDomain:
                             raise ValueError(
                                 f"No indices found from: {identity}={value!r}"
                             )
-                    
-                        start = n[-1] + 1
-                        stop = start - n.size
+
+                        if n.size:
+                            start = n[-1] + 1
+                            stop = start - n.size
+                        else:
+                            start = item.size -offset
+                            stop = start
+
+
                     print(n)
                     print ('start, stop=',start, stop)
              

--- a/cf/regrid/regrid.py
+++ b/cf/regrid/regrid.py
@@ -2465,7 +2465,6 @@ def create_esmpy_weights(
             from netCDF4 import Dataset
 
             from .. import __version__
-
             from ..data.array.locks import netcdf_lock
 
             if (

--- a/cf/test/test_DimensionCoordinate.py
+++ b/cf/test/test_DimensionCoordinate.py
@@ -737,6 +737,70 @@ class DimensionCoordinateTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             d.get_cell_characteristics()
 
+    def test_DimensionCoordinate_anchor(self):
+        """Test the DimensionCoordinate.anchor"""
+        f = cf.example_field(0)
+        d = f.dimension_coordinate("X")
+
+        self.assertEqual(d.period(), 360)
+
+        e = d.anchor(-1)
+        self.assertIsInstance(e, cf.DimensionCoordinate)
+        self.assertTrue(e.equals(d))
+
+        # Increasing
+        e = d.anchor(15)
+        self.assertTrue(e[0].equals(d[0]))
+        self.assertEqual(e[0].array, d[0].array)
+
+        e = d.anchor(30)
+        self.assertEqual(e[0].array, d[1].array)
+
+        e = d.anchor(361)
+        self.assertEqual(e[0].array, d[0].array + 360)
+
+        e = d.anchor(721)
+        self.assertEqual(e[0].array, d[0].array + 720)
+
+        e = d.anchor(15, cell=True)
+        self.assertEqual(e[0].array, d[0].array)
+
+        e = d.anchor(30, cell=True)
+        self.assertEqual(e[0].array, d[0].array)
+
+        e = d.anchor(361, cell=True)
+        self.assertEqual(e[0].array, d[0].array + 360)
+
+        e = d.anchor(721, cell=True)
+        self.assertEqual(e[0].array, d[0].array + 720)
+
+        # Decreasing
+        d = d[::-1]
+
+        e = d.anchor(721)
+        self.assertEqual(e[0].array, d[0].array + 360)
+
+        e = d.anchor(361)
+        self.assertEqual(e[0].array, d[0].array)
+
+        e = d.anchor(30)
+        self.assertEqual(e[0].array, d[-1].array)
+
+        e = d.anchor(15)
+        self.assertEqual(e[0].array, d[0].array - 360)
+
+        e = d.anchor(721, cell=True)
+        self.assertEqual(e[0].array, d[0].array + 360)
+
+        e = d.anchor(361, cell=True)
+        self.assertEqual(e[0].array, d[0].array)
+
+        e = d.anchor(30, cell=True)
+        self.assertEqual(e[0].array, d[0].array - 360)
+
+        e = d.anchor(15, cell=True)
+        self.assertEqual(e[0].array, d[0].array - 360)
+
 
 if __name__ == "__main__":
     print("Run date:", datetime.datetime.now())

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -1298,7 +1298,7 @@ class FieldTest(unittest.TestCase):
 
         # wi (decreasing)
         f.flip("X", inplace=True)
-       
+
         indices = f.indices(grid_longitude=cf.wi(50, 130))
         self.assertTrue(indices[0], "mask")
         g = f[indices]

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -1163,7 +1163,7 @@ class FieldTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             f.insert_dimension(1, "qwerty")
 
-    def test_Field_indices(self):
+    def test_Field__aaa__indices(self):
         f = cf.read(self.filename)[0]
 
         array = np.ma.array(f.array, copy=False)
@@ -1214,6 +1214,8 @@ class FieldTest(unittest.TestCase):
             (x == [-80, -40, 0, 40, 80, 120, 160, 200, 240.0]).all()
         )
 
+        print(f)
+        print(f.dimension_coordinate('X').array, f.cyclic())
         with self.assertRaises(ValueError):
             # No X coordinate values lie inside the range [90, 100]
             f.indices(grid_longitude=cf.wi(90, 100))

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -1163,7 +1163,7 @@ class FieldTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             f.insert_dimension(1, "qwerty")
 
-    def test_Field__aaa__indices(self):
+    def test_Field_indices(self):
         f = cf.read(self.filename)[0]
 
         array = np.ma.array(f.array, copy=False)
@@ -1214,8 +1214,30 @@ class FieldTest(unittest.TestCase):
             (x == [-80, -40, 0, 40, 80, 120, 160, 200, 240.0]).all()
         )
 
-        print(f)
-        print(f.dimension_coordinate('X').array, f.cyclic())
+        indices = f.indices(grid_longitude=cf.wi(-90, 270))
+        g = f[indices]
+        self.assertEqual(g.shape, (1, 10, 9))
+        x = g.dimension_coordinate("X").array
+        self.assertTrue(
+            (x == [-80, -40, 0, 40, 80, 120, 160, 200, 240.0]).all()
+        )
+
+        indices = f.indices(grid_longitude=cf.wi(-180, 180))
+        g = f[indices]
+        self.assertEqual(g.shape, (1, 10, 9))
+        x = g.dimension_coordinate("X").array
+        self.assertTrue(
+            (x == [-160, -120, -80, -40, 0, 40, 80, 120, 160]).all()
+        )
+
+        indices = f.indices(grid_longitude=cf.wi(-170, 170))
+        g = f[indices]
+        self.assertEqual(g.shape, (1, 10, 9))
+        x = g.dimension_coordinate("X").array
+        self.assertTrue(
+            (x == [-160, -120, -80, -40, 0, 40, 80, 120, 160]).all()
+        )
+
         with self.assertRaises(ValueError):
             # No X coordinate values lie inside the range [90, 100]
             f.indices(grid_longitude=cf.wi(90, 100))
@@ -1276,7 +1298,7 @@ class FieldTest(unittest.TestCase):
 
         # wi (decreasing)
         f.flip("X", inplace=True)
-
+       
         indices = f.indices(grid_longitude=cf.wi(50, 130))
         self.assertTrue(indices[0], "mask")
         g = f[indices]

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -1361,6 +1361,34 @@ class FieldTest(unittest.TestCase):
         x = g.dimension_coordinate("X").array
         self.assertTrue((x == [-200, -160, -120, -80, -40, 0, 40]).all())
 
+        indices = f.indices(grid_longitude=cf.wo(1, 5))
+        g = f[indices]
+        self.assertEqual(g.shape, (1, 10, 9))
+        x = g.dimension_coordinate("X").array
+        self.assertTrue(
+            (x == [-320, -280, -240, -200, -160, -120, -80, -40, 0]).all()
+        )
+
+        indices = f.indices(grid_longitude=cf.wo(41, 45))
+        g = f[indices]
+        self.assertEqual(g.shape, (1, 10, 9))
+        x = g.dimension_coordinate("X").array
+        self.assertTrue(
+            (x == [-280, -240, -200, -160, -120, -80, -40, 0, 40]).all()
+        )
+
+        indices = f.indices(grid_longitude=cf.wo(-5, -1))
+        g = f[indices]
+        self.assertEqual(g.shape, (1, 10, 9))
+        x = g.dimension_coordinate("X").array
+        self.assertTrue((x == [0, 40, 80, 120, 160, 200, 240, 280, 320]).all())
+
+        indices = f.indices(grid_longitude=cf.wo(-45, -41))
+        g = f[indices]
+        self.assertEqual(g.shape, (1, 10, 9))
+        x = g.dimension_coordinate("X").array
+        self.assertTrue((x == [-40, 0, 40, 80, 120, 160, 200, 240, 280]).all())
+
         with self.assertRaises(ValueError):
             # No X coordinate values lie outside the range [-90, 370]
             f.indices(grid_longitude=cf.wo(-90, 370))

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -1406,14 +1406,12 @@ class FieldTest(unittest.TestCase):
         g = f[indices]
         x = g.dimension_coordinate("X").array
         self.assertEqual(g.shape, (1, 10, 7))
-        x = g.dimension_coordinate("X").array
         self.assertTrue((x == [-240, -200, -160, -120, -80, -40, 0]).all())
 
         indices = f.indices(grid_longitude=cf.wo(35, 85))
         g = f[indices]
         x = g.dimension_coordinate("X").array
         self.assertEqual(g.shape, (1, 10, 7))
-        x = g.dimension_coordinate("X").array
         self.assertTrue((x == [-240, -200, -160, -120, -80, -40, 0]).all())
 
         with self.assertRaises(ValueError):

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -1396,6 +1396,15 @@ class FieldTest(unittest.TestCase):
         x = g.dimension_coordinate("X").array
         self.assertTrue((x == [80, 120, 160, 200, 240, 280, 320]).all())
 
+        indices = f.indices(grid_longitude=cf.wi(-45, 45))
+        g = f[indices]
+        self.assertEqual(g.shape, (1, 10, 9))
+        x = g.dimension_coordinate("X").array
+        print(x)
+        self.assertTrue(
+            (x == [-160, -120, -80, -40, 0, 40, 80, 120, 160]).all()
+        )
+
         # 2-d
         lon = f.construct("longitude").array
         lon = np.transpose(lon)
@@ -1490,7 +1499,6 @@ class FieldTest(unittest.TestCase):
                 shape = (1, 1, 1)
 
             self.assertEqual(g.shape, shape)
-            # REVIEW: getitem: `test_Field_indices`: make sure works when 'g.array' is not masked
             self.assertEqual(np.ma.compressed(g.array), 29)
             if mode != "full":
                 self.assertEqual(g.construct("longitude").array, 83)
@@ -1509,7 +1517,6 @@ class FieldTest(unittest.TestCase):
                 shape = (1, 2, 2)
 
             self.assertEqual(g.shape, shape)
-            # REVIEW: getitem: `test_Field_indices`: make sure works when 'g.array' is not masked
             self.assertTrue((np.ma.compressed(g.array) == [4, 29]).all())
 
         # Add 2-d auxiliary coordinates with bounds, so we can

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -1396,14 +1396,34 @@ class FieldTest(unittest.TestCase):
         x = g.dimension_coordinate("X").array
         self.assertTrue((x == [80, 120, 160, 200, 240, 280, 320]).all())
 
-        indices = f.indices(grid_longitude=cf.wi(-45, 45))
+        indices = f.indices(grid_longitude=cf.wo(-45, 45))
         g = f[indices]
-        self.assertEqual(g.shape, (1, 10, 9))
+        self.assertEqual(g.shape, (1, 10, 6))
         x = g.dimension_coordinate("X").array
-        print(x)
-        self.assertTrue(
-            (x == [-160, -120, -80, -40, 0, 40, 80, 120, 160]).all()
-        )
+        self.assertTrue((x == [80, 120, 160, 200, 240, 280]).all())
+
+        indices = f.indices(grid_longitude=cf.wo(35, 85))
+        g = f[indices]
+        x = g.dimension_coordinate("X").array
+        self.assertEqual(g.shape, (1, 10, 7))
+        x = g.dimension_coordinate("X").array
+        self.assertTrue((x == [-240, -200, -160, -120, -80, -40, 0]).all())
+
+        indices = f.indices(grid_longitude=cf.wo(35, 85))
+        g = f[indices]
+        x = g.dimension_coordinate("X").array
+        self.assertEqual(g.shape, (1, 10, 7))
+        x = g.dimension_coordinate("X").array
+        self.assertTrue((x == [-240, -200, -160, -120, -80, -40, 0]).all())
+
+        with self.assertRaises(ValueError):
+            f.indices(grid_longitude=cf.wo(0, 360))
+
+        with self.assertRaises(ValueError):
+            f.indices(grid_longitude=cf.wo(-90, 270))
+
+        with self.assertRaises(ValueError):
+            f.indices(grid_longitude=cf.wo(-180, 180))
 
         # 2-d
         lon = f.construct("longitude").array


### PR DESCRIPTION
Fixes #828.

This PR fixes and simplifies the treatment of cyclic subspaces in `cf.mixin.fielddomain._indices`. In the process, it refactors `cf.mixin.fielddomain.anchor` by moving the business-end of that to the new `cf.DimensionCoordinate.anchor`. This new method also allows for "cell" anchoring, which we might like to use later (see #824).