### PR TITLE
Docs: fix DOI badge at source & patch in built docs (to avoid rebuild)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -144,7 +144,7 @@ is built on a complete implementation of the <a class="reference internal" href=
 </div>
 <section id="functionality">
 <h3><a class="toc-backref" href="#id6"><strong>Functionality</strong></a><a class="headerlink" href="#functionality" title="Permalink to this headline">¶</a></h3>
-<p><a href="https://doi.org/10.5281/zenodo.14275599"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.14275599.svg" alt="DOI"></a></p>
+<p><a href="https://doi.org/10.5281/zenodo.14274886"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.14274886.svg" alt="DOI"></a></p>
 <p>The <code class="xref py py-obj docutils literal notranslate"><span class="pre">cf</span></code> package implements the <a class="reference internal" href="introduction.html#cf-data-model"><span class="std std-ref">CF data model</span></a> for its internal
 data structures and so is able to process any CF-compliant dataset. It
 is not strict about CF-compliance, however, so that partially

--- a/docs/introduction.html
+++ b/docs/introduction.html
@@ -143,7 +143,7 @@ is built on a complete implementation of the <a class="reference internal" href=
 </div>
 <section id="functionality">
 <h2><a class="toc-backref" href="#id5"><strong>Functionality</strong></a><a class="headerlink" href="#functionality" title="Permalink to this headline">¶</a></h2>
-<p>&lt;a href=”<a class="reference external" href="https://doi.org/10.5281/zenodo.14274886">https://doi.org/10.5281/zenodo.14274886</a>”&gt;&lt;img src=”<a class="reference external" href="https://zenodo.org/badge/DOI/https://doi.org/10.5281/zenodo.14274886">https://zenodo.org/badge/DOI/https://doi.org/10.5281/zenodo.14274886</a>” alt=”DOI”&gt;&lt;/a&gt;</p>
+<p><a href="https://doi.org/10.5281/zenodo.14274886"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.14274886.svg" alt="DOI"></a></p>
 <p>The <code class="xref py py-obj docutils literal notranslate"><span class="pre">cf</span></code> package implements the <a class="reference internal" href="#cf-data-model"><span class="std std-ref">CF data model</span></a> for its internal
 data structures and so is able to process any CF-compliant dataset. It
 is not strict about CF-compliance, however, so that partially

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -36,8 +36,8 @@ is built on a complete implementation of the :ref:`CF-data-model`.
 **Functionality**
 -----------------
 
-.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.14275599.svg
-  :target: https://doi.org/10.5281/zenodo.14275599
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.14274886.svg
+  :target: https://doi.org/10.5281/zenodo.14274886
 
 The `cf` package implements the :ref:`CF-data-model` for its internal
 data structures and so is able to process any CF-compliant dataset. It


### PR DESCRIPTION
On the docs homepage, through the introduction page source included also (via 'include' directive) in the index, some raw HTML was included in the RST for the latest version which caused some unrendered HTML text to show up directly under the heading 'Functionality':
![badge_issue](https://github.com/user-attachments/assets/7a4d1567-76e4-42a8-b786-0aeda25d8422)

I've updated the RST to include it in RST format so it should render to HTML when built but to avoid a full docs re-build I have patched the affected pages (index.html and introduction.html), with the fix which should now come from source as well.

FYI @davidhassell. Will merge without review since it is simple/self-contained, but I will check that it renders OK in the updated docs once the pages update via GitHub Pages and if not push a commit to ensure it is rendering and linking as it should.