### PR TITLE
Fix bug in `cf.read` that prevented some OPeNDAP URLS being read

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -1,3 +1,13 @@
+Version NEXTVERSION
+----------------
+
+**2026-06-??**
+
+* Fix bug in `cf.read` that prevented some OPeNDAP URLS being read
+  (https://github.com/NCAS-CMS/cf-python/issues/948)
+
+----
+
 Version 3.20.0
 --------------
 


### PR DESCRIPTION
Fixes #948 

Only changes Changelog. The fix is in `cfdm` (https://github.com/NCAS-CMS/cfdm/issues/406)