### PR TITLE
Fix to broken link to PDF cheatsheet

### DIFF
--- a/docs/cheat_sheet.html
+++ b/docs/cheat_sheet.html
@@ -133,7 +133,7 @@ and by <a href="https://ncas.ac.uk/">NCAS</a>.
 <p>Version 3.16.2 for version 1.11 of the CF conventions.</p>
 <p>This cheat sheet provides a summary of some key functions and methods in
 cf-python (also available as a printable PDF for
-<a class="reference download internal" download="" href="_downloads/8683cc7ed97b754fffeacb09b2521112/cheatsheet.pdf"><code class="xref download docutils literal notranslate"><span class="pre">pdf</span></code></a>).</p>
+<a class="reference download internal" download="" href="_downloads/cheatsheet.pdf"><code class="xref download docutils literal notranslate"><span class="pre">pdf</span></code></a>).</p>
 <table class="docutils align-default">
 <colgroup>
 <col style="width: 32%" />


### PR DESCRIPTION
Quick PR to fix a link to the PDF cheat sheet which is broken since the hash in the link wasn't removed somehow in the build process: see https://ncas-cms.github.io/cf-python/cheat_sheet.html and try to click 'pdf' (or open it in a new tab, remove the hash component and it works). I want to update this manually in the built HTML since I want to update the Intro. Scientific Computing to include a link to the cheat sheet from the current docs and don't want a broken link sitting there for someone to find.

I would have just pushed this fix as a lone commit if it weren't for the fact that I wanted to check if we need to update the release script in case anything is wrong that led to the hash component not getting removed to break the link, but actually taking a quick look the logic looks fine to me, so I am at a loss as to why the hash remained there in the latest release process:

https://github.com/NCAS-CMS/cf-python/blob/0c5af837fbe25847565a9f1f07eb3456fe70ca20/release_docs#L91-L101

Any ideas @davidhassell? If not I'll assume we did something wrong in the last release build and we can just merge this fix as-is.