### PR TITLE
Recipes tweaks for Sphinx Gallery build and rendering

### DIFF
--- a/docs/source/recipes/plot_04_recipe.py
+++ b/docs/source/recipes/plot_04_recipe.py
@@ -13,7 +13,7 @@ import cf
 # %%
 # 2. Read the field constructs:
 
-obs = cf.read("~/recipes/cru_ts4.06.1901.2021.tmp.dat.nc", chunks=None)
+obs = cf.read("~/recipes/cru_ts4.06.1901.2021.tmp.dat.nc", dask_chunks=None)
 print(obs)
 
 # %%

--- a/docs/source/recipes/plot_16_recipe.py
+++ b/docs/source/recipes/plot_16_recipe.py
@@ -19,13 +19,7 @@ import cf
 f = cf.read("~/recipes/ggap.nc")[0]
 
 # %%
-# 3. Create the file with subplots. If changing the number of subplots,
-# ensure the number of rows * number of columns = the number of projections.
-# Here we are doing 6 projections so 2 x 3 is fine:
-cfp.gopen(rows=2, columns=3, bottom=0.2, file="projections.png")
-
-# %%
-# 4. List the projection types to use. Here we are using
+# 3. List the projection types to use. Here we are using
 # Cylindrical/Default, North Pole Stereographic, South Pole Stereographic,
 # Mollweide, Mercator and Robinson. However there are several other choices
 # possible, see:
@@ -34,7 +28,11 @@ cfp.gopen(rows=2, columns=3, bottom=0.2, file="projections.png")
 projtypes = ["cyl", "npstere", "spstere", "moll", "merc", "robin"]
 
 # %%
-# 5. Loop through the list of projection types and plot each as a sub-plot:
+# 4. Create the file with subplots. If changing the number of subplots,
+# ensure the number of rows * number of columns = the number of projections.
+# Here we are doing 6 projections so 2 x 3 is fine. Then loop through the
+# list of projection types and plot each as a sub-plot.
+cfp.gopen(rows=2, columns=3, bottom=0.2, file="projections.png")
 for i, proj in enumerate(projtypes):
     # gpos has 1 added to the index because it takes 1 as its first value
     cfp.gpos(i + 1)

--- a/docs/source/recipes/plot_16_recipe.py
+++ b/docs/source/recipes/plot_16_recipe.py
@@ -31,7 +31,7 @@ projtypes = ["cyl", "npstere", "spstere", "moll", "merc", "robin"]
 # 4. Create the file with subplots. If changing the number of subplots,
 # ensure the number of rows * number of columns = the number of projections.
 # Here we are doing 6 projections so 2 x 3 is fine. Then loop through the
-# list of projection types and plot each as a sub-plot.
+# list of projection types and plot each as a sub-plot:
 cfp.gopen(rows=2, columns=3, bottom=0.2, file="projections.png")
 for i, proj in enumerate(projtypes):
     # gpos has 1 added to the index because it takes 1 as its first value

--- a/docs/source/recipes/plot_17_recipe.py
+++ b/docs/source/recipes/plot_17_recipe.py
@@ -106,5 +106,4 @@ for i, colour_scale in enumerate(colour_scales_columns):
         colorbar_thick=0.02,
         colorbar_fontsize=11,
     )
-
-cfp.gclose(view=True)
+cfp.gclose()

--- a/docs/source/recipes/plot_17_recipe.py
+++ b/docs/source/recipes/plot_17_recipe.py
@@ -66,7 +66,10 @@ colour_scales_columns = [
 
 # %%
 # 5. Create the figure and give it an overall title. Ensure the
-# number of rows * number of columns = number of colour scales:
+# number of rows * number of columns = number of colour scales.
+# Then we loop through all the different colour maps defined and plot
+# as subplots, with each category in the same column, labelling each column
+# with the colour scale category:
 cfp.gopen(rows=3, columns=3, bottom=0.1, top=0.85)
 plt.suptitle(
     (
@@ -75,11 +78,6 @@ plt.suptitle(
     ),
     fontsize=18,
 )
-
-# %%
-# 6. We loop through all the different colour maps defined and plot
-# as subplots, with each category in the same column, labelling each column
-# with the colour scale category:
 for i, colour_scale in enumerate(colour_scales_columns):
     cfp.gpos(i + 1)
     cfp.cscale(colour_scale)

--- a/docs/source/recipes/plot_18_recipe.py
+++ b/docs/source/recipes/plot_18_recipe.py
@@ -141,5 +141,4 @@ cfp.con(
     colorbar_drawedges=False,
     **label_info,
 )
-
 cfp.gclose()

--- a/docs/source/recipes/plot_19_recipe.py
+++ b/docs/source/recipes/plot_19_recipe.py
@@ -46,19 +46,17 @@ colours_seasons_mapping = {
 }
 
 # %%
-# 6. Create and open the plot file:
-cfp.gopen(
-    rows=2, columns=1, bottom=0.1, top=0.85, file="global_avg_sst_plot.png"
-)
-
-# %%
-# 7. Put maxima subplot at top since these values are higher, given
-# increasing x axis. Note we set limits manually with 'gset' only to
+# 6. Create and open the plot file. Put maxima subplot at top since these
+# values are higher, given increasing x axis.
+# Note we set limits manually with 'gset' only to
 # allow space so the legend doesn't overlap the data, which isn't
 # possible purely from positioning it anywhere within the default plot.
 # Otherwise cf-plot handles this for us. To plot the per-season means
 # of the maxima, we loop through the season query mapping and do a
 # "T: mean" collapse setting the season as the grouping:
+cfp.gopen(
+    rows=2, columns=1, bottom=0.1, top=0.85, file="global_avg_sst_plot.png"
+)
 cfp.gpos(1)
 cfp.gset(xmin="1980-01-01", xmax="2022-12-01", ymin=304, ymax=312)
 for colour, season_query in colours_seasons_mapping.items():
@@ -78,11 +76,9 @@ cfp.lineplot(
     xlabel="",
     label="All months",
 )
-
-# %%
-# 8. Create and add minima subplot below the maxima one. Just like for the
+# Create and add minima subplot below the maxima one. Just like for the
 # maxima case, we plot per-season means by looping through the season query
-# mapping and doing a "T: mean" collapse setting the season as the grouping:
+# mapping and doing a "T: mean" collapse setting the season as the grouping
 cfp.gpos(2)
 cfp.gset(xmin="1980-01-01", xmax="2022-12-01", ymin=269, ymax=272)
 for colour, season_query in colours_seasons_mapping.items():
@@ -100,9 +96,7 @@ cfp.lineplot(
     am_min,
     color="grey",
 )
-
-# %%
-# 9. Add an overall title to the plot and close the file to save it:
+# Add an overall title to the plot and close the file to save it
 plt.suptitle(
     "Global mean sea surface temperature (SST) monthly\nminima and maxima "
     "showing seasonal means of these extrema",

--- a/docs/source/recipes/plot_20_recipe.py
+++ b/docs/source/recipes/plot_20_recipe.py
@@ -68,19 +68,22 @@ v_2 = v_1.where(cf.lt(-9000), cf.masked)
 div = cf.div_xy(u_2, v_2, radius="earth")
 
 # %%
-# 8. Generate the final plot. First we configure the overall plot by
+# 8. First we configure the overall plot by
 # making the map higher resolution, to show the coastlines of the UK and
 # Ireland in greater detail, and changing the colourmap to better reflect
 # the data which can be positive or negative, i.e. has 0 as the 'middle'
-# value of significance, so should use a diverging colour map. Then we
-# plot the current vectors, noting we had to play around with the 'stride'
-# and 'scale' parameter values to adjust the vector spacing and size so that
-# the vector field is best represented and visible without over-cluttering
-# the plot. Finally we plot the divergence as a contour plot without any
-# lines showing. This compound plot is saved on one canvas using 'gopen'
-# and 'gclose' to wrap the two plotting calls:
+# value of significance, so should use a diverging colour map.
 cfp.mapset(resolution="10m")
 cfp.cscale("ncl_default")
+
+# %%
+# 9. Now generate the final plot. Plot the current vectors, noting we had
+# to play around with the 'stride' and 'scale' parameter values to adjust
+# the vector spacing and size so that the vector field is best represented
+# and visible without over-cluttering the plot. Finally we plot the
+# divergence as a contour plot without any lines showing. This compound
+# plot is saved on one canvas using 'gopen' and 'gclose' to wrap the two
+# plotting calls:
 cfp.gopen(
     file=f"irish-sea-currents-divergence-{chosen_time.replace(' ', '-')}.png"
 )

--- a/release_docs
+++ b/release_docs
@@ -29,7 +29,7 @@ elif [[ $1 = "dev" ]] ; then
 elif [[ $1 = "dev-clean" ]] ; then
   # For testing: creates separate dir and does not (git) commit and
   # also deletes an existing .doctrees subdirectory
-    dir=$PWD/docs/dev
+  dir=$PWD/docs/dev
 elif [[ $1 = "dev-scrub" ]] ; then
   # For testing: creates separate dir and does not (git) commit and
   # also completely deletes the new target directory.
@@ -38,10 +38,15 @@ elif [[ $1 = "dev-scrub" ]] ; then
 elif [[ $1 = "dev-recipes" ]] ; then
   # For testing: similar to dev, but specifically for generating recipes.
   dir=$PWD/docs/dev
+elif [[ $1 = "dev-recipes-scrub" ]] ; then
+  # For testing: similar to dev, but specifically for generating recipes,
+  # but cleaning any generated recipe files and gen'd dev dir first.
+  dir=$PWD/docs/dev
+  rm -fr $dir
 else
   set +x
   echo "\$1 must be one of 'dev', 'dev-clean', 'dev-scrub', 'latest', 'archive',
-  or 'dev-recipes'"
+  'dev-recipes' or 'dev-recipes-scrub'"
   exit 2
 fi
 
@@ -76,6 +81,13 @@ mkdir -p $dir/_downloads
 #  # Force recreation of recipes
 #  rm source/recipes/*.md5
 #fi
+if [[ $1 = "dev-recipes-scrub" ]] ; then
+  # Force recreation of recipes
+  rm source/recipes/*.md5
+  rm source/recipes/*.ipynb
+  rm source/recipes/*_codeobj.pickle
+  rm source/recipes/*_recipe.rst
+fi
 
 export CF_DOCS_MODE=$1
 
@@ -164,11 +176,11 @@ if [[ $1 = "latest" ]] ; then
   cd $dir
   git add \
           *.html \
-	  class/*.html \
-	  function/*.html \
-	  method/*.html \
-	  attribute/*.html \
-	  recipes/*.html \
+          class/*.html \
+          function/*.html \
+          method/*.html \
+          attribute/*.html \
+          recipes/*.html \
           *.inv \
           *.js \
           _static \
@@ -185,4 +197,3 @@ fi
 set +x
 
 echo PYTHONPATH=$PYTHONPATH
-


### PR DESCRIPTION
Was intending to push these directly as commits, but since we've had some last-minute bug fixes I will use a PR to keep it self-contained. This PR is mostly tweaks to the numbered blocks in the new recipes, to get all `gopen()` and `gclose()` wrapped code into one block, else plots don't seem to emerge through the Sphinx Gallery build (in future I'll look into ways to fix this so we can keep the blocks separated out, which is clearer, but for the new release there is no time to investigate). Otherwise there is one update to a deprecated keyword and a new option for the `release_docs` script to facilitate recipe build debugging.

No review required as infrastructural and non-controversial and I am due to do the release ASAP.