### PR TITLE
`cf.Data.arctan2()`: Fixes NCAS-CMS/cf-python#890 by trying to conform valid units first.

### DIFF
--- a/cf/data/data.py
+++ b/cf/data/data.py
@@ -4407,7 +4407,9 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
             x2: array_like
                 X coordinates. *x1* and *x2* must be broadcastable to
                 a common shape (which becomes the shape of the
-                output).
+                output). If both *x1* and *x2* have units, they must
+                be in the same dimension (can be conformed), else
+                they will be treated as unitless.
 
         :Returns:
 
@@ -4434,6 +4436,10 @@ class Data(DataClassDeprecationsMixin, Container, cfdm.Data):
         [90.0 -90.0]
 
         """
+
+        if isinstance(getattr(x2, "Units", None), Units):
+            x1 = conform_units(x1, x2.Units)
+
         try:
             y = x1.to_dask_array()
         except AttributeError:


### PR DESCRIPTION
The function `cf.Data.arctan2` now first checks if `x2` has `cf`-style units (of the same type as the `cf.Units` class).

- If `x1` unitless and `x2` has `cf` units:
  - Attempts to conform `x1` to `x2`'s units, but `x1` remains unitless
  - `da.arctan2()` treats them both as unitless
- If `x1` has `cf` units and `x2` unitless:
  - Does not attempt to conform `x1` to `x2`'s units
  - `da.arctan2()` treats them both as unitless
- If `x1` and `x2` both unitless
  - Does not attempt to conform `x1` to `x2`'s units
  - `da.arctan2()` treats them both as unitless
- If 'x1' and 'x2' both have `cf` units
  - Attempts to conform `x1` to `x2`'s units
    - If `x1`'s units are of a different dimension than `x2`'s, an exception is raised
  - `da.arctan2()` operates on `x2` and the converted `x1`