### PR TITLE
Add "isort:skip_file" directives to recipes

### DIFF
--- a/cf/test/test_DimensionCoordinate.py
+++ b/cf/test/test_DimensionCoordinate.py
@@ -808,7 +808,6 @@ class DimensionCoordinateTest(unittest.TestCase):
         e = d.anchor(15, cell=True)
         self.assertEqual(e[0].array, d[0].array - 360)
 
-
     def test_DimensionCoordinate_direction(self):
         """Test DimensionCoordinate.direction"""
         d = self.dim.copy()

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,6 @@ from sphinx_gallery.sorting import FileNameSortKey
 
 import cf
 
-
 print("\ncf environment:")
 print("-----------------")
 cf.environment()
@@ -392,7 +391,9 @@ sphinx_gallery_conf = {
     "inspect_global_variables": True,
     "within_subsection_order": FileNameSortKey,
     "default_thumb_file": "_static/logo.svg",
-    "image_scrapers": ("matplotlib",),  # Ensures Matplotlib images are captured
+    "image_scrapers": (
+        "matplotlib",
+    ),  # Ensures Matplotlib images are captured
     "plot_gallery": "True",  # Enables plot rendering
     "reset_modules": ("matplotlib",),  # Helps with memory management
     "capture_repr": (),

--- a/docs/source/recipes/plot_08_recipe.py
+++ b/docs/source/recipes/plot_08_recipe.py
@@ -3,6 +3,8 @@ Plotting statistically significant temperature trends with stippling
 ====================================================================
 
 In this recipe, we will analyse and plot temperature trends from the HadCRUT.5.0.1.0 dataset for two different time periods. The plotted maps also include stippling, which is used to highlight areas where the temperature trends are statistically significant.
+
+isort:skip_file
 """
 
 # %%

--- a/docs/source/recipes/plot_12_recipe.py
+++ b/docs/source/recipes/plot_12_recipe.py
@@ -8,6 +8,7 @@ In this recipe, we will make use of a
 to plot the `high-quality` retrieval of Aerosol Optical Depth (AOD) from all other
 retrievals.
 
+isort:skip_file
 """
 
 # %%

--- a/docs/source/recipes/plot_13_recipe.py
+++ b/docs/source/recipes/plot_13_recipe.py
@@ -11,6 +11,7 @@ The Niño 3.4 index typically uses a 5-month running mean, and El Niño or La
 Niña events are defined when the Niño 3.4 SSTs exceed +/- 0.4 degrees Celsius for a
 period of six months or more.
 
+isort:skip_file
 """
 
 # %%

--- a/docs/source/recipes/plot_17_recipe.py
+++ b/docs/source/recipes/plot_17_recipe.py
@@ -6,6 +6,8 @@ In this recipe, we will plot the same data with different colour maps from
 three categories in separate subplots to illustrate the importance of
 choosing a suitable one for given data. To avoid unintended bias and
 misrepresentation, or lack of accessibility, a careful choice must be made.
+
+isort:skip_file
 """
 
 # %%

--- a/docs/source/recipes/plot_18_recipe.py
+++ b/docs/source/recipes/plot_18_recipe.py
@@ -8,6 +8,7 @@ cover over a particular day), regrid them to the same resolution then
 calculate the correlation coefficient, to get a measure of the relationship
 between them.
 
+isort:skip_file
 """
 
 # %%

--- a/docs/source/recipes/plot_19_recipe.py
+++ b/docs/source/recipes/plot_19_recipe.py
@@ -7,6 +7,8 @@ temperature per month and, because it is very difficult to
 interpret for trends when in a monthly form, we calculate and plot
 on top of this the mean across each season for both the minima and the
 maxima.
+
+isort:skip_file
 """
 
 # %%
@@ -55,7 +57,10 @@ colours_seasons_mapping = {
 # of the maxima, we loop through the season query mapping and do a
 # "T: mean" collapse setting the season as the grouping:
 cfp.gopen(
-    rows=2, columns=1, bottom=0.1, top=0.85,
+    rows=2,
+    columns=1,
+    bottom=0.1,
+    top=0.85,
 )
 cfp.gpos(1)
 cfp.gset(xmin="1980-01-01", xmax="2022-12-01", ymin=304, ymax=312)


### PR DESCRIPTION
`pre-commit` wants to reorder the imports in some of the recipe files, but due to the esmpy/shapely class we don't want this to happen - so we can add some "isort:skip_file" directives to the relevant Python recipe files.

See https://pycqa.github.io/isort/ for details.