### PR TITLE
Test skipping based on module (esp. `healpix`) availability

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -32,5 +32,5 @@ per-file-ignores =
     */__init__.py: F401
     # Whole-module test skips (via setUp method) for these cases means exit
     # before reach undefined vars where need given module for defining those.
-    # This is the cleanest way but sets off F821 so skip those:
+    # This is the cleanest way but sets off F821 code en-masse so ignore that.
     cf/test/test_HEALPix_utils.py: F821

--- a/.flake8
+++ b/.flake8
@@ -30,3 +30,6 @@ per-file-ignores =
     # https://stackoverflow.com/questions/59167405/)
     __init__.py: F401
     */__init__.py: F401
+    # Whole-module test skip means exit before reach undefined vars where need
+    # given (healpix) module for defining those. Is cleanest way but needs:
+    cf/test/test_HEALPix_utils.py: F821

--- a/.flake8
+++ b/.flake8
@@ -30,6 +30,7 @@ per-file-ignores =
     # https://stackoverflow.com/questions/59167405/)
     __init__.py: F401
     */__init__.py: F401
-    # Whole-module test skip means exit before reach undefined vars where need
-    # given (healpix) module for defining those. Is cleanest way but needs:
+    # Whole-module test skips (via setUp method) for these cases means exit
+    # before reach undefined vars where need given module for defining those.
+    # This is the cleanest way but sets off F821 so skip those:
     cf/test/test_HEALPix_utils.py: F821

--- a/cf/test/test_Domain.py
+++ b/cf/test/test_Domain.py
@@ -7,12 +7,6 @@ import numpy as np
 
 import cf
 
-healpix_available = False
-# Note: here only need healpix for cf under-the-hood code, not in test
-# directly, so no need to actually import healpix, just test it is there.
-if find_spec("healpix"):
-    healpix_available = True
-
 
 class DomainTest(unittest.TestCase):
     d = cf.example_field(1).domain
@@ -501,7 +495,9 @@ class DomainTest(unittest.TestCase):
         d2.cyclic("X", iscyclic=False)
         self.assertTrue(d2.iscyclic("X"))
 
-    @unittest.skipUnless(healpix_available, "Requires 'healpix' package.")
+    # Note: here only need healpix for cf under-the-hood code, not in test
+    # directly, so no need to actually import healpix, just test it is there.
+    @unittest.skipUnless(find_spec("healpix"), "Requires 'healpix' package.")
     def test_Domain_create_healpix(self):
         """Test Domain.create_healpix."""
         d = cf.Domain.create_healpix(0)

--- a/cf/test/test_Domain.py
+++ b/cf/test/test_Domain.py
@@ -1,10 +1,17 @@
 import datetime
 import re
 import unittest
+from importlib.util import find_spec
 
 import numpy as np
 
 import cf
+
+healpix_available = False
+# Note: here only need healpix for cf under-the-hood code, not in test
+# directly, so no need to actually import healpix, just test it is there.
+if find_spec("healpix"):
+    healpix_available = True
 
 
 class DomainTest(unittest.TestCase):
@@ -494,6 +501,7 @@ class DomainTest(unittest.TestCase):
         d2.cyclic("X", iscyclic=False)
         self.assertTrue(d2.iscyclic("X"))
 
+    @unittest.skipUnless(healpix_available, "Requires 'healpix' package.")
     def test_Domain_create_healpix(self):
         """Test Domain.create_healpix."""
         d = cf.Domain.create_healpix(0)

--- a/cf/test/test_Field.py
+++ b/cf/test/test_Field.py
@@ -16,6 +16,12 @@ faulthandler.enable()  # to debug seg faults and timeouts
 
 import cf
 
+healpix_available = False
+# Note: here only need healpix for cf under-the-hood code, not in test
+# directly, so no need to actually import healpix, just test it is there.
+if find_spec("healpix"):
+    healpix_available = True
+
 n_tmpfiles = 1
 tmpfiles = [
     tempfile.mkstemp("_test_Field.nc", dir=os.getcwd())[1]
@@ -3137,6 +3143,7 @@ class FieldTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             g.to_units("degC")
 
+    @unittest.skipUnless(healpix_available, "Requires 'healpix' package.")
     def test_Field_healpix_change_indexing_scheme(self):
         """Test Field.healpix_change_indexing_scheme."""
         # HEALPix field
@@ -3236,6 +3243,7 @@ class FieldTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.f0.healpix_change_indexing_scheme("ring")
 
+    @unittest.skipUnless(healpix_available, "Requires 'healpix' package.")
     def test_Field_healpix_to_ugrid(self):
         """Test Field.healpix_to_ugrid."""
         # HEALPix field
@@ -3276,6 +3284,7 @@ class FieldTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.f0.healpix_to_ugrid()
 
+    @unittest.skipUnless(healpix_available, "Requires 'healpix' package.")
     def test_Field_create_latlon_coordinates(self):
         """Test Field.create_latlon_coordinates."""
         # ------------------------------------------------------------
@@ -3334,6 +3343,7 @@ class FieldTest(unittest.TestCase):
             self.assertTrue(mc[:16].equals(l2.auxiliary_coordinate(c)[:16]))
             self.assertTrue(mc[16:].equals(l1.auxiliary_coordinate(c)[4:]))
 
+    @unittest.skipUnless(healpix_available, "Requires 'healpix' package.")
     def test_Field_healpix_subspace(self):
         """Test Field.subspace for HEALPix grids"""
         f = self.f12
@@ -3369,6 +3379,7 @@ class FieldTest(unittest.TestCase):
             np.array_equal(g.coordinate("healpix_index"), [13, 12])
         )
 
+    @unittest.skipUnless(healpix_available, "Requires 'healpix' package.")
     def test_Field_healpix_decrease_refinement_level(self):
         """Test Field.healpix_decrease_refinement_level."""
         f = self.f12
@@ -3469,6 +3480,7 @@ class FieldTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.f0.healpix_decrease_refinement_level(0, "mean")
 
+    @unittest.skipUnless(healpix_available, "Requires 'healpix' package.")
     def test_Field_healpix_increase_refinement_level(self):
         """Test Field.healpix_increase_refinement_level."""
         f = self.f12

--- a/cf/test/test_HEALPix_utils.py
+++ b/cf/test/test_HEALPix_utils.py
@@ -1,32 +1,48 @@
 import datetime
 import unittest
 
-import healpix
 import numpy as np
 
 import cf
 
-# Create matching lists of selected nested, ring, nuniq and zuniq
-# indices for every refinement level.
-indices = [
-    (r, i, healpix.nest2ring(healpix.order2nside(r), i))
-    for r in range(30)
-    for i in (0, 7, (12 * 4**r) - 1)
-]
-refinement_levels, nested_indices, ring_indices = map(list, zip(*indices))
-
-nuniq_indices = [
-    i + 4 ** (1 + r) for r, i in zip(refinement_levels, nested_indices)
-]
-
-zuniq_indices = [
-    (2 * i + 1) * 4 ** (29 - r)
-    for r, i in zip(refinement_levels, nested_indices)
-]
+healpix_imported = True
+try:
+    import healpix  # noqa: F401
+except ImportError:
+    healpix_imported = False
 
 
 class DataTest(unittest.TestCase):
     """Unit tests for HEALPix utilities."""
+
+    def setUp(self):
+        """Preparations called immediately before each test method."""
+        # Skip all if healpix module not available!
+        if not healpix_imported:
+            self.skipTest(
+                "Test module requires 'healpix' package. Install it to run all."
+            )
+        else:
+            # Create matching lists of selected nested, ring, nuniq and zuniq
+            # indices for every refinement level.
+            indices = [
+                (r, i, healpix.nest2ring(healpix.order2nside(r), i))
+                for r in range(30)
+                for i in (0, 7, (12 * 4**r) - 1)
+            ]
+            refinement_levels, nested_indices, ring_indices = map(
+                list, zip(*indices)
+            )
+
+            nuniq_indices = [  # noqa: F841
+                i + 4 ** (1 + r)
+                for r, i in zip(refinement_levels, nested_indices)
+            ]
+
+            zuniq_indices = [  # noqa: F841
+                (2 * i + 1) * 4 ** (29 - r)
+                for r, i in zip(refinement_levels, nested_indices)
+            ]
 
     def test_HEALPix_uniq2zuniq(self):
         """Test _uniq2zuniq"""

--- a/cf/test/test_HEALPix_utils.py
+++ b/cf/test/test_HEALPix_utils.py
@@ -22,34 +22,34 @@ class DataTest(unittest.TestCase):
             self.skipTest(
                 "Test module requires 'healpix' package. Install it to run all."
             )
-        else:
-            # Create matching lists of selected nested, ring, nuniq and zuniq
-            # indices for every refinement level.
-            indices = [
-                (r, i, healpix.nest2ring(healpix.order2nside(r), i))
-                for r in range(30)
-                for i in (0, 7, (12 * 4**r) - 1)
-            ]
-            refinement_levels, nested_indices, ring_indices = map(
-                list, zip(*indices)
-            )
 
-            nuniq_indices = [  # noqa: F841
-                i + 4 ** (1 + r)
-                for r, i in zip(refinement_levels, nested_indices)
-            ]
+        # Create matching lists of selected nested, ring, nuniq and zuniq
+        # indices for every refinement level.
+        indices = [
+            (r, i, healpix.nest2ring(healpix.order2nside(r), i))
+            for r in range(30)
+            for i in (0, 7, (12 * 4**r) - 1)
+        ]
+        self.refinement_levels, self.nested_indices, self.ring_indices = map(
+            list, zip(*indices)
+        )
 
-            zuniq_indices = [  # noqa: F841
-                (2 * i + 1) * 4 ** (29 - r)
-                for r, i in zip(refinement_levels, nested_indices)
-            ]
+        self.nuniq_indices = [  # noqa: F841
+            i + 4 ** (1 + r)
+            for r, i in zip(self.refinement_levels, self.nested_indices)
+        ]
+
+        self.zuniq_indices = [  # noqa: F841
+            (2 * i + 1) * 4 ** (29 - r)
+            for r, i in zip(self.refinement_levels, self.nested_indices)
+        ]
 
     def test_HEALPix_uniq2zuniq(self):
         """Test _uniq2zuniq"""
         from cf.data.dask_utils_healpix import _uniq2zuniq
 
         self.assertTrue(
-            np.array_equal(_uniq2zuniq(nuniq_indices), zuniq_indices)
+            np.array_equal(_uniq2zuniq(self.nuniq_indices), self.zuniq_indices)
         )
 
     def test_HEALPix_zuniq2uniq(self):
@@ -57,7 +57,7 @@ class DataTest(unittest.TestCase):
         from cf.data.dask_utils_healpix import _zuniq2uniq
 
         self.assertTrue(
-            np.array_equal(_zuniq2uniq(zuniq_indices), nuniq_indices)
+            np.array_equal(_zuniq2uniq(self.zuniq_indices), self.nuniq_indices)
         )
 
     def test_HEALPix_zuniq2pix(self):
@@ -65,14 +65,14 @@ class DataTest(unittest.TestCase):
         from cf.data.dask_utils_healpix import _zuniq2pix
 
         # nested
-        order, i = _zuniq2pix(zuniq_indices, nest=True)
+        order, i = _zuniq2pix(self.zuniq_indices, nest=True)
 
-        self.assertTrue(np.array_equal(order, refinement_levels))
-        self.assertTrue(np.array_equal(i, nested_indices))
+        self.assertTrue(np.array_equal(order, self.refinement_levels))
+        self.assertTrue(np.array_equal(i, self.nested_indices))
 
         # ring
         with self.assertRaises(NotImplementedError):
-            _zuniq2pix(zuniq_indices, nest=False)
+            _zuniq2pix(self.zuniq_indices, nest=False)
 
     def test_HEALPix_pix2zuniq(self):
         """Test _pix2zuniq"""
@@ -81,18 +81,18 @@ class DataTest(unittest.TestCase):
         # nested
         z = [
             _pix2zuniq(r, i, nest=True)
-            for r, i in zip(refinement_levels, nested_indices)
+            for r, i in zip(self.refinement_levels, self.nested_indices)
         ]
 
-        self.assertTrue(np.array_equal(z, zuniq_indices))
+        self.assertTrue(np.array_equal(z, self.zuniq_indices))
 
         # ring
         z = [
             _pix2zuniq(r, i, nest=False)
-            for r, i in zip(refinement_levels, ring_indices)
+            for r, i in zip(self.refinement_levels, self.ring_indices)
         ]
 
-        self.assertTrue(np.array_equal(z, zuniq_indices))
+        self.assertTrue(np.array_equal(z, self.zuniq_indices))
 
 
 if __name__ == "__main__":

--- a/cf/test/test_RegridOperator.py
+++ b/cf/test/test_RegridOperator.py
@@ -55,6 +55,7 @@ class RegridOperatorTest(unittest.TestCase):
     def test_RegridOperator_copy(self):
         self.assertIsInstance(self.r.copy(), self.r.__class__)
 
+    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_RegridOperator_equal_weights(self):
         r0 = self.r
         r1 = r0.copy()
@@ -62,6 +63,7 @@ class RegridOperatorTest(unittest.TestCase):
         r1.weights.data += 0.1
         self.assertFalse(r0.equal_weights(r1))
 
+    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_RegridOperator_equal_dst_mask(self):
         r0 = self.r.copy()
         r1 = r0.copy()

--- a/cf/test/test_RegridOperator.py
+++ b/cf/test/test_RegridOperator.py
@@ -19,11 +19,16 @@ if find_spec("esmpy") or find_spec("ESMF"):
 class RegridOperatorTest(unittest.TestCase):
 
     def setUp(self):
-        src = cf.example_field(0)
-        dst = cf.example_field(1)
-        self.r = src.regrids(dst, "linear", return_operator=True)
+        # Skip all if espmy module not available!
+        if not esmpy_imported:
+            self.skipTest(
+                "Test module requires 'esmpy' package. Install it to run all."
+            )
+        else:
+            src = cf.example_field(0)
+            dst = cf.example_field(1)
+            self.r = src.regrids(dst, "linear", return_operator=True)
 
-    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_RegridOperator_attributes(self):
         self.assertEqual(self.r.coord_sys, "spherical")
         self.assertEqual(self.r.method, "linear")
@@ -51,11 +56,9 @@ class RegridOperatorTest(unittest.TestCase):
         self.assertIsNone(self.r.dst_z)
         self.assertFalse(self.r.ln_z)
 
-    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_RegridOperator_copy(self):
         self.assertIsInstance(self.r.copy(), self.r.__class__)
 
-    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_RegridOperator_equal_weights(self):
         r0 = self.r
         r1 = r0.copy()
@@ -63,7 +66,6 @@ class RegridOperatorTest(unittest.TestCase):
         r1.weights.data += 0.1
         self.assertFalse(r0.equal_weights(r1))
 
-    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_RegridOperator_equal_dst_mask(self):
         r0 = self.r.copy()
         r1 = r0.copy()

--- a/cf/test/test_collapse.py
+++ b/cf/test/test_collapse.py
@@ -12,12 +12,6 @@ faulthandler.enable()  # to debug seg faults and timeouts
 
 import cf
 
-healpix_available = False
-# Note: here only need healpix for cf under-the-hood code, not in test
-# directly, so no need to actually import healpix, just test it is there.
-if find_spec("healpix"):
-    healpix_available = True
-
 n_tmpfiles = 1
 tmpfiles = [
     tempfile.mkstemp("_test_collapse.nc", dir=os.getcwd())[1]
@@ -832,7 +826,9 @@ class Field_collapseTest(unittest.TestCase):
         # Check the collpsed fields writes
         cf.write(f, tmpfile)
 
-    @unittest.skipUnless(healpix_available, "Requires 'healpix' package.")
+    # Note: here only need healpix for cf under-the-hood code, not in test
+    # directly, so no need to actually import healpix, just test it is there.
+    @unittest.skipUnless(find_spec("healpix"), "Requires 'healpix' package.")
     def test_Field_collapse_HEALPix(self):
         """Test HEALPix collapses."""
         f0 = cf.example_field(12)

--- a/cf/test/test_collapse.py
+++ b/cf/test/test_collapse.py
@@ -4,12 +4,19 @@ import faulthandler
 import os
 import tempfile
 import unittest
+from importlib.util import find_spec
 
 import numpy as np
 
 faulthandler.enable()  # to debug seg faults and timeouts
 
 import cf
+
+healpix_available = False
+# Note: here only need healpix for cf under-the-hood code, not in test
+# directly, so no need to actually import healpix, just test it is there.
+if find_spec("healpix"):
+    healpix_available = True
 
 n_tmpfiles = 1
 tmpfiles = [
@@ -825,6 +832,7 @@ class Field_collapseTest(unittest.TestCase):
         # Check the collpsed fields writes
         cf.write(f, tmpfile)
 
+    @unittest.skipUnless(healpix_available, "Requires 'healpix' package.")
     def test_Field_collapse_HEALPix(self):
         """Test HEALPix collapses."""
         f0 = cf.example_field(12)

--- a/cf/test/test_functions.py
+++ b/cf/test/test_functions.py
@@ -13,12 +13,6 @@ faulthandler.enable()  # to debug seg faults and timeouts
 
 import cf
 
-healpix_available = False
-# Note: here only need healpix for cf under-the-hood code, not in test
-# directly, so no need to actually import healpix, just test it is there.
-if find_spec("healpix"):
-    healpix_available = True
-
 
 class functionTest(unittest.TestCase):
     def setUp(self):
@@ -494,7 +488,9 @@ class functionTest(unittest.TestCase):
             with self.assertRaises(IndexError):
                 cf.normalize_slice(index, 8, cyclic=True)
 
-    @unittest.skipUnless(healpix_available, "Requires 'healpix' package.")
+    # Note: here only need healpix for cf under-the-hood code, not in test
+    # directly, so no need to actually import healpix, just test it is there.
+    @unittest.skipUnless(find_spec("healpix"), "Requires 'healpix' package.")
     def test_locate(self):
         """Test cf.locate"""
         # HEALPix

--- a/cf/test/test_functions.py
+++ b/cf/test/test_functions.py
@@ -4,6 +4,7 @@ import os
 import platform
 import sys
 import unittest
+from importlib.util import find_spec
 
 import dask.array as da
 import numpy as np
@@ -11,6 +12,12 @@ import numpy as np
 faulthandler.enable()  # to debug seg faults and timeouts
 
 import cf
+
+healpix_available = False
+# Note: here only need healpix for cf under-the-hood code, not in test
+# directly, so no need to actually import healpix, just test it is there.
+if find_spec("healpix"):
+    healpix_available = True
 
 
 class functionTest(unittest.TestCase):
@@ -487,6 +494,7 @@ class functionTest(unittest.TestCase):
             with self.assertRaises(IndexError):
                 cf.normalize_slice(index, 8, cyclic=True)
 
+    @unittest.skipUnless(healpix_available, "Requires 'healpix' package.")
     def test_locate(self):
         """Test cf.locate"""
         # HEALPix

--- a/cf/test/test_regrid.py
+++ b/cf/test/test_regrid.py
@@ -141,7 +141,7 @@ class RegridTest(unittest.TestCase):
 
     def setUp(self):
         """Preparations called immediately before each test method."""
-        # Skip all if healpix module not available!
+        # Skip all if esmpy module not available!
         if not esmpy_imported:
             self.skipTest(
                 "Test module requires 'esmpy' package. Install it to run all."

--- a/cf/test/test_regrid.py
+++ b/cf/test/test_regrid.py
@@ -138,19 +138,27 @@ def esmpy_regrid_Nd(coord_sys, method, src, dst, **kwargs):
 
 
 class RegridTest(unittest.TestCase):
-    # Get the test source and destination fields
-    filename = os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), "regrid.nc"
-    )
-    dst_src = cf.read(filename)
-    dst = dst_src[0]
-    src = dst_src[1]
 
-    filename_xyz = os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), "regrid_xyz.nc"
-    )
+    def setUp(self):
+        """Preparations called immediately before each test method."""
+        # Skip all if healpix module not available!
+        if not esmpy_imported:
+            self.skipTest(
+                "Test module requires 'esmpy' package. Install it to run all."
+            )
+        else:
+            # Get the test source and destination fields
+            filename = os.path.join(
+                os.path.dirname(os.path.abspath(__file__)), "regrid.nc"
+            )
+            dst_src = cf.read(filename)
+            dst = dst_src[0]  # noqa: F841
+            src = dst_src[1]  # noqa: F841
 
-    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
+            filename_xyz = os.path.join(  # noqa: F841
+                os.path.dirname(os.path.abspath(__file__)), "regrid_xyz.nc"
+            )
+
     def test_Field_regrid_2d_field(self):
         """2-d regridding with Field destination grid."""
         self.assertFalse(cf.regrid_logging())
@@ -302,7 +310,6 @@ class RegridTest(unittest.TestCase):
             with self.assertRaises(ValueError):
                 src.regrids(dst, method=method).array
 
-    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_Field_regrids_coords(self):
         """Spherical regridding with coords destination grid."""
         self.assertFalse(cf.regrid_logging())
@@ -372,7 +379,6 @@ class RegridTest(unittest.TestCase):
         d1 = src.regrids(r)
         self.assertTrue(d1.data.equals(d0.data, atol=atol, rtol=rtol))
 
-    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_Field_regridc_2d_coords(self):
         """2-d Cartesian regridding with coords destination grid."""
         self.assertFalse(cf.regrid_logging())
@@ -403,7 +409,6 @@ class RegridTest(unittest.TestCase):
         d1 = src.regridc(r)
         self.assertTrue(d1.data.equals(d0.data, atol=atol, rtol=rtol))
 
-    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_Field_regrids_bad_dst(self):
         """Disallowed destination grid types raise an exception."""
         self.assertFalse(cf.regrid_logging())
@@ -417,7 +422,6 @@ class RegridTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.src.regrids("foobar", method="conservative")
 
-    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_Field_regrids_domain(self):
         """Spherical regridding with Domain destination grid."""
         self.assertFalse(cf.regrid_logging())
@@ -441,7 +445,6 @@ class RegridTest(unittest.TestCase):
         d1 = src.regrids(r)
         self.assertTrue(d1.equals(d0, atol=atol, rtol=rtol))
 
-    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_Field_regridc_domain(self):
         """Spherical regridding with Domain destination grid."""
         self.assertFalse(cf.regrid_logging())
@@ -467,7 +470,6 @@ class RegridTest(unittest.TestCase):
         d1 = src.regridc(r)
         self.assertTrue(d1.equals(d0, atol=atol, rtol=rtol))
 
-    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_Field_regrids_field_operator(self):
         """Spherical regridding with operator destination grid."""
         self.assertFalse(cf.regrid_logging())
@@ -505,7 +507,6 @@ class RegridTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             dst.regrids(r)
 
-    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_Field_regrids_non_coordinates(self):
         """Check setting of non-coordinate metadata."""
         self.assertFalse(cf.regrid_logging())
@@ -554,7 +555,6 @@ class RegridTest(unittest.TestCase):
         # Cell measures
         self.assertFalse(d1.cell_measures())
 
-    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_Field_regridc_3d_field(self):
         """3-d Cartesian regridding with Field destination grid."""
         self.assertFalse(cf.regrid_logging())
@@ -658,7 +658,6 @@ class RegridTest(unittest.TestCase):
             with self.assertRaises(ValueError):
                 src.regridc(dst, method=method, axes=axes)
 
-    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_Field_regridc_1d_field(self):
         """1-d Cartesian regridding with Field destination grid."""
         self.assertFalse(cf.regrid_logging())
@@ -749,7 +748,6 @@ class RegridTest(unittest.TestCase):
             with self.assertRaises(ValueError):
                 src.regridc(dst, method=method, axes=axes)
 
-    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_Field_regridc_1d_coordinates_z(self):
         """1-d Z Cartesian regridding with coordinates destination grid."""
         self.assertFalse(cf.regrid_logging())
@@ -762,7 +760,6 @@ class RegridTest(unittest.TestCase):
         z = d.dimension_coordinate("Z")
         self.assertTrue(z.data.equals(dst.data))
 
-    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_Field_regrid_chunks(self):
         """Regridding of chunked axes"""
         self.assertFalse(cf.regrid_logging())
@@ -779,7 +776,6 @@ class RegridTest(unittest.TestCase):
         d0 = src.regrids(dst, method="linear")
         self.assertEqual(d0.data.numblocks, (1, 1, 1))
 
-    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_Field_regrid_weights_file(self):
         """Regridding creation/use of weights file"""
         self.assertFalse(cf.regrid_logging())
@@ -815,7 +811,6 @@ class RegridTest(unittest.TestCase):
                 src.regrids(r1, method="linear", weights_file=tmpfile)
             )
 
-    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_return_esmpy_regrid_operator(self):
         """esmpy regrid operator returns esmpy.Regrid in regrids and regridc"""
         self.assertFalse(cf.regrid_logging())

--- a/cf/test/test_regrid.py
+++ b/cf/test/test_regrid.py
@@ -11,6 +11,12 @@ import numpy as np
 
 import cf
 
+esmpy_imported = True
+try:
+    import esmpy  # noqa: F401
+except ImportError:
+    esmpy_imported = False
+
 n_tmpfiles = 1
 tmpfiles = [
     tempfile.mkstemp("_test_regrid.nc", dir=os.getcwd())[1]
@@ -29,14 +35,6 @@ def _remove_tmpfiles():
 
 
 atexit.register(_remove_tmpfiles)
-
-
-esmpy_imported = True
-try:
-    import esmpy  # noqa: F401
-except ImportError:
-    esmpy_imported = False
-
 
 all_methods = (
     "linear",
@@ -405,6 +403,7 @@ class RegridTest(unittest.TestCase):
         d1 = src.regridc(r)
         self.assertTrue(d1.data.equals(d0.data, atol=atol, rtol=rtol))
 
+    @unittest.skipUnless(esmpy_imported, "Requires esmpy/ESMF package.")
     def test_Field_regrids_bad_dst(self):
         """Disallowed destination grid types raise an exception."""
         self.assertFalse(cf.regrid_logging())

--- a/cf/test/test_regrid.py
+++ b/cf/test/test_regrid.py
@@ -146,18 +146,18 @@ class RegridTest(unittest.TestCase):
             self.skipTest(
                 "Test module requires 'esmpy' package. Install it to run all."
             )
-        else:
-            # Get the test source and destination fields
-            filename = os.path.join(
-                os.path.dirname(os.path.abspath(__file__)), "regrid.nc"
-            )
-            dst_src = cf.read(filename)
-            dst = dst_src[0]  # noqa: F841
-            src = dst_src[1]  # noqa: F841
 
-            filename_xyz = os.path.join(  # noqa: F841
-                os.path.dirname(os.path.abspath(__file__)), "regrid_xyz.nc"
-            )
+        # Get the test source and destination fields
+        filename = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "regrid.nc"
+        )
+        dst_src = cf.read(filename)
+        self.dst = dst_src[0]  # noqa: F841
+        self.src = dst_src[1]  # noqa: F841
+
+        self.filename_xyz = os.path.join(  # noqa: F841
+            os.path.dirname(os.path.abspath(__file__)), "regrid_xyz.nc"
+        )
 
     def test_Field_regrid_2d_field(self):
         """2-d regridding with Field destination grid."""

--- a/cf/test/test_regrid.py
+++ b/cf/test/test_regrid.py
@@ -152,8 +152,8 @@ class RegridTest(unittest.TestCase):
             os.path.dirname(os.path.abspath(__file__)), "regrid.nc"
         )
         dst_src = cf.read(filename)
-        self.dst = dst_src[0]  # noqa: F841
-        self.src = dst_src[1]  # noqa: F841
+        self.dst = dst_src[0]
+        self.src = dst_src[1]
 
         self.filename_xyz = os.path.join(  # noqa: F841
             os.path.dirname(os.path.abspath(__file__)), "regrid_xyz.nc"
@@ -626,7 +626,7 @@ class RegridTest(unittest.TestCase):
                 #    # effectively) 1-d regridding
                 #    continue
 
-                if method in ("nearest_dtos"):
+                if method in ("nearest_dtos",):
                     continue
 
                 x = src.regridc(

--- a/cf/test/test_weights.py
+++ b/cf/test/test_weights.py
@@ -1,9 +1,16 @@
 import datetime
 import unittest
+from importlib.util import find_spec
 
 import numpy as np
 
 import cf
+
+healpix_available = False
+# Note: here only need healpix for cf under-the-hood code, not in test
+# directly, so no need to actually import healpix, just test it is there.
+if find_spec("healpix"):
+    healpix_available = True
 
 # A radius greater than 1. Used since weights based on the unit
 # sphere and non-spheres are tested separately.
@@ -152,6 +159,7 @@ class WeightsTest(unittest.TestCase):
         self.assertTrue((w.array == correct_weights).all())
         self.assertEqual(w.Units, cf.Units("m2"))
 
+    @unittest.skipUnless(healpix_available, "Requires 'healpix' package.")
     def test_weights_polygon_area_ugrid(self):
         f = cf.example_field(8)
         f = f[..., [0, 2]]
@@ -345,6 +353,7 @@ class WeightsTest(unittest.TestCase):
         ):
             f.weights("area")
 
+    @unittest.skipUnless(healpix_available, "Requires 'healpix' package.")
     def test_weights_healpix(self):
         """Test HEALPix weights."""
         # HEALPix grid with Multi-Order Coverage (a combination of


### PR DESCRIPTION
We have some test skipping for lack of required module availability, including cases where it is an 'optional' dependency not enforced by packaging requirements, but not comprehensive and not accounting for the new `healpix` optional dependency.

In the background to the EXPECT GA I've went in and added all skips required, replacing those on individual methods with module-level skipping for relevant test modules (regrid-related tests which all need `esmpy` including one case where there was a false positive i.e. test pass from lack of skip, and tests requiring an explicit or under-the-hood use of `healpix`).

@davidhassell a sanity check would be useful but feel free to approve if you don't think a review is necessary given this PR is only trivial test infra changes.